### PR TITLE
discovery_client: Explicitly connect to IPv4 address to avoid a delay

### DIFF
--- a/ni_measurementlink_service/_internal/discovery_client.py
+++ b/ni_measurementlink_service/_internal/discovery_client.py
@@ -210,7 +210,10 @@ def _get_discovery_service_address() -> str:
     _logger.debug("Discovery service key file path: %s", key_file_path)
     with _open_key_file(str(key_file_path)) as key_file:
         key_json = json.load(key_file)
-        return "localhost:" + key_json["InsecurePort"]
+        # Hack: the discovery service doesn't listen on IPv6 yet, so explicitly connect to the
+        # IPv4 address instead of localhost. Otherwise, gRPC tries to connect to the IPv6
+        # address and fails, which causes a delay.
+        return "127.0.0.1:" + key_json["InsecurePort"]
 
 
 def _get_key_file_path(cluster_id: typing.Optional[str] = None) -> pathlib.Path:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Connect to the discovery service using 127.0.0.1 instead of localhost. The discovery service does not listen on IPv6 yet, and using localhost causes gRPC to try IPv6 first (5 times) and fail, which causes a noticeable delay.

### Why should this Pull Request be merged?

Speed up service start/registration.

### What testing has been done?

Captured traffic with Wireshark before/after.
Compared log timestamps before/after.

[AB#2267714](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2267714)