### PR TITLE
ni_measurement_service: Update __enter__() type annotations to support subclassing

### DIFF
--- a/ni_measurementlink_service/measurement/service.py
+++ b/ni_measurementlink_service/measurement/service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from threading import Lock
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, TypeVar
 
 import grpc
 
@@ -50,6 +50,11 @@ class MeasurementContext:
         grpc_servicer.measurement_service_context.get().abort(code, details)
 
 
+# Eventually, these can be replaced with typing.Self (Python >= 3.11).
+_TGrpcChannelPool = TypeVar("_TGrpcChannelPool", bound="GrpcChannelPool")
+_TMeasurementService = TypeVar("_TMeasurementService", bound="MeasurementService")
+
+
 class GrpcChannelPool(object):
     """Class that manages gRPC channel lifetimes."""
 
@@ -58,7 +63,7 @@ class GrpcChannelPool(object):
         self._lock: Lock = Lock()
         self._channel_cache: Dict[str, grpc.Channel] = {}
 
-    def __enter__(self) -> GrpcChannelPool:
+    def __enter__(self: _TGrpcChannelPool) -> _TGrpcChannelPool:
         """Enter the runtime context of the GrpcChannelPool."""
         return self
 
@@ -289,7 +294,7 @@ class MeasurementService:
         self.grpc_service.stop()
         self.channel_pool.close()
 
-    def __enter__(self) -> MeasurementService:
+    def __enter__(self: _TMeasurementService) -> _TMeasurementService:
         """Enter the runtime context related to the measurement service."""
         return self
 

--- a/ni_measurementlink_service/session_management.py
+++ b/ni_measurementlink_service/session_management.py
@@ -1,6 +1,6 @@
 """Contains methods related to managing driver sessions."""
 from functools import cached_property
-from typing import Iterable, List, NamedTuple, Optional
+from typing import Iterable, List, NamedTuple, Optional, TypeVar
 
 import grpc
 
@@ -107,6 +107,10 @@ class SessionInformation(NamedTuple):
     channel_mappings: Iterable[ChannelMapping]
 
 
+# Eventually, this can be replaced with typing.Self (Python >= 3.11).
+_TReservation = TypeVar("_TReservation", bound="Reservation")
+
+
 class Reservation(object):
     """Manage session reservation."""
 
@@ -119,7 +123,7 @@ class Reservation(object):
         self._session_manager = session_manager
         self._session_info = session_info
 
-    def __enter__(self):
+    def __enter__(self: _TReservation) -> _TReservation:
         """Context management protocol. Returns self."""
         return self
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update `__enter__()` type annotations to support returning a subclass.

Python 3.11 adds a cleaner solution in the form of `typing.Self`. I tried using `typing_extensions.Self`, but I couldn't get it to work with Python 3.9:
```
examples\niswitch_control_relays\teststand_fixture.py:21: error: Self? has no attribute "pin_map_channel"
examples\niswitch_control_relays\teststand_fixture.py:29: error: Self? has no attribute "session_management_channel"
examples\niswitch_control_relays\teststand_fixture.py:41: error: Self? has no attribute "get_grpc_device_channel"
```

### Why should this Pull Request be merged?

Fixes #186

### What testing has been done?

Ran mypy on a few example directories.