### PR TITLE
Create dictionary properly in scope example using channel_mappings

### DIFF
--- a/examples/niscope_acquire_waveform/measurement.py
+++ b/examples/niscope_acquire_waveform/measurement.py
@@ -132,8 +132,9 @@ def measure(
 
         session_info = reservation.session_info[0]
         channel_names = session_info.channel_list
-        channel_list = [c.strip() for c in channel_names.split(",")]
-        pin_to_channel = dict(zip(pin_names, channel_list))
+        pin_to_channel = {
+            mapping.pin_or_relay_name: mapping.channel for mapping in session_info.channel_mappings
+        }
         if trigger_source in pin_to_channel:
             trigger_source = pin_to_channel[trigger_source]
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

For the niscope_acquire_waveform example, uses the channel_mappings provided by the session management service to build the pin-to-channel dictionary used in the measurement code to find the source trigger channel.

### Why should this Pull Request be merged?

The previous implementation built a pin-to-channel dictionary by relying on the channel_list of the session coincidentally being in a particular order, which is not guaranteed. Now that the mappings are provided as part of the reservation response, we can use them to build the dictionary correctly regardless of the channel_list's order.

### What testing has been done?

Ran the example before and after the changes to see that it functions as expected.