### PR TITLE
examples: Add grpcio dependency to all examples that explicitly import grpc

### DIFF
--- a/examples/nidcpower_source_dc_voltage/pyproject.toml
+++ b/examples/nidcpower_source_dc_voltage/pyproject.toml
@@ -9,6 +9,7 @@ python = "^3.8"
 nidcpower = ">=1.4.3"
 ni-measurementlink-service = "*"
 click = ">=7.1.2"
+grpcio = "*"
 
 [tool.poetry.dev-dependencies]
 # Uncomment to use prerelease dependencies (requires poetry>=1.2).

--- a/examples/nidcpower_source_dc_voltage_with_labview_ui/pyproject.toml
+++ b/examples/nidcpower_source_dc_voltage_with_labview_ui/pyproject.toml
@@ -9,6 +9,7 @@ python = "^3.8"
 nidcpower = ">=1.4.3"
 ni-measurementlink-service = "*"
 click = ">=7.1.2"
+grpcio = "*"
 
 [tool.poetry.dev-dependencies]
 # Uncomment to use prerelease dependencies (requires poetry>=1.2).

--- a/examples/nidmm_measurement/pyproject.toml
+++ b/examples/nidmm_measurement/pyproject.toml
@@ -9,6 +9,7 @@ python = "^3.8"
 nidmm = ">=1.4.3"
 ni-measurementlink-service = "*"
 click = ">=7.1.2"
+grpcio = "*"
 
 [tool.poetry.dev-dependencies]
 # Uncomment to use prerelease dependencies (requires poetry>=1.2).

--- a/examples/nifgen_standard_function/pyproject.toml
+++ b/examples/nifgen_standard_function/pyproject.toml
@@ -9,6 +9,7 @@ python = "^3.8"
 nifgen = ">=1.4.3"
 ni-measurementlink-service = "*"
 click = ">=7.1.2"
+grpcio = "*"
 
 [tool.poetry.dev-dependencies]
 # Uncomment to use prerelease dependencies (requires poetry>=1.2).

--- a/examples/niscope_acquire_waveform/pyproject.toml
+++ b/examples/niscope_acquire_waveform/pyproject.toml
@@ -9,6 +9,7 @@ python = "^3.8"
 niscope = ">=1.4.3"
 ni-measurementlink-service = "*"
 click = ">=7.1.2"
+grpcio = "*"
 
 [tool.poetry.dev-dependencies]
 # Uncomment to use prerelease dependencies (requires poetry>=1.2).

--- a/examples/niswitch_control_relays/pyproject.toml
+++ b/examples/niswitch_control_relays/pyproject.toml
@@ -9,6 +9,7 @@ python = "^3.8"
 niswitch = ">=1.4.3"
 ni-measurementlink-service = "*"
 click = ">=7.1.2"
+grpcio = "*"
 
 [tool.poetry.dev-dependencies]
 # Uncomment to use prerelease dependencies (requires poetry>=1.2).


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add a dependency on `grpcio` to all of the examples that explicitly `import grpc`.

### Why should this Pull Request be merged?

Include what you use.

Follow-up from https://github.com/ni/measurementlink-python/pull/191#discussion_r1067154477

### What testing has been done?

Made same change to `nivisa_dmm_measurement`, ran `git clean -dffx`, and re-tested.