### PR TITLE
pyproject.toml: Add more trove classifiers for PyPI, plus license/repo for nimg

### DIFF
--- a/ni_measurementlink_generator/pyproject.toml
+++ b/ni_measurementlink_generator/pyproject.toml
@@ -4,6 +4,19 @@ version = "0.12.0"
 description = "MeasurementLink Code Generator for Python"
 authors = ["NI <opensource@ni.com>"]
 readme = "README.md"
+repository = "https://github.com/ni/measurementlink-python/"
+license = "MIT"
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Manufacturing",
+    "Intended Audience :: Science/Research",
+    "Operating System :: Microsoft :: Windows",
+    # Poetry automatically adds classifiers for the license and the supported Python versions.
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Topic :: Scientific/Engineering",
+    "Topic :: System :: Hardware",
+]
 
 [tool.poetry.dependencies]
 python = "^3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,17 @@ authors = ["NI <opensource@ni.com>"]
 readme = "README.md" # apply the repo readme to the package as well
 repository = "https://github.com/ni/measurementlink-python/"
 license = "MIT"
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Manufacturing",
+    "Intended Audience :: Science/Research",
+    "Operating System :: Microsoft :: Windows",
+    # Poetry automatically adds classifiers for the license and the supported Python versions.
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Topic :: Scientific/Engineering",
+    "Topic :: System :: Hardware",
+]
 
 [tool.poetry.dependencies]
 python = "^3.8"


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add more trove classifiers for PyPI, in addition to the ones that Poetry adds automatically.

### Why should this Pull Request be merged?

Better describe purpose/status of package.

Fixes #190

### What testing has been done?

Ran `poetry install` to ensure the `pyproject.toml` didn't have any syntax errors.