### PR TITLE
ni_measurement_generator: Fix template import in __main__.py

### DIFF
--- a/ni_measurement_generator/ni_measurement_generator/__main__.py
+++ b/ni_measurement_generator/ni_measurement_generator/__main__.py
@@ -1,4 +1,4 @@
 """"Creates a measurement through use of template.py."""
-from template import create_measurement
+from ni_measurement_generator.template import create_measurement
 
 create_measurement()


### PR DESCRIPTION
### What does this Pull Request accomplish?

This fixes an import error in ``ni_measurement_generator\__main__.py``:
```
C:\Dev\measurement-services-python>poetry run python -m ni_measurement_generator SampleMeasurement 0.1.0.0 Measurement Product --directory-out tmp
Traceback (most recent call last):
  File "C:\Users\bkeryan\.pyenv\pyenv-win\versions\3.8.10\lib\runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Users\bkeryan\.pyenv\pyenv-win\versions\3.8.10\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\Dev\measurement-services-python\.venv\lib\site-packages\ni_measurement_generator\__main__.py", line 2, in <module>
    from template import create_measurement
ModuleNotFoundError: No module named 'template'
```

### Why should this Pull Request be merged?

It makes `python -m ni_measurement_generator` work correctly.

### What testing has been done?

Ran `poetry build` in `ni_measurement_generator` directory.
Ran `poetry run pip install ni_measurement_generator\dist\ni_measurement_generator-0.1.0-py3-none-any.whl --force-reinstall` in the top-level directory.
Ran `poetry run python -m ni_measurement_generator SampleMeasurement 0.1.0.0 Measurement Product --directory-out tmp` in the top-level directory.