### PR TITLE
examples: Resave TestStand sequences with latest type palette INI

### DIFF
--- a/examples/nidcpower_source_dc_voltage/NIDCPowerSourceDCVoltage.seq
+++ b/examples/nidcpower_source_dc_voltage/NIDCPowerSourceDCVoltage.seq
@@ -2,12 +2,12 @@
 <teststandfileheader type='SequenceFile' fileversion='962' productname='TestStand' productversion='2021 (21.0.0.49156)' compatibleversion='21.0.0.0' buildversion='21.0.0.49156' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.ni.com/TestStand/21.0.0/SequenceFile">
 	<typelist>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='1'>
-			<Expression classname='ExprValue' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
+			<Expression classname='ExprValue' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
 				<value/>
 			</Expression>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='2'>
-			<StepTypeMenu classname='Obj' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
+			<StepTypeMenu classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
 				<subprops>
 					<CanBeSubstepType classname='Bool'>
 						<value>false</value>
@@ -37,12 +37,12 @@
 			</StepTypeMenu>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='3'>
-			<StepTypeSubstepsArray classname='Objs' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4849688' valueflags='24'>
+			<StepTypeSubstepsArray classname='Objs' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4849688' valueflags='24'>
 				<value lbound='[0]' ubound='[]'/>
 			</StepTypeSubstepsArray>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='4'>
-			<NI_ArrayDimensions classname='ArrayDimensions' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_ArrayDimensions classname='ArrayDimensions' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<LowerBounds classname='Nums'>
 						<value lbound='[0]' ubound='[]'/>
@@ -54,7 +54,7 @@
 			</NI_ArrayDimensions>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='5'>
-			<NI_PropertyObjectType classname='PropertyObjectType' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_PropertyObjectType classname='PropertyObjectType' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<ValueType classname='Num'>
 						<value>3</value>
@@ -88,7 +88,7 @@
 			</NI_PropertyObjectType>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='6'>
-			<NI_CustomResult classname='CustomResult' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_CustomResult classname='CustomResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Name typename='Expression' xsi:type='Expression' classname='ExprValue'>
 						<value/>
@@ -148,7 +148,7 @@
 			</NI_CustomResult>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='7'>
-			<TEInf classname='Obj' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4456472' instanceoverrideflags='4456472' valueflags='24'>
+			<TEInf classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4456472' instanceoverrideflags='4456472' valueflags='24'>
 				<subprops>
 					<Id classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
 						<value/>
@@ -423,7 +423,7 @@
 			</TEInf>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='8'>
-			<StepTypeNIData classname='Obj' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
+			<StepTypeNIData classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
 				<subprops>
 					<EditPanels classname='Strs'>
 						<value lbound='[0]' ubound='[]'/>
@@ -432,7 +432,7 @@
 			</StepTypeNIData>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='9'>
-			<Error classname='Obj' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
+			<Error classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
 				<extdata controllername='STRUCT' allowstructpassing='true' packingoption='8' exclude='false' type='0' arraystorage='0' strbuffersize='256' strstorage='0'/>
 				<extdata controllername='CLUST' allowclusterpassing='true' exclude='false' memberlabel=''/>
 				<extdata controllername='DNSTRUCT' allowstructpassing='true' exclude='false' membername=''/>
@@ -466,7 +466,7 @@
 			<CommonResults classname='Obj' isroottypedef='true' typecategory='3' timestamp='1465572565' typeversion='3.1.0.100' typelastmodversion='21.0.0.49156' typeminprodversion='3.1.0.0' typeflags='33554432' flagsforinstances='4194304' valueflags='4194304'/>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='11'>
-			<Substep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
+			<Substep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
 				<subprops>
 					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
 						<value>"%ModuleDescription"</value>
@@ -891,7 +891,7 @@
 			</Substep>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='12'>
-			<NI_DotNetParameterResult classname='DotNetParameterResult' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_DotNetParameterResult classname='DotNetParameterResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
 						<value/>
@@ -907,7 +907,7 @@
 			</NI_DotNetParameterResult>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='13'>
-			<DotNetParameter classname='DotNetParameter' isroottypedef='true' typecategory='3' timestamp='1628821096' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<DotNetParameter classname='DotNetParameter' isroottypedef='true' typecategory='3' timestamp='1650061192' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Name classname='Str'>
 						<value>_notNamed</value>
@@ -974,7 +974,7 @@
 			</DotNetParameter>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='14'>
-			<NI_DotNetCallResult classname='DotNetCallResult' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_DotNetCallResult classname='DotNetCallResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
 						<value/>
@@ -990,7 +990,7 @@
 			</NI_DotNetCallResult>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='15'>
-			<DotNetCall classname='DotNetCall' isroottypedef='true' typecategory='3' timestamp='1628821096' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<DotNetCall classname='DotNetCall' isroottypedef='true' typecategory='3' timestamp='1650061192' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<ClassName classname='Str'>
 						<value/>
@@ -1091,12 +1091,12 @@
 			</DotNetCall>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='0'>
-			<Path classname='PathValue' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
+			<Path classname='PathValue' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
 				<value/>
 			</Path>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='16'>
-			<DotNetStepAdditions classname='DotNetModule' isroottypedef='true' typecategory='3' timestamp='1628821096' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<DotNetStepAdditions classname='DotNetModule' isroottypedef='true' typecategory='3' timestamp='1650061192' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Calls classname='Objs'>
 						<value lbound='[0]' ubound='[]'>
@@ -1241,7 +1241,7 @@
 			</DotNetStepAdditions>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='17'>
-			<PostSubstep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
+			<PostSubstep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
 				<subprops>
 					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
 						<value>"%ModuleDescription"</value>
@@ -1666,7 +1666,7 @@
 			</PostSubstep>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='18'>
-			<NoneStepAdditions classname='NoneModule' isroottypedef='true' typecategory='3' timestamp='1628820742' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'/>
+			<NoneStepAdditions classname='NoneModule' isroottypedef='true' typecategory='3' timestamp='1650060850' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'/>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='19'>
 			<NI_MeasurementParameter classname='Obj' isroottypedef='true' typecategory='2' timestamp='1669042099' typeversion='21.0.5.4' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0'>
@@ -1699,7 +1699,7 @@
 			</NI_MeasurementParameter>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='20'>
-			<NI_Measurement classname='StepType' isroottypedef='true' typecategory='1' timestamp='1669042104' typeversion='21.0.5.7' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='2'>
+			<NI_Measurement classname='StepType' isroottypedef='true' typecategory='1' timestamp='1670875325' typeversion='21.0.5.8' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='2'>
 				<subprops>
 					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
 						<value>ResStr("MEASUREMENT_STEP_TYPE", "MEASUREMENT_DESCRIPTION_NAME")</value>
@@ -1768,7 +1768,7 @@
 																	<DotNetCall typename='DotNetCall' xsi:type='DotNetCall' name=''>
 																		<subprops>
 																			<ClassName classname='Str'>
-																				<value>NationalInstruments.MeasurementServices.NewStepHandler</value>
+																				<value>NationalInstruments.MeasurementLink.NewStepHandler</value>
 																			</ClassName>
 																			<MemberType classname='Num'>
 																				<value>4</value>
@@ -1800,7 +1800,7 @@
 																									<value>0</value>
 																								</Type>
 																								<TypeName classname='Str'>
-																									<value>NationalInstruments.MeasurementServices.NewStepHandler</value>
+																									<value>NationalInstruments.MeasurementLink.NewStepHandler</value>
 																								</TypeName>
 																								<Flags classname='Num'>
 																									<value>6</value>
@@ -1872,7 +1872,7 @@
 																	<DotNetCall typename='DotNetCall' xsi:type='DotNetCall' name=''>
 																		<subprops>
 																			<ClassName classname='Str'>
-																				<value>NationalInstruments.MeasurementServices.NewStepHandler</value>
+																				<value>NationalInstruments.MeasurementLink.NewStepHandler</value>
 																			</ClassName>
 																			<MemberType classname='Num'>
 																				<value>1</value>
@@ -1975,7 +1975,7 @@
 															</value>
 														</Calls>
 														<AssemblyPath classname='PathValue'>
-															<value>NationalInstruments.MeasurementServices.TestStandMeasurementClient.dll</value>
+															<value>NationalInstruments.MeasurementLink.TestStandMeasurementClient.dll</value>
 														</AssemblyPath>
 														<AssemblyStrongName classname='Str'>
 															<value/>
@@ -1984,7 +1984,7 @@
 															<value>0</value>
 														</AssemblyLocation>
 														<ClassName classname='Str'>
-															<value>NationalInstruments.MeasurementServices.NewStepHandler</value>
+															<value>NationalInstruments.MeasurementLink.NewStepHandler</value>
 														</ClassName>
 														<IsStruct classname='Bool'>
 															<value>false</value>
@@ -2379,7 +2379,7 @@
 																	<DotNetCall typename='DotNetCall' xsi:type='DotNetCall' name=''>
 																		<subprops>
 																			<ClassName classname='Str'>
-																				<value>NationalInstruments.MeasurementServices.MeasurementStepExecution</value>
+																				<value>NationalInstruments.MeasurementLink.MeasurementStepExecution</value>
 																			</ClassName>
 																			<MemberType classname='Num'>
 																				<value>4</value>
@@ -2411,7 +2411,7 @@
 																									<value>0</value>
 																								</Type>
 																								<TypeName classname='Str'>
-																									<value>NationalInstruments.MeasurementServices.MeasurementStepExecution</value>
+																									<value>NationalInstruments.MeasurementLink.MeasurementStepExecution</value>
 																								</TypeName>
 																								<Flags classname='Num'>
 																									<value>6</value>
@@ -2483,7 +2483,7 @@
 																	<DotNetCall typename='DotNetCall' xsi:type='DotNetCall' name=''>
 																		<subprops>
 																			<ClassName classname='Str'>
-																				<value>NationalInstruments.MeasurementServices.MeasurementStepExecution</value>
+																				<value>NationalInstruments.MeasurementLink.MeasurementStepExecution</value>
 																			</ClassName>
 																			<MemberType classname='Num'>
 																				<value>1</value>
@@ -2586,7 +2586,7 @@
 															</value>
 														</Calls>
 														<AssemblyPath classname='PathValue'>
-															<value>NationalInstruments.MeasurementServices.TestStandMeasurementClient.dll</value>
+															<value>NationalInstruments.MeasurementLink.TestStandMeasurementClient.dll</value>
 														</AssemblyPath>
 														<AssemblyStrongName classname='Str'>
 															<value/>
@@ -2595,7 +2595,7 @@
 															<value>0</value>
 														</AssemblyLocation>
 														<ClassName classname='Str'>
-															<value>NationalInstruments.MeasurementServices.MeasurementStepExecution</value>
+															<value>NationalInstruments.MeasurementLink.MeasurementStepExecution</value>
 														</ClassName>
 														<IsStruct classname='Bool'>
 															<value>false</value>
@@ -3313,7 +3313,7 @@
 						<subprops>
 							<EditPanels classname='Strs'>
 								<value lbound='[0]' ubound='[0]'>
-									<value arrayindex='[0]'>NationalInstruments.MeasurementServices.TestStandMeasurementClient.dll|NationalInstruments.MeasurementServices.MeasurementStepPanelInfo</value>
+									<value arrayindex='[0]'>NationalInstruments.MeasurementLink.TestStandMeasurementClient.dll|NationalInstruments.MeasurementLink.MeasurementStepPanelInfo</value>
 								</value>
 							</EditPanels>
 						</subprops>

--- a/examples/nidcpower_source_dc_voltage_with_labview_ui/NIDCPowerSourceDCVoltage.seq
+++ b/examples/nidcpower_source_dc_voltage_with_labview_ui/NIDCPowerSourceDCVoltage.seq
@@ -2,12 +2,12 @@
 <teststandfileheader type='SequenceFile' fileversion='962' productname='TestStand' productversion='2021 (21.0.0.49156)' compatibleversion='21.0.0.0' buildversion='21.0.0.49156' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.ni.com/TestStand/21.0.0/SequenceFile">
 	<typelist>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='1'>
-			<Expression classname='ExprValue' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
+			<Expression classname='ExprValue' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
 				<value/>
 			</Expression>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='2'>
-			<StepTypeMenu classname='Obj' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
+			<StepTypeMenu classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
 				<subprops>
 					<CanBeSubstepType classname='Bool'>
 						<value>false</value>
@@ -37,12 +37,12 @@
 			</StepTypeMenu>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='3'>
-			<StepTypeSubstepsArray classname='Objs' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4849688' valueflags='24'>
+			<StepTypeSubstepsArray classname='Objs' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4849688' valueflags='24'>
 				<value lbound='[0]' ubound='[]'/>
 			</StepTypeSubstepsArray>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='4'>
-			<NI_ArrayDimensions classname='ArrayDimensions' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_ArrayDimensions classname='ArrayDimensions' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<LowerBounds classname='Nums'>
 						<value lbound='[0]' ubound='[]'/>
@@ -54,7 +54,7 @@
 			</NI_ArrayDimensions>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='5'>
-			<NI_PropertyObjectType classname='PropertyObjectType' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_PropertyObjectType classname='PropertyObjectType' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<ValueType classname='Num'>
 						<value>3</value>
@@ -88,7 +88,7 @@
 			</NI_PropertyObjectType>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='6'>
-			<NI_CustomResult classname='CustomResult' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_CustomResult classname='CustomResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Name typename='Expression' xsi:type='Expression' classname='ExprValue'>
 						<value/>
@@ -148,7 +148,7 @@
 			</NI_CustomResult>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='7'>
-			<TEInf classname='Obj' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4456472' instanceoverrideflags='4456472' valueflags='24'>
+			<TEInf classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4456472' instanceoverrideflags='4456472' valueflags='24'>
 				<subprops>
 					<Id classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
 						<value/>
@@ -423,7 +423,7 @@
 			</TEInf>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='8'>
-			<StepTypeNIData classname='Obj' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
+			<StepTypeNIData classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
 				<subprops>
 					<EditPanels classname='Strs'>
 						<value lbound='[0]' ubound='[]'/>
@@ -432,7 +432,7 @@
 			</StepTypeNIData>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='9'>
-			<Error classname='Obj' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
+			<Error classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
 				<extdata controllername='STRUCT' allowstructpassing='true' packingoption='8' exclude='false' type='0' arraystorage='0' strbuffersize='256' strstorage='0'/>
 				<extdata controllername='CLUST' allowclusterpassing='true' exclude='false' memberlabel=''/>
 				<extdata controllername='DNSTRUCT' allowstructpassing='true' exclude='false' membername=''/>
@@ -466,7 +466,7 @@
 			<CommonResults classname='Obj' isroottypedef='true' typecategory='3' timestamp='1465572565' typeversion='3.1.0.100' typelastmodversion='21.0.0.49156' typeminprodversion='3.1.0.0' typeflags='33554432' flagsforinstances='4194304' valueflags='4194304'/>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='11'>
-			<Substep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
+			<Substep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
 				<subprops>
 					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
 						<value>"%ModuleDescription"</value>
@@ -891,7 +891,7 @@
 			</Substep>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='12'>
-			<NI_DotNetParameterResult classname='DotNetParameterResult' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_DotNetParameterResult classname='DotNetParameterResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
 						<value/>
@@ -907,7 +907,7 @@
 			</NI_DotNetParameterResult>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='13'>
-			<DotNetParameter classname='DotNetParameter' isroottypedef='true' typecategory='3' timestamp='1628821096' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<DotNetParameter classname='DotNetParameter' isroottypedef='true' typecategory='3' timestamp='1650061192' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Name classname='Str'>
 						<value>_notNamed</value>
@@ -974,7 +974,7 @@
 			</DotNetParameter>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='14'>
-			<NI_DotNetCallResult classname='DotNetCallResult' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_DotNetCallResult classname='DotNetCallResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
 						<value/>
@@ -990,7 +990,7 @@
 			</NI_DotNetCallResult>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='15'>
-			<DotNetCall classname='DotNetCall' isroottypedef='true' typecategory='3' timestamp='1628821096' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<DotNetCall classname='DotNetCall' isroottypedef='true' typecategory='3' timestamp='1650061192' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<ClassName classname='Str'>
 						<value/>
@@ -1091,12 +1091,12 @@
 			</DotNetCall>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='0'>
-			<Path classname='PathValue' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
+			<Path classname='PathValue' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
 				<value/>
 			</Path>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='16'>
-			<DotNetStepAdditions classname='DotNetModule' isroottypedef='true' typecategory='3' timestamp='1628821096' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<DotNetStepAdditions classname='DotNetModule' isroottypedef='true' typecategory='3' timestamp='1650061192' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Calls classname='Objs'>
 						<value lbound='[0]' ubound='[]'>
@@ -1241,7 +1241,7 @@
 			</DotNetStepAdditions>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='17'>
-			<PostSubstep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
+			<PostSubstep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
 				<subprops>
 					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
 						<value>"%ModuleDescription"</value>
@@ -1666,7 +1666,7 @@
 			</PostSubstep>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='18'>
-			<NoneStepAdditions classname='NoneModule' isroottypedef='true' typecategory='3' timestamp='1628820742' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'/>
+			<NoneStepAdditions classname='NoneModule' isroottypedef='true' typecategory='3' timestamp='1650060850' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'/>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='19'>
 			<NI_MeasurementParameter classname='Obj' isroottypedef='true' typecategory='2' timestamp='1669042099' typeversion='21.0.5.4' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0'>
@@ -1699,7 +1699,7 @@
 			</NI_MeasurementParameter>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='20'>
-			<NI_Measurement classname='StepType' isroottypedef='true' typecategory='1' timestamp='1670627442' typeversion='21.0.5.8' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='2'>
+			<NI_Measurement classname='StepType' isroottypedef='true' typecategory='1' timestamp='1670875325' typeversion='21.0.5.8' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='2'>
 				<subprops>
 					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
 						<value>ResStr("MEASUREMENT_STEP_TYPE", "MEASUREMENT_DESCRIPTION_NAME")</value>
@@ -1768,7 +1768,7 @@
 																	<DotNetCall typename='DotNetCall' xsi:type='DotNetCall' name=''>
 																		<subprops>
 																			<ClassName classname='Str'>
-																				<value>NationalInstruments.MeasurementServices.NewStepHandler</value>
+																				<value>NationalInstruments.MeasurementLink.NewStepHandler</value>
 																			</ClassName>
 																			<MemberType classname='Num'>
 																				<value>4</value>
@@ -1800,7 +1800,7 @@
 																									<value>0</value>
 																								</Type>
 																								<TypeName classname='Str'>
-																									<value>NationalInstruments.MeasurementServices.NewStepHandler</value>
+																									<value>NationalInstruments.MeasurementLink.NewStepHandler</value>
 																								</TypeName>
 																								<Flags classname='Num'>
 																									<value>6</value>
@@ -1872,7 +1872,7 @@
 																	<DotNetCall typename='DotNetCall' xsi:type='DotNetCall' name=''>
 																		<subprops>
 																			<ClassName classname='Str'>
-																				<value>NationalInstruments.MeasurementServices.NewStepHandler</value>
+																				<value>NationalInstruments.MeasurementLink.NewStepHandler</value>
 																			</ClassName>
 																			<MemberType classname='Num'>
 																				<value>1</value>
@@ -1984,7 +1984,7 @@
 															<value>0</value>
 														</AssemblyLocation>
 														<ClassName classname='Str'>
-															<value>NationalInstruments.MeasurementServices.NewStepHandler</value>
+															<value>NationalInstruments.MeasurementLink.NewStepHandler</value>
 														</ClassName>
 														<IsStruct classname='Bool'>
 															<value>false</value>
@@ -2379,7 +2379,7 @@
 																	<DotNetCall typename='DotNetCall' xsi:type='DotNetCall' name=''>
 																		<subprops>
 																			<ClassName classname='Str'>
-																				<value>NationalInstruments.MeasurementServices.MeasurementStepExecution</value>
+																				<value>NationalInstruments.MeasurementLink.MeasurementStepExecution</value>
 																			</ClassName>
 																			<MemberType classname='Num'>
 																				<value>4</value>
@@ -2411,7 +2411,7 @@
 																									<value>0</value>
 																								</Type>
 																								<TypeName classname='Str'>
-																									<value>NationalInstruments.MeasurementServices.MeasurementStepExecution</value>
+																									<value>NationalInstruments.MeasurementLink.MeasurementStepExecution</value>
 																								</TypeName>
 																								<Flags classname='Num'>
 																									<value>6</value>
@@ -2483,7 +2483,7 @@
 																	<DotNetCall typename='DotNetCall' xsi:type='DotNetCall' name=''>
 																		<subprops>
 																			<ClassName classname='Str'>
-																				<value>NationalInstruments.MeasurementServices.MeasurementStepExecution</value>
+																				<value>NationalInstruments.MeasurementLink.MeasurementStepExecution</value>
 																			</ClassName>
 																			<MemberType classname='Num'>
 																				<value>1</value>
@@ -2595,7 +2595,7 @@
 															<value>0</value>
 														</AssemblyLocation>
 														<ClassName classname='Str'>
-															<value>NationalInstruments.MeasurementServices.MeasurementStepExecution</value>
+															<value>NationalInstruments.MeasurementLink.MeasurementStepExecution</value>
 														</ClassName>
 														<IsStruct classname='Bool'>
 															<value>false</value>
@@ -3313,7 +3313,7 @@
 						<subprops>
 							<EditPanels classname='Strs'>
 								<value lbound='[0]' ubound='[0]'>
-									<value arrayindex='[0]'>NationalInstruments.MeasurementLink.TestStandMeasurementClient.dll|NationalInstruments.MeasurementServices.MeasurementStepPanelInfo</value>
+									<value arrayindex='[0]'>NationalInstruments.MeasurementLink.TestStandMeasurementClient.dll|NationalInstruments.MeasurementLink.MeasurementStepPanelInfo</value>
 								</value>
 							</EditPanels>
 						</subprops>

--- a/examples/nidmm_measurement/NIDmmMeasurement.seq
+++ b/examples/nidmm_measurement/NIDmmMeasurement.seq
@@ -2,12 +2,12 @@
 <teststandfileheader type='SequenceFile' fileversion='962' productname='TestStand' productversion='2021 (21.0.0.49156)' compatibleversion='21.0.0.0' buildversion='21.0.0.49156' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.ni.com/TestStand/21.0.0/SequenceFile">
 	<typelist>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='1'>
-			<Expression classname='ExprValue' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
+			<Expression classname='ExprValue' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
 				<value/>
 			</Expression>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='2'>
-			<StepTypeMenu classname='Obj' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
+			<StepTypeMenu classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
 				<subprops>
 					<CanBeSubstepType classname='Bool'>
 						<value>false</value>
@@ -37,12 +37,12 @@
 			</StepTypeMenu>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='3'>
-			<StepTypeSubstepsArray classname='Objs' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4849688' valueflags='24'>
+			<StepTypeSubstepsArray classname='Objs' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4849688' valueflags='24'>
 				<value lbound='[0]' ubound='[]'/>
 			</StepTypeSubstepsArray>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='4'>
-			<NI_ArrayDimensions classname='ArrayDimensions' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_ArrayDimensions classname='ArrayDimensions' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<LowerBounds classname='Nums'>
 						<value lbound='[0]' ubound='[]'/>
@@ -54,7 +54,7 @@
 			</NI_ArrayDimensions>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='5'>
-			<NI_PropertyObjectType classname='PropertyObjectType' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_PropertyObjectType classname='PropertyObjectType' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<ValueType classname='Num'>
 						<value>3</value>
@@ -88,7 +88,7 @@
 			</NI_PropertyObjectType>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='6'>
-			<NI_CustomResult classname='CustomResult' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_CustomResult classname='CustomResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Name typename='Expression' xsi:type='Expression' classname='ExprValue'>
 						<value/>
@@ -148,7 +148,7 @@
 			</NI_CustomResult>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='7'>
-			<TEInf classname='Obj' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4456472' instanceoverrideflags='4456472' valueflags='24'>
+			<TEInf classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4456472' instanceoverrideflags='4456472' valueflags='24'>
 				<subprops>
 					<Id classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
 						<value/>
@@ -423,7 +423,7 @@
 			</TEInf>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='8'>
-			<StepTypeNIData classname='Obj' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
+			<StepTypeNIData classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
 				<subprops>
 					<EditPanels classname='Strs'>
 						<value lbound='[0]' ubound='[]'/>
@@ -432,7 +432,7 @@
 			</StepTypeNIData>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='9'>
-			<Error classname='Obj' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
+			<Error classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
 				<extdata controllername='STRUCT' allowstructpassing='true' packingoption='8' exclude='false' type='0' arraystorage='0' strbuffersize='256' strstorage='0'/>
 				<extdata controllername='CLUST' allowclusterpassing='true' exclude='false' memberlabel=''/>
 				<extdata controllername='DNSTRUCT' allowstructpassing='true' exclude='false' membername=''/>
@@ -466,7 +466,7 @@
 			<CommonResults classname='Obj' isroottypedef='true' typecategory='3' timestamp='1465572565' typeversion='3.1.0.100' typelastmodversion='21.0.0.49156' typeminprodversion='3.1.0.0' typeflags='33554432' flagsforinstances='4194304' valueflags='4194304'/>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='11'>
-			<Substep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
+			<Substep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
 				<subprops>
 					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
 						<value>"%ModuleDescription"</value>
@@ -891,7 +891,7 @@
 			</Substep>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='12'>
-			<NI_DotNetParameterResult classname='DotNetParameterResult' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_DotNetParameterResult classname='DotNetParameterResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
 						<value/>
@@ -907,7 +907,7 @@
 			</NI_DotNetParameterResult>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='13'>
-			<DotNetParameter classname='DotNetParameter' isroottypedef='true' typecategory='3' timestamp='1628821096' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<DotNetParameter classname='DotNetParameter' isroottypedef='true' typecategory='3' timestamp='1650061192' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Name classname='Str'>
 						<value>_notNamed</value>
@@ -974,7 +974,7 @@
 			</DotNetParameter>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='14'>
-			<NI_DotNetCallResult classname='DotNetCallResult' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_DotNetCallResult classname='DotNetCallResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
 						<value/>
@@ -990,7 +990,7 @@
 			</NI_DotNetCallResult>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='15'>
-			<DotNetCall classname='DotNetCall' isroottypedef='true' typecategory='3' timestamp='1628821096' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<DotNetCall classname='DotNetCall' isroottypedef='true' typecategory='3' timestamp='1650061192' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<ClassName classname='Str'>
 						<value/>
@@ -1091,12 +1091,12 @@
 			</DotNetCall>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='0'>
-			<Path classname='PathValue' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
+			<Path classname='PathValue' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
 				<value/>
 			</Path>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='16'>
-			<DotNetStepAdditions classname='DotNetModule' isroottypedef='true' typecategory='3' timestamp='1628821096' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<DotNetStepAdditions classname='DotNetModule' isroottypedef='true' typecategory='3' timestamp='1650061192' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Calls classname='Objs'>
 						<value lbound='[0]' ubound='[]'>
@@ -1241,7 +1241,7 @@
 			</DotNetStepAdditions>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='17'>
-			<PostSubstep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
+			<PostSubstep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
 				<subprops>
 					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
 						<value>"%ModuleDescription"</value>
@@ -1666,7 +1666,7 @@
 			</PostSubstep>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='18'>
-			<NoneStepAdditions classname='NoneModule' isroottypedef='true' typecategory='3' timestamp='1628820742' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'/>
+			<NoneStepAdditions classname='NoneModule' isroottypedef='true' typecategory='3' timestamp='1650060850' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'/>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='19'>
 			<NI_MeasurementParameter classname='Obj' isroottypedef='true' typecategory='2' timestamp='1669042099' typeversion='21.0.5.4' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0'>
@@ -1699,7 +1699,7 @@
 			</NI_MeasurementParameter>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='20'>
-			<NI_Measurement classname='StepType' isroottypedef='true' typecategory='1' timestamp='1669042104' typeversion='21.0.5.7' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='2'>
+			<NI_Measurement classname='StepType' isroottypedef='true' typecategory='1' timestamp='1670875325' typeversion='21.0.5.8' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='2'>
 				<subprops>
 					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
 						<value>ResStr("MEASUREMENT_STEP_TYPE", "MEASUREMENT_DESCRIPTION_NAME")</value>
@@ -1768,7 +1768,7 @@
 																	<DotNetCall typename='DotNetCall' xsi:type='DotNetCall' name=''>
 																		<subprops>
 																			<ClassName classname='Str'>
-																				<value>NationalInstruments.MeasurementServices.NewStepHandler</value>
+																				<value>NationalInstruments.MeasurementLink.NewStepHandler</value>
 																			</ClassName>
 																			<MemberType classname='Num'>
 																				<value>4</value>
@@ -1800,7 +1800,7 @@
 																									<value>0</value>
 																								</Type>
 																								<TypeName classname='Str'>
-																									<value>NationalInstruments.MeasurementServices.NewStepHandler</value>
+																									<value>NationalInstruments.MeasurementLink.NewStepHandler</value>
 																								</TypeName>
 																								<Flags classname='Num'>
 																									<value>6</value>
@@ -1872,7 +1872,7 @@
 																	<DotNetCall typename='DotNetCall' xsi:type='DotNetCall' name=''>
 																		<subprops>
 																			<ClassName classname='Str'>
-																				<value>NationalInstruments.MeasurementServices.NewStepHandler</value>
+																				<value>NationalInstruments.MeasurementLink.NewStepHandler</value>
 																			</ClassName>
 																			<MemberType classname='Num'>
 																				<value>1</value>
@@ -1975,7 +1975,7 @@
 															</value>
 														</Calls>
 														<AssemblyPath classname='PathValue'>
-															<value>NationalInstruments.MeasurementServices.TestStandMeasurementClient.dll</value>
+															<value>NationalInstruments.MeasurementLink.TestStandMeasurementClient.dll</value>
 														</AssemblyPath>
 														<AssemblyStrongName classname='Str'>
 															<value/>
@@ -1984,7 +1984,7 @@
 															<value>0</value>
 														</AssemblyLocation>
 														<ClassName classname='Str'>
-															<value>NationalInstruments.MeasurementServices.NewStepHandler</value>
+															<value>NationalInstruments.MeasurementLink.NewStepHandler</value>
 														</ClassName>
 														<IsStruct classname='Bool'>
 															<value>false</value>
@@ -2379,7 +2379,7 @@
 																	<DotNetCall typename='DotNetCall' xsi:type='DotNetCall' name=''>
 																		<subprops>
 																			<ClassName classname='Str'>
-																				<value>NationalInstruments.MeasurementServices.MeasurementStepExecution</value>
+																				<value>NationalInstruments.MeasurementLink.MeasurementStepExecution</value>
 																			</ClassName>
 																			<MemberType classname='Num'>
 																				<value>4</value>
@@ -2411,7 +2411,7 @@
 																									<value>0</value>
 																								</Type>
 																								<TypeName classname='Str'>
-																									<value>NationalInstruments.MeasurementServices.MeasurementStepExecution</value>
+																									<value>NationalInstruments.MeasurementLink.MeasurementStepExecution</value>
 																								</TypeName>
 																								<Flags classname='Num'>
 																									<value>6</value>
@@ -2483,7 +2483,7 @@
 																	<DotNetCall typename='DotNetCall' xsi:type='DotNetCall' name=''>
 																		<subprops>
 																			<ClassName classname='Str'>
-																				<value>NationalInstruments.MeasurementServices.MeasurementStepExecution</value>
+																				<value>NationalInstruments.MeasurementLink.MeasurementStepExecution</value>
 																			</ClassName>
 																			<MemberType classname='Num'>
 																				<value>1</value>
@@ -2586,7 +2586,7 @@
 															</value>
 														</Calls>
 														<AssemblyPath classname='PathValue'>
-															<value>NationalInstruments.MeasurementServices.TestStandMeasurementClient.dll</value>
+															<value>NationalInstruments.MeasurementLink.TestStandMeasurementClient.dll</value>
 														</AssemblyPath>
 														<AssemblyStrongName classname='Str'>
 															<value/>
@@ -2595,7 +2595,7 @@
 															<value>0</value>
 														</AssemblyLocation>
 														<ClassName classname='Str'>
-															<value>NationalInstruments.MeasurementServices.MeasurementStepExecution</value>
+															<value>NationalInstruments.MeasurementLink.MeasurementStepExecution</value>
 														</ClassName>
 														<IsStruct classname='Bool'>
 															<value>false</value>
@@ -3313,7 +3313,7 @@
 						<subprops>
 							<EditPanels classname='Strs'>
 								<value lbound='[0]' ubound='[0]'>
-									<value arrayindex='[0]'>NationalInstruments.MeasurementServices.TestStandMeasurementClient.dll|NationalInstruments.MeasurementServices.MeasurementStepPanelInfo</value>
+									<value arrayindex='[0]'>NationalInstruments.MeasurementLink.TestStandMeasurementClient.dll|NationalInstruments.MeasurementLink.MeasurementStepPanelInfo</value>
 								</value>
 							</EditPanels>
 						</subprops>

--- a/examples/nifgen_standard_function/NIFgenStandardFunction.seq
+++ b/examples/nifgen_standard_function/NIFgenStandardFunction.seq
@@ -2,12 +2,12 @@
 <teststandfileheader type='SequenceFile' fileversion='962' productname='TestStand' productversion='2021 (21.0.0.49156)' compatibleversion='21.0.0.0' buildversion='21.0.0.49156' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.ni.com/TestStand/21.0.0/SequenceFile">
 	<typelist>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='1'>
-			<Expression classname='ExprValue' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
+			<Expression classname='ExprValue' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
 				<value/>
 			</Expression>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='2'>
-			<StepTypeMenu classname='Obj' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
+			<StepTypeMenu classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
 				<subprops>
 					<CanBeSubstepType classname='Bool'>
 						<value>false</value>
@@ -37,12 +37,12 @@
 			</StepTypeMenu>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='3'>
-			<StepTypeSubstepsArray classname='Objs' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4849688' valueflags='24'>
+			<StepTypeSubstepsArray classname='Objs' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4849688' valueflags='24'>
 				<value lbound='[0]' ubound='[]'/>
 			</StepTypeSubstepsArray>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='4'>
-			<NI_ArrayDimensions classname='ArrayDimensions' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_ArrayDimensions classname='ArrayDimensions' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<LowerBounds classname='Nums'>
 						<value lbound='[0]' ubound='[]'/>
@@ -54,7 +54,7 @@
 			</NI_ArrayDimensions>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='5'>
-			<NI_PropertyObjectType classname='PropertyObjectType' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_PropertyObjectType classname='PropertyObjectType' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<ValueType classname='Num'>
 						<value>3</value>
@@ -88,7 +88,7 @@
 			</NI_PropertyObjectType>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='6'>
-			<NI_CustomResult classname='CustomResult' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_CustomResult classname='CustomResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Name typename='Expression' xsi:type='Expression' classname='ExprValue'>
 						<value/>
@@ -148,7 +148,7 @@
 			</NI_CustomResult>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='7'>
-			<TEInf classname='Obj' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4456472' instanceoverrideflags='4456472' valueflags='24'>
+			<TEInf classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4456472' instanceoverrideflags='4456472' valueflags='24'>
 				<subprops>
 					<Id classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
 						<value/>
@@ -423,7 +423,7 @@
 			</TEInf>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='8'>
-			<StepTypeNIData classname='Obj' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
+			<StepTypeNIData classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
 				<subprops>
 					<EditPanels classname='Strs'>
 						<value lbound='[0]' ubound='[]'/>
@@ -432,7 +432,7 @@
 			</StepTypeNIData>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='9'>
-			<Error classname='Obj' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
+			<Error classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
 				<extdata controllername='STRUCT' allowstructpassing='true' packingoption='8' exclude='false' type='0' arraystorage='0' strbuffersize='256' strstorage='0'/>
 				<extdata controllername='CLUST' allowclusterpassing='true' exclude='false' memberlabel=''/>
 				<extdata controllername='DNSTRUCT' allowstructpassing='true' exclude='false' membername=''/>
@@ -466,7 +466,7 @@
 			<CommonResults classname='Obj' isroottypedef='true' typecategory='3' timestamp='1465572565' typeversion='3.1.0.100' typelastmodversion='21.0.0.49156' typeminprodversion='3.1.0.0' typeflags='33554432' flagsforinstances='4194304' valueflags='4194304'/>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='11'>
-			<Substep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
+			<Substep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
 				<subprops>
 					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
 						<value>"%ModuleDescription"</value>
@@ -891,7 +891,7 @@
 			</Substep>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='12'>
-			<NI_DotNetParameterResult classname='DotNetParameterResult' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_DotNetParameterResult classname='DotNetParameterResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
 						<value/>
@@ -907,7 +907,7 @@
 			</NI_DotNetParameterResult>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='13'>
-			<DotNetParameter classname='DotNetParameter' isroottypedef='true' typecategory='3' timestamp='1628821096' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<DotNetParameter classname='DotNetParameter' isroottypedef='true' typecategory='3' timestamp='1650061192' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Name classname='Str'>
 						<value>_notNamed</value>
@@ -974,7 +974,7 @@
 			</DotNetParameter>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='14'>
-			<NI_DotNetCallResult classname='DotNetCallResult' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_DotNetCallResult classname='DotNetCallResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
 						<value/>
@@ -990,7 +990,7 @@
 			</NI_DotNetCallResult>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='15'>
-			<DotNetCall classname='DotNetCall' isroottypedef='true' typecategory='3' timestamp='1628821096' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<DotNetCall classname='DotNetCall' isroottypedef='true' typecategory='3' timestamp='1650061192' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<ClassName classname='Str'>
 						<value/>
@@ -1091,12 +1091,12 @@
 			</DotNetCall>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='0'>
-			<Path classname='PathValue' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
+			<Path classname='PathValue' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
 				<value/>
 			</Path>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='16'>
-			<DotNetStepAdditions classname='DotNetModule' isroottypedef='true' typecategory='3' timestamp='1628821096' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<DotNetStepAdditions classname='DotNetModule' isroottypedef='true' typecategory='3' timestamp='1650061192' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Calls classname='Objs'>
 						<value lbound='[0]' ubound='[]'>
@@ -1241,7 +1241,7 @@
 			</DotNetStepAdditions>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='17'>
-			<PostSubstep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
+			<PostSubstep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
 				<subprops>
 					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
 						<value>"%ModuleDescription"</value>
@@ -1666,7 +1666,7 @@
 			</PostSubstep>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='18'>
-			<NoneStepAdditions classname='NoneModule' isroottypedef='true' typecategory='3' timestamp='1628820742' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'/>
+			<NoneStepAdditions classname='NoneModule' isroottypedef='true' typecategory='3' timestamp='1650060850' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'/>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='19'>
 			<NI_MeasurementParameter classname='Obj' isroottypedef='true' typecategory='2' timestamp='1669042099' typeversion='21.0.5.4' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0'>
@@ -1699,7 +1699,7 @@
 			</NI_MeasurementParameter>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='20'>
-			<NI_Measurement classname='StepType' isroottypedef='true' typecategory='1' timestamp='1669042104' typeversion='21.0.5.7' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='2'>
+			<NI_Measurement classname='StepType' isroottypedef='true' typecategory='1' timestamp='1670875325' typeversion='21.0.5.8' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='2'>
 				<subprops>
 					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
 						<value>ResStr("MEASUREMENT_STEP_TYPE", "MEASUREMENT_DESCRIPTION_NAME")</value>
@@ -1768,7 +1768,7 @@
 																	<DotNetCall typename='DotNetCall' xsi:type='DotNetCall' name=''>
 																		<subprops>
 																			<ClassName classname='Str'>
-																				<value>NationalInstruments.MeasurementServices.NewStepHandler</value>
+																				<value>NationalInstruments.MeasurementLink.NewStepHandler</value>
 																			</ClassName>
 																			<MemberType classname='Num'>
 																				<value>4</value>
@@ -1800,7 +1800,7 @@
 																									<value>0</value>
 																								</Type>
 																								<TypeName classname='Str'>
-																									<value>NationalInstruments.MeasurementServices.NewStepHandler</value>
+																									<value>NationalInstruments.MeasurementLink.NewStepHandler</value>
 																								</TypeName>
 																								<Flags classname='Num'>
 																									<value>6</value>
@@ -1872,7 +1872,7 @@
 																	<DotNetCall typename='DotNetCall' xsi:type='DotNetCall' name=''>
 																		<subprops>
 																			<ClassName classname='Str'>
-																				<value>NationalInstruments.MeasurementServices.NewStepHandler</value>
+																				<value>NationalInstruments.MeasurementLink.NewStepHandler</value>
 																			</ClassName>
 																			<MemberType classname='Num'>
 																				<value>1</value>
@@ -1975,7 +1975,7 @@
 															</value>
 														</Calls>
 														<AssemblyPath classname='PathValue'>
-															<value>NationalInstruments.MeasurementServices.TestStandMeasurementClient.dll</value>
+															<value>NationalInstruments.MeasurementLink.TestStandMeasurementClient.dll</value>
 														</AssemblyPath>
 														<AssemblyStrongName classname='Str'>
 															<value/>
@@ -1984,7 +1984,7 @@
 															<value>0</value>
 														</AssemblyLocation>
 														<ClassName classname='Str'>
-															<value>NationalInstruments.MeasurementServices.NewStepHandler</value>
+															<value>NationalInstruments.MeasurementLink.NewStepHandler</value>
 														</ClassName>
 														<IsStruct classname='Bool'>
 															<value>false</value>
@@ -2379,7 +2379,7 @@
 																	<DotNetCall typename='DotNetCall' xsi:type='DotNetCall' name=''>
 																		<subprops>
 																			<ClassName classname='Str'>
-																				<value>NationalInstruments.MeasurementServices.MeasurementStepExecution</value>
+																				<value>NationalInstruments.MeasurementLink.MeasurementStepExecution</value>
 																			</ClassName>
 																			<MemberType classname='Num'>
 																				<value>4</value>
@@ -2411,7 +2411,7 @@
 																									<value>0</value>
 																								</Type>
 																								<TypeName classname='Str'>
-																									<value>NationalInstruments.MeasurementServices.MeasurementStepExecution</value>
+																									<value>NationalInstruments.MeasurementLink.MeasurementStepExecution</value>
 																								</TypeName>
 																								<Flags classname='Num'>
 																									<value>6</value>
@@ -2483,7 +2483,7 @@
 																	<DotNetCall typename='DotNetCall' xsi:type='DotNetCall' name=''>
 																		<subprops>
 																			<ClassName classname='Str'>
-																				<value>NationalInstruments.MeasurementServices.MeasurementStepExecution</value>
+																				<value>NationalInstruments.MeasurementLink.MeasurementStepExecution</value>
 																			</ClassName>
 																			<MemberType classname='Num'>
 																				<value>1</value>
@@ -2586,7 +2586,7 @@
 															</value>
 														</Calls>
 														<AssemblyPath classname='PathValue'>
-															<value>NationalInstruments.MeasurementServices.TestStandMeasurementClient.dll</value>
+															<value>NationalInstruments.MeasurementLink.TestStandMeasurementClient.dll</value>
 														</AssemblyPath>
 														<AssemblyStrongName classname='Str'>
 															<value/>
@@ -2595,7 +2595,7 @@
 															<value>0</value>
 														</AssemblyLocation>
 														<ClassName classname='Str'>
-															<value>NationalInstruments.MeasurementServices.MeasurementStepExecution</value>
+															<value>NationalInstruments.MeasurementLink.MeasurementStepExecution</value>
 														</ClassName>
 														<IsStruct classname='Bool'>
 															<value>false</value>
@@ -3313,7 +3313,7 @@
 						<subprops>
 							<EditPanels classname='Strs'>
 								<value lbound='[0]' ubound='[0]'>
-									<value arrayindex='[0]'>NationalInstruments.MeasurementServices.TestStandMeasurementClient.dll|NationalInstruments.MeasurementServices.MeasurementStepPanelInfo</value>
+									<value arrayindex='[0]'>NationalInstruments.MeasurementLink.TestStandMeasurementClient.dll|NationalInstruments.MeasurementLink.MeasurementStepPanelInfo</value>
 								</value>
 							</EditPanels>
 						</subprops>

--- a/examples/niscope_acquire_waveform/NIScopeAcquireWaveform.seq
+++ b/examples/niscope_acquire_waveform/NIScopeAcquireWaveform.seq
@@ -2,12 +2,12 @@
 <teststandfileheader type='SequenceFile' fileversion='962' productname='TestStand' productversion='2021 (21.0.0.49156)' compatibleversion='21.0.0.0' buildversion='21.0.0.49156' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.ni.com/TestStand/21.0.0/SequenceFile">
 	<typelist>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='1'>
-			<Expression classname='ExprValue' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
+			<Expression classname='ExprValue' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
 				<value/>
 			</Expression>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='2'>
-			<StepTypeMenu classname='Obj' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
+			<StepTypeMenu classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
 				<subprops>
 					<CanBeSubstepType classname='Bool'>
 						<value>false</value>
@@ -37,12 +37,12 @@
 			</StepTypeMenu>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='3'>
-			<StepTypeSubstepsArray classname='Objs' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4849688' valueflags='24'>
+			<StepTypeSubstepsArray classname='Objs' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4849688' valueflags='24'>
 				<value lbound='[0]' ubound='[]'/>
 			</StepTypeSubstepsArray>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='4'>
-			<NI_ArrayDimensions classname='ArrayDimensions' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_ArrayDimensions classname='ArrayDimensions' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<LowerBounds classname='Nums'>
 						<value lbound='[0]' ubound='[]'/>
@@ -54,7 +54,7 @@
 			</NI_ArrayDimensions>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='5'>
-			<NI_PropertyObjectType classname='PropertyObjectType' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_PropertyObjectType classname='PropertyObjectType' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<ValueType classname='Num'>
 						<value>3</value>
@@ -88,7 +88,7 @@
 			</NI_PropertyObjectType>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='6'>
-			<NI_CustomResult classname='CustomResult' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_CustomResult classname='CustomResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Name typename='Expression' xsi:type='Expression' classname='ExprValue'>
 						<value/>
@@ -148,7 +148,7 @@
 			</NI_CustomResult>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='7'>
-			<TEInf classname='Obj' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4456472' instanceoverrideflags='4456472' valueflags='24'>
+			<TEInf classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4456472' instanceoverrideflags='4456472' valueflags='24'>
 				<subprops>
 					<Id classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
 						<value/>
@@ -423,7 +423,7 @@
 			</TEInf>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='8'>
-			<StepTypeNIData classname='Obj' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
+			<StepTypeNIData classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
 				<subprops>
 					<EditPanels classname='Strs'>
 						<value lbound='[0]' ubound='[]'/>
@@ -432,7 +432,7 @@
 			</StepTypeNIData>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='9'>
-			<Error classname='Obj' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
+			<Error classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
 				<extdata controllername='STRUCT' allowstructpassing='true' packingoption='8' exclude='false' type='0' arraystorage='0' strbuffersize='256' strstorage='0'/>
 				<extdata controllername='CLUST' allowclusterpassing='true' exclude='false' memberlabel=''/>
 				<extdata controllername='DNSTRUCT' allowstructpassing='true' exclude='false' membername=''/>
@@ -466,7 +466,7 @@
 			<CommonResults classname='Obj' isroottypedef='true' typecategory='3' timestamp='1465572565' typeversion='3.1.0.100' typelastmodversion='21.0.0.49156' typeminprodversion='3.1.0.0' typeflags='33554432' flagsforinstances='4194304' valueflags='4194304'/>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='11'>
-			<Substep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
+			<Substep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
 				<subprops>
 					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
 						<value>"%ModuleDescription"</value>
@@ -891,7 +891,7 @@
 			</Substep>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='12'>
-			<NI_DotNetParameterResult classname='DotNetParameterResult' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_DotNetParameterResult classname='DotNetParameterResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
 						<value/>
@@ -907,7 +907,7 @@
 			</NI_DotNetParameterResult>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='13'>
-			<DotNetParameter classname='DotNetParameter' isroottypedef='true' typecategory='3' timestamp='1628821096' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<DotNetParameter classname='DotNetParameter' isroottypedef='true' typecategory='3' timestamp='1650061192' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Name classname='Str'>
 						<value>_notNamed</value>
@@ -974,7 +974,7 @@
 			</DotNetParameter>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='14'>
-			<NI_DotNetCallResult classname='DotNetCallResult' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_DotNetCallResult classname='DotNetCallResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
 						<value/>
@@ -990,7 +990,7 @@
 			</NI_DotNetCallResult>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='15'>
-			<DotNetCall classname='DotNetCall' isroottypedef='true' typecategory='3' timestamp='1628821096' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<DotNetCall classname='DotNetCall' isroottypedef='true' typecategory='3' timestamp='1650061192' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<ClassName classname='Str'>
 						<value/>
@@ -1091,12 +1091,12 @@
 			</DotNetCall>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='0'>
-			<Path classname='PathValue' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
+			<Path classname='PathValue' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
 				<value/>
 			</Path>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='16'>
-			<DotNetStepAdditions classname='DotNetModule' isroottypedef='true' typecategory='3' timestamp='1628821096' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<DotNetStepAdditions classname='DotNetModule' isroottypedef='true' typecategory='3' timestamp='1650061192' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Calls classname='Objs'>
 						<value lbound='[0]' ubound='[]'>
@@ -1241,7 +1241,7 @@
 			</DotNetStepAdditions>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='17'>
-			<PostSubstep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
+			<PostSubstep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
 				<subprops>
 					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
 						<value>"%ModuleDescription"</value>
@@ -1666,7 +1666,7 @@
 			</PostSubstep>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='18'>
-			<NoneStepAdditions classname='NoneModule' isroottypedef='true' typecategory='3' timestamp='1628820742' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'/>
+			<NoneStepAdditions classname='NoneModule' isroottypedef='true' typecategory='3' timestamp='1650060850' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'/>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='19'>
 			<NI_MeasurementParameter classname='Obj' isroottypedef='true' typecategory='2' timestamp='1669042099' typeversion='21.0.5.4' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0'>
@@ -1699,7 +1699,7 @@
 			</NI_MeasurementParameter>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='20'>
-			<NI_Measurement classname='StepType' isroottypedef='true' typecategory='1' timestamp='1669042104' typeversion='21.0.5.7' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='2'>
+			<NI_Measurement classname='StepType' isroottypedef='true' typecategory='1' timestamp='1670875325' typeversion='21.0.5.8' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='2'>
 				<subprops>
 					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
 						<value>ResStr("MEASUREMENT_STEP_TYPE", "MEASUREMENT_DESCRIPTION_NAME")</value>
@@ -1768,7 +1768,7 @@
 																	<DotNetCall typename='DotNetCall' xsi:type='DotNetCall' name=''>
 																		<subprops>
 																			<ClassName classname='Str'>
-																				<value>NationalInstruments.MeasurementServices.NewStepHandler</value>
+																				<value>NationalInstruments.MeasurementLink.NewStepHandler</value>
 																			</ClassName>
 																			<MemberType classname='Num'>
 																				<value>4</value>
@@ -1800,7 +1800,7 @@
 																									<value>0</value>
 																								</Type>
 																								<TypeName classname='Str'>
-																									<value>NationalInstruments.MeasurementServices.NewStepHandler</value>
+																									<value>NationalInstruments.MeasurementLink.NewStepHandler</value>
 																								</TypeName>
 																								<Flags classname='Num'>
 																									<value>6</value>
@@ -1872,7 +1872,7 @@
 																	<DotNetCall typename='DotNetCall' xsi:type='DotNetCall' name=''>
 																		<subprops>
 																			<ClassName classname='Str'>
-																				<value>NationalInstruments.MeasurementServices.NewStepHandler</value>
+																				<value>NationalInstruments.MeasurementLink.NewStepHandler</value>
 																			</ClassName>
 																			<MemberType classname='Num'>
 																				<value>1</value>
@@ -1975,7 +1975,7 @@
 															</value>
 														</Calls>
 														<AssemblyPath classname='PathValue'>
-															<value>NationalInstruments.MeasurementServices.TestStandMeasurementClient.dll</value>
+															<value>NationalInstruments.MeasurementLink.TestStandMeasurementClient.dll</value>
 														</AssemblyPath>
 														<AssemblyStrongName classname='Str'>
 															<value/>
@@ -1984,7 +1984,7 @@
 															<value>0</value>
 														</AssemblyLocation>
 														<ClassName classname='Str'>
-															<value>NationalInstruments.MeasurementServices.NewStepHandler</value>
+															<value>NationalInstruments.MeasurementLink.NewStepHandler</value>
 														</ClassName>
 														<IsStruct classname='Bool'>
 															<value>false</value>
@@ -2379,7 +2379,7 @@
 																	<DotNetCall typename='DotNetCall' xsi:type='DotNetCall' name=''>
 																		<subprops>
 																			<ClassName classname='Str'>
-																				<value>NationalInstruments.MeasurementServices.MeasurementStepExecution</value>
+																				<value>NationalInstruments.MeasurementLink.MeasurementStepExecution</value>
 																			</ClassName>
 																			<MemberType classname='Num'>
 																				<value>4</value>
@@ -2411,7 +2411,7 @@
 																									<value>0</value>
 																								</Type>
 																								<TypeName classname='Str'>
-																									<value>NationalInstruments.MeasurementServices.MeasurementStepExecution</value>
+																									<value>NationalInstruments.MeasurementLink.MeasurementStepExecution</value>
 																								</TypeName>
 																								<Flags classname='Num'>
 																									<value>6</value>
@@ -2483,7 +2483,7 @@
 																	<DotNetCall typename='DotNetCall' xsi:type='DotNetCall' name=''>
 																		<subprops>
 																			<ClassName classname='Str'>
-																				<value>NationalInstruments.MeasurementServices.MeasurementStepExecution</value>
+																				<value>NationalInstruments.MeasurementLink.MeasurementStepExecution</value>
 																			</ClassName>
 																			<MemberType classname='Num'>
 																				<value>1</value>
@@ -2586,7 +2586,7 @@
 															</value>
 														</Calls>
 														<AssemblyPath classname='PathValue'>
-															<value>NationalInstruments.MeasurementServices.TestStandMeasurementClient.dll</value>
+															<value>NationalInstruments.MeasurementLink.TestStandMeasurementClient.dll</value>
 														</AssemblyPath>
 														<AssemblyStrongName classname='Str'>
 															<value/>
@@ -2595,7 +2595,7 @@
 															<value>0</value>
 														</AssemblyLocation>
 														<ClassName classname='Str'>
-															<value>NationalInstruments.MeasurementServices.MeasurementStepExecution</value>
+															<value>NationalInstruments.MeasurementLink.MeasurementStepExecution</value>
 														</ClassName>
 														<IsStruct classname='Bool'>
 															<value>false</value>
@@ -3313,7 +3313,7 @@
 						<subprops>
 							<EditPanels classname='Strs'>
 								<value lbound='[0]' ubound='[0]'>
-									<value arrayindex='[0]'>NationalInstruments.MeasurementServices.TestStandMeasurementClient.dll|NationalInstruments.MeasurementServices.MeasurementStepPanelInfo</value>
+									<value arrayindex='[0]'>NationalInstruments.MeasurementLink.TestStandMeasurementClient.dll|NationalInstruments.MeasurementLink.MeasurementStepPanelInfo</value>
 								</value>
 							</EditPanels>
 						</subprops>

--- a/examples/niswitch_control_relays/NISwitchControlRelays.seq
+++ b/examples/niswitch_control_relays/NISwitchControlRelays.seq
@@ -2,12 +2,12 @@
 <teststandfileheader type='SequenceFile' fileversion='962' productname='TestStand' productversion='2021 (21.0.0.49156)' compatibleversion='21.0.0.0' buildversion='21.0.0.49156' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.ni.com/TestStand/21.0.0/SequenceFile">
 	<typelist>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='1'>
-			<Expression classname='ExprValue' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
+			<Expression classname='ExprValue' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
 				<value/>
 			</Expression>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='2'>
-			<StepTypeMenu classname='Obj' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
+			<StepTypeMenu classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
 				<subprops>
 					<CanBeSubstepType classname='Bool'>
 						<value>false</value>
@@ -37,12 +37,12 @@
 			</StepTypeMenu>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='3'>
-			<StepTypeSubstepsArray classname='Objs' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4849688' valueflags='24'>
+			<StepTypeSubstepsArray classname='Objs' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4849688' valueflags='24'>
 				<value lbound='[0]' ubound='[]'/>
 			</StepTypeSubstepsArray>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='4'>
-			<NI_ArrayDimensions classname='ArrayDimensions' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_ArrayDimensions classname='ArrayDimensions' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<LowerBounds classname='Nums'>
 						<value lbound='[0]' ubound='[]'/>
@@ -54,7 +54,7 @@
 			</NI_ArrayDimensions>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='5'>
-			<NI_PropertyObjectType classname='PropertyObjectType' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_PropertyObjectType classname='PropertyObjectType' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<ValueType classname='Num'>
 						<value>3</value>
@@ -88,7 +88,7 @@
 			</NI_PropertyObjectType>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='6'>
-			<NI_CustomResult classname='CustomResult' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_CustomResult classname='CustomResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Name typename='Expression' xsi:type='Expression' classname='ExprValue'>
 						<value/>
@@ -148,7 +148,7 @@
 			</NI_CustomResult>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='7'>
-			<TEInf classname='Obj' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4456472' instanceoverrideflags='4456472' valueflags='24'>
+			<TEInf classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4456472' instanceoverrideflags='4456472' valueflags='24'>
 				<subprops>
 					<Id classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
 						<value/>
@@ -423,7 +423,7 @@
 			</TEInf>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='8'>
-			<StepTypeNIData classname='Obj' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
+			<StepTypeNIData classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
 				<subprops>
 					<EditPanels classname='Strs'>
 						<value lbound='[0]' ubound='[]'/>
@@ -432,7 +432,7 @@
 			</StepTypeNIData>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='9'>
-			<Error classname='Obj' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
+			<Error classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
 				<extdata controllername='STRUCT' allowstructpassing='true' packingoption='8' exclude='false' type='0' arraystorage='0' strbuffersize='256' strstorage='0'/>
 				<extdata controllername='CLUST' allowclusterpassing='true' exclude='false' memberlabel=''/>
 				<extdata controllername='DNSTRUCT' allowstructpassing='true' exclude='false' membername=''/>
@@ -466,7 +466,7 @@
 			<CommonResults classname='Obj' isroottypedef='true' typecategory='3' timestamp='1465572565' typeversion='3.1.0.100' typelastmodversion='21.0.0.49156' typeminprodversion='3.1.0.0' typeflags='33554432' flagsforinstances='4194304' valueflags='4194304'/>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='11'>
-			<Substep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
+			<Substep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
 				<subprops>
 					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
 						<value>"%ModuleDescription"</value>
@@ -891,7 +891,7 @@
 			</Substep>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='12'>
-			<NI_DotNetParameterResult classname='DotNetParameterResult' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_DotNetParameterResult classname='DotNetParameterResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
 						<value/>
@@ -907,7 +907,7 @@
 			</NI_DotNetParameterResult>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='13'>
-			<DotNetParameter classname='DotNetParameter' isroottypedef='true' typecategory='3' timestamp='1628821096' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<DotNetParameter classname='DotNetParameter' isroottypedef='true' typecategory='3' timestamp='1650061192' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Name classname='Str'>
 						<value>_notNamed</value>
@@ -974,7 +974,7 @@
 			</DotNetParameter>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='14'>
-			<NI_DotNetCallResult classname='DotNetCallResult' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_DotNetCallResult classname='DotNetCallResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
 						<value/>
@@ -990,7 +990,7 @@
 			</NI_DotNetCallResult>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='15'>
-			<DotNetCall classname='DotNetCall' isroottypedef='true' typecategory='3' timestamp='1628821096' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<DotNetCall classname='DotNetCall' isroottypedef='true' typecategory='3' timestamp='1650061192' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<ClassName classname='Str'>
 						<value/>
@@ -1091,12 +1091,12 @@
 			</DotNetCall>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='0'>
-			<Path classname='PathValue' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
+			<Path classname='PathValue' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
 				<value/>
 			</Path>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='16'>
-			<DotNetStepAdditions classname='DotNetModule' isroottypedef='true' typecategory='3' timestamp='1628821096' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<DotNetStepAdditions classname='DotNetModule' isroottypedef='true' typecategory='3' timestamp='1650061192' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Calls classname='Objs'>
 						<value lbound='[0]' ubound='[]'>
@@ -1241,7 +1241,7 @@
 			</DotNetStepAdditions>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='17'>
-			<PostSubstep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
+			<PostSubstep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
 				<subprops>
 					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
 						<value>"%ModuleDescription"</value>
@@ -1666,7 +1666,7 @@
 			</PostSubstep>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='18'>
-			<NoneStepAdditions classname='NoneModule' isroottypedef='true' typecategory='3' timestamp='1628820742' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'/>
+			<NoneStepAdditions classname='NoneModule' isroottypedef='true' typecategory='3' timestamp='1650060850' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'/>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='19'>
 			<NI_MeasurementParameter classname='Obj' isroottypedef='true' typecategory='2' timestamp='1669042099' typeversion='21.0.5.4' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0'>
@@ -1699,7 +1699,7 @@
 			</NI_MeasurementParameter>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='20'>
-			<NI_Measurement classname='StepType' isroottypedef='true' typecategory='1' timestamp='1669042104' typeversion='21.0.5.7' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='2'>
+			<NI_Measurement classname='StepType' isroottypedef='true' typecategory='1' timestamp='1670875325' typeversion='21.0.5.8' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='2'>
 				<subprops>
 					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
 						<value>ResStr("MEASUREMENT_STEP_TYPE", "MEASUREMENT_DESCRIPTION_NAME")</value>
@@ -1768,7 +1768,7 @@
 																	<DotNetCall typename='DotNetCall' xsi:type='DotNetCall' name=''>
 																		<subprops>
 																			<ClassName classname='Str'>
-																				<value>NationalInstruments.MeasurementServices.NewStepHandler</value>
+																				<value>NationalInstruments.MeasurementLink.NewStepHandler</value>
 																			</ClassName>
 																			<MemberType classname='Num'>
 																				<value>4</value>
@@ -1800,7 +1800,7 @@
 																									<value>0</value>
 																								</Type>
 																								<TypeName classname='Str'>
-																									<value>NationalInstruments.MeasurementServices.NewStepHandler</value>
+																									<value>NationalInstruments.MeasurementLink.NewStepHandler</value>
 																								</TypeName>
 																								<Flags classname='Num'>
 																									<value>6</value>
@@ -1872,7 +1872,7 @@
 																	<DotNetCall typename='DotNetCall' xsi:type='DotNetCall' name=''>
 																		<subprops>
 																			<ClassName classname='Str'>
-																				<value>NationalInstruments.MeasurementServices.NewStepHandler</value>
+																				<value>NationalInstruments.MeasurementLink.NewStepHandler</value>
 																			</ClassName>
 																			<MemberType classname='Num'>
 																				<value>1</value>
@@ -1975,7 +1975,7 @@
 															</value>
 														</Calls>
 														<AssemblyPath classname='PathValue'>
-															<value>NationalInstruments.MeasurementServices.TestStandMeasurementClient.dll</value>
+															<value>NationalInstruments.MeasurementLink.TestStandMeasurementClient.dll</value>
 														</AssemblyPath>
 														<AssemblyStrongName classname='Str'>
 															<value/>
@@ -1984,7 +1984,7 @@
 															<value>0</value>
 														</AssemblyLocation>
 														<ClassName classname='Str'>
-															<value>NationalInstruments.MeasurementServices.NewStepHandler</value>
+															<value>NationalInstruments.MeasurementLink.NewStepHandler</value>
 														</ClassName>
 														<IsStruct classname='Bool'>
 															<value>false</value>
@@ -2379,7 +2379,7 @@
 																	<DotNetCall typename='DotNetCall' xsi:type='DotNetCall' name=''>
 																		<subprops>
 																			<ClassName classname='Str'>
-																				<value>NationalInstruments.MeasurementServices.MeasurementStepExecution</value>
+																				<value>NationalInstruments.MeasurementLink.MeasurementStepExecution</value>
 																			</ClassName>
 																			<MemberType classname='Num'>
 																				<value>4</value>
@@ -2411,7 +2411,7 @@
 																									<value>0</value>
 																								</Type>
 																								<TypeName classname='Str'>
-																									<value>NationalInstruments.MeasurementServices.MeasurementStepExecution</value>
+																									<value>NationalInstruments.MeasurementLink.MeasurementStepExecution</value>
 																								</TypeName>
 																								<Flags classname='Num'>
 																									<value>6</value>
@@ -2483,7 +2483,7 @@
 																	<DotNetCall typename='DotNetCall' xsi:type='DotNetCall' name=''>
 																		<subprops>
 																			<ClassName classname='Str'>
-																				<value>NationalInstruments.MeasurementServices.MeasurementStepExecution</value>
+																				<value>NationalInstruments.MeasurementLink.MeasurementStepExecution</value>
 																			</ClassName>
 																			<MemberType classname='Num'>
 																				<value>1</value>
@@ -2586,7 +2586,7 @@
 															</value>
 														</Calls>
 														<AssemblyPath classname='PathValue'>
-															<value>NationalInstruments.MeasurementServices.TestStandMeasurementClient.dll</value>
+															<value>NationalInstruments.MeasurementLink.TestStandMeasurementClient.dll</value>
 														</AssemblyPath>
 														<AssemblyStrongName classname='Str'>
 															<value/>
@@ -2595,7 +2595,7 @@
 															<value>0</value>
 														</AssemblyLocation>
 														<ClassName classname='Str'>
-															<value>NationalInstruments.MeasurementServices.MeasurementStepExecution</value>
+															<value>NationalInstruments.MeasurementLink.MeasurementStepExecution</value>
 														</ClassName>
 														<IsStruct classname='Bool'>
 															<value>false</value>
@@ -3313,7 +3313,7 @@
 						<subprops>
 							<EditPanels classname='Strs'>
 								<value lbound='[0]' ubound='[0]'>
-									<value arrayindex='[0]'>NationalInstruments.MeasurementServices.TestStandMeasurementClient.dll|NationalInstruments.MeasurementServices.MeasurementStepPanelInfo</value>
+									<value arrayindex='[0]'>NationalInstruments.MeasurementLink.TestStandMeasurementClient.dll|NationalInstruments.MeasurementLink.MeasurementStepPanelInfo</value>
 								</value>
 							</EditPanels>
 						</subprops>


### PR DESCRIPTION
### What does this Pull Request accomplish?

Re-save all example TestStand sequences with the latest version of `NI_MeasurementLink.ini` (from ASW PR 407855).

### Why should this Pull Request be merged?

Prevent type conflict errors when loading example TestStand sequences.

### What testing has been done?

Loaded sequences.
