### PR TITLE
nidmm_measurement: Add out-of-range check

### DIFF
--- a/examples/nidmm_measurement/measurement.py
+++ b/examples/nidmm_measurement/measurement.py
@@ -107,7 +107,12 @@ def measure(
         signal_out_of_range = math.isnan(measured_value) or math.isinf(measured_value)
         absolute_resolution = session.resolution_absolute
 
-    logging.info("Completed measurement")
+    logging.info(
+        "Completed measurement: measured_value=%g signal_out_of_range=%s absolute_resolution=%g",
+        measured_value,
+        signal_out_of_range,
+        absolute_resolution,
+    )
     return (measured_value, signal_out_of_range, absolute_resolution)
 
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add an out-of-range check to `nidmm_measurement`. nimi-python doesn't include the `IsOverRange()` and `IsUnderRange()` methods because they simply check whether the measured value is NaN or +Inf (over range), or -Inf (under range).

Log `nidmm_measurement` output values.

### Why should this Pull Request be merged?

Fixes #172 

### What testing has been done?

I couldn't test an actual out of range condition with a simulated DMM, but I tested by adding `measured_value = math.inf` etc. to the code.