### PR TITLE
Change to MeasurementLink directory for the key file

### DIFF
--- a/ni_measurement_service/_internal/discovery_client.py
+++ b/ni_measurement_service/_internal/discovery_client.py
@@ -225,7 +225,7 @@ def _get_key_file_directory() -> pathlib.Path:
         return (
             pathlib.Path(os.environ["ProgramData"])
             / "National Instruments"
-            / "Measurement Framework"
+            / "MeasurementLink"
             / "Discovery"
             / version
         )


### PR DESCRIPTION
### What does this Pull Request accomplish?

Change the directory where we're looking for the key file to 'MeasurementLink'.

### Why should this Pull Request be merged?

Keep up-to-date and allow measurement services to work with the latest discovery service.

### What testing has been done?

Ran the sample measurement with the latest InstrumentStudio that had the updated key file location to ensure it registered itself correctly.
