### PR TITLE
Add array datatypes

### DIFF
--- a/ni_measurement_service/measurement/info.py
+++ b/ni_measurement_service/measurement/info.py
@@ -75,4 +75,10 @@ class DataType(enum.Enum):
     Boolean = (type_pb2.Field.TYPE_BOOL, False)
     String = (type_pb2.Field.TYPE_STRING, False)
 
+    Int32Array1D = (type_pb2.Field.TYPE_INT32, True)
+    Int64Array1D = (type_pb2.Field.TYPE_INT64, True)
+    UInt32Array1D = (type_pb2.Field.TYPE_UINT32, True)
+    UInt64Array1D = (type_pb2.Field.TYPE_UINT64, True)
+    FloatArray1D = (type_pb2.Field.TYPE_FLOAT, True)
     DoubleArray1D = (type_pb2.Field.TYPE_DOUBLE, True)
+    BooleanArray1D = (type_pb2.Field.TYPE_BOOL, True)


### PR DESCRIPTION
Added array data types that are now supported by measurement uis

### What does this Pull Request accomplish?

Adds numeric and boolean array data types to the measurement-service datatype enum

### Why should this Pull Request be merged?

Can't write measurements with non-double arrays without this change

### What testing has been done?

Tested with a local package change using an ArrayTest that accepts all array types and passes them to corresponding outputs
