### PR TITLE
Add workflow to sync GitHub issue and AzDO Bug

### DIFF
--- a/.github/workflows/sync_github_issues_to_azdo.yml
+++ b/.github/workflows/sync_github_issues_to_azdo.yml
@@ -1,0 +1,24 @@
+name: Sync issue to Azure DevOps work item
+
+on:
+  issues:
+    types:
+      [opened, edited, deleted, closed, reopened, labeled, unlabeled, assigned]
+
+jobs:
+  alert:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: danhellem/github-actions-issue-to-work-item@v2.1
+        env:
+          ado_token: "${{ secrets.AZDO_Work_Item_Token }}"
+          github_token: "${{ secrets.GH_REPO_TOKEN }}"
+          ado_organization: "ni"
+          ado_project: "DevCentral"
+          ado_area_path: "DevCentral\\Product RnD\\PlatformSW\\Test System SW\\CBS\\Test Automation Frameworks"
+          ado_wit: "Bug"
+          ado_new_state: "New"
+          ado_active_state: "Active"
+          ado_close_state: "Closed"
+          ado_bypassrules: true
+          log_level: 100


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Workflow will create a Bug in Azure when an issue is created in GitHub. These will have links to each other and closing the issue will close the Bug in Azure.

### Why should this Pull Request be merged?

Better awareness and tracking of issues in Azure

### What testing has been done?

None. Have done this in another repo and will test here once the workflow is in place.