### PR TITLE
GitHub workflow: use less specific version of push-protect

### DIFF
--- a/.github/workflows/Publish_NIMS.yml
+++ b/.github/workflows/Publish_NIMS.yml
@@ -69,7 +69,7 @@ jobs:
       
       - name: Push changes to the Main branch
         if: ${{ startsWith(github.event.release.target_commitish, 'main') }}
-        uses: CasperWA/push-protected@v2.10.0
+        uses: CasperWA/push-protected@v2
         with:
           token: ${{ secrets.ADMIN_PAT }}
           branch: ${{ github.event.release.target_commitish }}  


### PR DESCRIPTION
### What does this Pull Request accomplish?

Use latest version of CasperWA/push-protect@2 rather than locking to a version from April.

### Why should this Pull Request be merged?

This allows us to benefit from enhancements and bugfixes to this action.

### What testing has been done?

None whatsoever.