### PR TITLE
Don't push the version of ni-measurement-generator to main for now

### DIFF
--- a/.github/workflows/Publish_NIMG.yml
+++ b/.github/workflows/Publish_NIMG.yml
@@ -64,14 +64,6 @@ jobs:
           git add .
           git commit -m "Promote NIMG package version to match the release tag" -a
         working-directory: ./ni_measurement_generator
-      
-      - name: Push changes to the Main branch
-        if: ${{ startsWith(github.event.release.target_commitish, 'main') }}
-        uses: CasperWA/push-protected@v2.10.0
-        with:
-          token: ${{ secrets.ADMIN_PAT }}
-          branch: ${{ github.event.release.target_commitish }}  
-          unprotect_reviews: true
 
       # To Test the Publish use : poetry publish --build --username __token__ --password ${{ secrets.TEST_PYPI_TOKEN }} -r test-pypi
       - name: Build Python package and publish to PyPI


### PR DESCRIPTION
### What does this Pull Request accomplish?

Stop trying to commit the nimg version to main. Still use the release tag version in the publish.
