### PR TITLE
Add pin array enum for measurement code to use

### DIFF
--- a/ni_measurement_service/measurement/info.py
+++ b/ni_measurement_service/measurement/info.py
@@ -73,3 +73,4 @@ class DataType(enum.Enum):
     DoubleArray1D = (type_pb2.Field.TYPE_DOUBLE, True, TypeSpecialization.NoType)
     BooleanArray1D = (type_pb2.Field.TYPE_BOOL, True, TypeSpecialization.NoType)
     StringArray1D = (type_pb2.Field.TYPE_STRING, True, TypeSpecialization.NoType)
+    PinArray1D = (type_pb2.Field.TYPE_STRING, True, TypeSpecialization.Pin)

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -48,7 +48,10 @@ def test___measurement_service___add_configuration__configuration_added(
 
 @pytest.mark.parametrize(
     "display_name,type,default_value,instrument_type",
-    [("PinConfiguration", DataType.Pin, "Pin1", "test instrument")],
+    [
+        ("PinConfiguration", DataType.Pin, "Pin1", "test instrument"),
+        ("PinArrayConfiguration", DataType.PinArray1D, ["Pin1", "Pin2"], "test instrument 2"),
+    ],
 )
 def test___measurement_service___add_pin_configuration__pin_configuration_added(
     display_name, type, default_value, instrument_type
@@ -115,7 +118,8 @@ def test___measurement_service___add_non_pin_configuration__pin_type_annotations
         ("Int64", DataType.Int64, 1.0),
         ("UInt32", DataType.UInt32, [1.009, -1.0009]),
         ("UInt44", DataType.UInt64, ""),
-        ("PinType", DataType.Pin, 1.0),
+        ("Pin", DataType.Pin, 1.0),
+        ("Pin1DArray", DataType.PinArray1D, [1.009, -1.0009]),
     ],
 )
 def test___measurement_service___add_configuration_with_mismatch_default_value__raises_type_error(


### PR DESCRIPTION
### What does this Pull Request accomplish?
Adds `PinArray1D` to the `DataType` enum. 

### Why should this Pull Request be merged?
This PR will enable measurement authors to create a parameter with the `PinArray1D` type.
Sample -- Adding `New Pin Array In` as Pin Array parameter: 
![image](https://user-images.githubusercontent.com/28588382/205611518-5e06be77-e003-44f8-845d-2a88afd0b823.png)

The related task from Azure: 

- [Task 2229558](https://dev.azure.com/ni/DevCentral/_workitems/edit/2229558): Update the data type enum to support pin 1D array

### What testing has been done?

- Manual Test that `PinArray1D` can be added to measurement code.
- Updated the automated test to include `PinArray1D`
