### PR TITLE
DiscoveryClient: Read the discovery service port number from the key file

### DIFF
--- a/ni_measurement_service/_internal/discovery_client.py
+++ b/ni_measurement_service/_internal/discovery_client.py
@@ -195,7 +195,7 @@ def _open_key_file(path: str) -> typing.TextIO:
         # (Support for opening files with FILE_SHARE_DELETE on Windows).
         try:
             win32_file_handle = win32file.CreateFile(
-                str(path),
+                path,
                 win32file.GENERIC_READ,
                 win32file.FILE_SHARE_READ
                 | win32file.FILE_SHARE_WRITE
@@ -207,12 +207,12 @@ def _open_key_file(path: str) -> typing.TextIO:
             )
         except win32file.error as e:
             if e.winerror == winerror.ERROR_FILE_NOT_FOUND:
-                raise FileNotFoundError(errno.ENOENT, e.strerror, str(path)) from e
+                raise FileNotFoundError(errno.ENOENT, e.strerror, path) from e
             elif (
                 e.winerror == winerror.ERROR_ACCESS_DENIED
                 or e.winerror == winerror.ERROR_SHARING_VIOLATION
             ):
-                raise PermissionError(errno.EACCES, e.strerror, str(path)) from e
+                raise PermissionError(errno.EACCES, e.strerror, path) from e
             raise
 
         # The CRT file descriptor takes ownership of the Win32 file handle.


### PR DESCRIPTION
### What does this Pull Request accomplish?

Read the discovery service port number from the key file instead of hardcoding it.

Lazily initialize the discovery client's gRPC stub in order to avoid throwing errors at construction time.

### Why should this Pull Request be merged?

This fixes https://github.com/ni/measurement-services-python/issues/20

This allows changing the port number or using a dynamic port number.

### What testing has been done?

Manually tested sample_measurement with and without discovery service running.