### PR TITLE
Remove the wait time or delay time of 2secs just before service exit.

### DIFF
--- a/ni_measurement_service/_internal/service_manager.py
+++ b/ni_measurement_service/_internal/service_manager.py
@@ -1,5 +1,4 @@
 import logging
-import time
 from typing import Callable, List
 
 import grpc


### PR DESCRIPTION
### What this PR accomplishes

Removed the wait time of 2secs just before service **exit**.

This wait was previously added to help user read the Unrgisteration message printed when the service is running as standalone console application and user presses Enter. Based on internal discussions it is concluded that delay of 2secs can be removed.

>"When it says "press enter to close", it's better for the example to close immediately than to make the user wonder why it takes so long to close. Anyone who needs to see the debug/info logs can see them by running the example from a command prompt."