### PR TITLE
Add channel mappings data to SessionInformation in session management client

### DIFF
--- a/ni_measurementlink_service/session_management.py
+++ b/ni_measurementlink_service/session_management.py
@@ -1,20 +1,13 @@
 """Contains methods related to managing driver sessions."""
 from functools import cached_property
-from typing import Iterable
-from typing import List
-from typing import NamedTuple
-from typing import Optional
+from typing import Iterable, List, NamedTuple, Optional
 
 import grpc
 
 from ni_measurementlink_service._internal.stubs import session_pb2
-from ni_measurementlink_service._internal.stubs.ni.measurementlink import (
-    pin_map_context_pb2,
-)
+from ni_measurementlink_service._internal.stubs.ni.measurementlink import pin_map_context_pb2
 from ni_measurementlink_service._internal.stubs.ni.measurementlink.sessionmanagement.v1 import (
     session_management_service_pb2,
-)
-from ni_measurementlink_service._internal.stubs.ni.measurementlink.sessionmanagement.v1 import (
     session_management_service_pb2_grpc,
 )
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds channel mapping information to the SessionInformation class returned from session reservations in the session management client.

### Why should this Pull Request be merged?

The SessionInformation message in the session management service .proto file had channel_mappings information added to it. These mappings can be used to figure out which channel maps to a pin when there are multiple channels in the same session. To expose the information, we need to update the hand-written session management client.

### What testing has been done?

Ran existing tests.
Made local modifications to an example to inspect the channel_mappings on the SessionInformation class.