### PR TITLE
Fixed ni-measurement-generator help documentation

### DIFF
--- a/ni_measurement_generator/ni_measurement_generator/template.py
+++ b/ni_measurement_generator/ni_measurement_generator/template.py
@@ -114,10 +114,6 @@ def create_measurement(
 
     DISPLAY_NAME: The measurement display name for client to display to user.
     The created .serviceconfig file will take this as its file name.
-
-    VERSION: The measurement version that helps to maintain versions of a measurement in future.
-    Should be formatted like x.x.x.x
-    e.g. 0.2.6.8
     """
     service_class = _resolve_service_class(service_class, display_name)
     display_name_for_filenames = re.sub(r"\s+", "", display_name)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Removes out-of-date documentation from ni-measurement-generator help

### Why should this Pull Request be merged?

Fixes #96 

### What testing has been done?

Ran `poetry run ni-measurement-generator --help`
```   
Usage: ni-measurement-generator [OPTIONS] DISPLAY_NAME  

  Generate a Python measurement service from a template.

  You can use this to get started writing your own measurement services.

  DISPLAY_NAME: The measurement display name for client to display to user.
  The created .serviceconfig file will take this as its file name.

Options:
  --measurement-version TEXT  Version number in the form x.y.z.q
  -u, --ui-file TEXT          Name of the UI File, Default is
                              <display_name>.measui.
  -s, --service-class TEXT    Service Class that the measurement belongs to.
                              Default is <display_name>_Python.
  -d, --description TEXT      Description URL that contains information about
                              the measurement.
  -o, --directory-out TEXT    Output directory for measurement files. Default
                              is the current directory/<display_name>
  --help                      Show this message and exit.
```
