### PR TITLE
Removing abort_when_done from FGEN example.

### DIFF
--- a/examples/nifgen_standard_function/NIFgenStandardFunction.measui
+++ b/examples/nifgen_standard_function/NIFgenStandardFunction.measui
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<SourceFile Checksum="781ED04CA16AF5E767AFDCBC0E9E947C69A3A5949C2908D7BE68B1087E3053FCB5824887C9C1382004956EC0D4B226C7823D99C14AA36630E86DC0AEA78DD2C5" Timestamp="1D9069B020F3E87" xmlns="http://www.ni.com/PlatformFramework">
+<SourceFile Checksum="474328318FDB50FC3F99B7181C2B6594B56F0EAC83C80A81294CE37750F1F978E11E6AFED7D35AB729CAFF1FF7C9790DD5BB07D972A657F0B5907BC24BF1964E" Timestamp="1D92C1D54FB2F64" xmlns="http://www.ni.com/PlatformFramework">
 	<SourceModelFeatureSet>
-		<ParsableNamespace AssemblyFileVersion="9.7.0.2171" FeatureSetName="Configuration Based Software Core" Name="http://www.ni.com/ConfigurationBasedSoftware.Core" OldestCompatibleVersion="6.3.0.49152" Version="6.3.0.49152" />
-		<ParsableNamespace AssemblyFileVersion="9.7.0.2171" FeatureSetName="LabVIEW Controls" Name="http://www.ni.com/Controls.LabVIEW.Design" OldestCompatibleVersion="8.1.0.49152" Version="8.1.0.49152" />
-		<ParsableNamespace AssemblyFileVersion="23.0.0.2171" FeatureSetName="InstrumentStudio Measurement UI" Name="http://www.ni.com/InstrumentFramework/ScreenDocument" OldestCompatibleVersion="22.1.0.1" Version="22.1.0.1" />
-		<ParsableNamespace AssemblyFileVersion="9.7.0.2171" FeatureSetName="Editor" Name="http://www.ni.com/PanelCommon" OldestCompatibleVersion="6.1.0.0" Version="6.1.0.49152" />
-		<ParsableNamespace AssemblyFileVersion="9.7.0.2171" FeatureSetName="Editor" Name="http://www.ni.com/PlatformFramework" OldestCompatibleVersion="8.1.0.49152" Version="8.1.0.49152" />
-		<ApplicationVersionInfo Build="23.0.0.2171" Name="MeasurementLink UI Editor" Version="23.0.0.2171" />
+		<ParsableNamespace AssemblyFileVersion="9.7.0.49258" FeatureSetName="Configuration Based Software Core" Name="http://www.ni.com/ConfigurationBasedSoftware.Core" OldestCompatibleVersion="6.3.0.49152" Version="6.3.0.49152" />
+		<ParsableNamespace AssemblyFileVersion="9.7.0.49258" FeatureSetName="LabVIEW Controls" Name="http://www.ni.com/Controls.LabVIEW.Design" OldestCompatibleVersion="8.1.0.49152" Version="8.1.0.49152" />
+		<ParsableNamespace AssemblyFileVersion="23.0.0.49258" FeatureSetName="InstrumentStudio Measurement UI" Name="http://www.ni.com/InstrumentFramework/ScreenDocument" OldestCompatibleVersion="22.1.0.1" Version="22.1.0.1" />
+		<ParsableNamespace AssemblyFileVersion="9.7.0.49258" FeatureSetName="Editor" Name="http://www.ni.com/PanelCommon" OldestCompatibleVersion="6.1.0.0" Version="6.1.0.49152" />
+		<ParsableNamespace AssemblyFileVersion="9.7.0.49258" FeatureSetName="Editor" Name="http://www.ni.com/PlatformFramework" OldestCompatibleVersion="8.1.0.49152" Version="8.1.0.49152" />
+		<ApplicationVersionInfo Build="23.0.0.49258" Name="MeasurementLink UI Editor" Version="23.0.0.49258" />
 	</SourceModelFeatureSet>
 	<Screen ClientId="{782d1b4c-4bb0-4fee-b195-03544d32de7c}" DisplayName="NI-FGEN Standard Function (Py)" Id="4e74a15e122740b596612afe9f35308c" ServiceClass="ni.examples.NIFgenStandardFunction_Python" xmlns="http://www.ni.com/InstrumentFramework/ScreenDocument">
 		<ScreenSurface BackgroundColor="[SMSolidColorBrush]#ffffffff" Height="[float]450" Id="625f0974374047b2bc643babf49a74e5" Left="[float]0" PanelSizeMode="Fixed" Top="[float]0" Width="[float]270" xmlns="http://www.ni.com/ConfigurationBasedSoftware.Core">
@@ -20,15 +20,13 @@
 				<Text Height="[float]144" Id="6a9f52b7d65043689a82818d28f67c8c" Left="[float]126" Text="[string]Supported types:&#xD;&#xA;- Sine&#xD;&#xA;- Square&#xD;&#xA;- Triangle&#xD;&#xA;- Ramp Up&#xD;&#xA;- Ramp Down&#xD;&#xA;- DC&#xD;&#xA;- Noise&#xD;&#xA;" TextWrapping="[TextWrapping]Wrap" Top="[float]16" Width="[float]91" xmlns="http://www.ni.com/PlatformFramework" />
 			</ScreenSurfaceCanvas>
 			<Label Height="[float]16" Id="cb2217f529d84fb2b1017f06e1eb3ed8" LabelOwner="[UIModel]9d7236c231a4412cb3c46bb2b395e0f0" Left="[float]16" Text="[string]Waveform" Top="[float]69" Width="[float]54" xmlns="http://www.ni.com/PanelCommon" />
-			<ScreenSurfaceCanvas Background="[SMSolidColorBrush]#80808080" BaseName="[string]Canvas" Height="[float]109" Id="4c70df2eda7f4028ab09f2f5161c11c3" Label="[UIModel]baf1504130a5409a8e3970f76111e2a8" Left="[float]16" Top="[float]318" Width="[float]235">
+			<ScreenSurfaceCanvas Background="[SMSolidColorBrush]#80808080" BaseName="[string]Canvas" Height="[float]78" Id="4c70df2eda7f4028ab09f2f5161c11c3" Label="[UIModel]baf1504130a5409a8e3970f76111e2a8" Left="[float]16" Top="[float]318" Width="[float]235">
 				<ChannelNumericText AdaptsToType="[bool]True" BaseName="[string]Numeric" Channel="[string]{782d1b4c-4bb0-4fee-b195-03544d32de7c}/Configuration/duration" Enabled="[bool]True" Height="[float]24" Id="c2b1de59a7c344f680a0f3d6811fa3ba" IsLabelBoundToChannel="[bool]False" Label="[UIModel]e4a9dee5b67f4a7898c643c0dfb2cc08" Left="[float]17" Top="[float]35" UnitAnnotation="[string]" ValueFormatter="[string]LV:G5" ValueType="[Type]Double" Width="[float]70" />
 				<Label Height="[float]16" Id="e4a9dee5b67f4a7898c643c0dfb2cc08" LabelOwner="[UIModel]c2b1de59a7c344f680a0f3d6811fa3ba" Left="[float]17" Text="[string]Duration (s)" Top="[float]15" Width="[float]62" xmlns="http://www.ni.com/PanelCommon" />
-				<ChannelCheckBox BaseName="[string]Checkbox" Channel="[string]{782d1b4c-4bb0-4fee-b195-03544d32de7c}/Configuration/abort_when_done" Content="[string]Abort when done?" Enabled="[bool]True" Height="[float]16" Id="8e59519e621246ae88f2641dc8848449" IsLabelBoundToChannel="[bool]False" Label="[UIModel]ec5edfa2cab3453495fa80b81400ff04" Left="[float]16" MinHeight="[float]16" MinWidth="[float]16" Top="[float]77" Width="[float]119" />
-				<Label Height="[float]0" Id="ec5edfa2cab3453495fa80b81400ff04" LabelOwner="[UIModel]8e59519e621246ae88f2641dc8848449" Left="[float]16" Text="[string]Abort generation" Top="[float]57" Visible="[bool]False" Width="[float]0" xmlns="http://www.ni.com/PanelCommon" />
 			</ScreenSurfaceCanvas>
 			<Label Height="[float]16" Id="baf1504130a5409a8e3970f76111e2a8" LabelOwner="[UIModel]4c70df2eda7f4028ab09f2f5161c11c3" Left="[float]16" Text="[string]Execution" Top="[float]298" Width="[float]51" xmlns="http://www.ni.com/PanelCommon" />
 			<ChannelPinSelector AllowUndefinedValues="[bool]True" BaseName="[string]Pin" Channel="[string]{782d1b4c-4bb0-4fee-b195-03544d32de7c}/Configuration/pin_name" DataType="[Type]String" Height="[float]24" Id="66db519df5724b6abe32b6cb766d6952" IsLabelBoundToChannel="[bool]False" Label="[UIModel]95d399ecd74544039046fa6b09fb64ce" Left="[float]17" SelectedResource="[NI_Core_DataValues_TagRefnum]Pin1" Top="[float]35" Width="[float]136" xmlns="http://www.ni.com/InstrumentFramework/ScreenDocument" />
-			<Label Height="[float]16" Id="95d399ecd74544039046fa6b09fb64ce" LabelOwner="[UIModel]66db519df5724b6abe32b6cb766d6952" Left="[float]17" Text="[string]Pin name" Top="[float]15" Width="[float]50" xmlns="http://www.ni.com/PanelCommon" />
+			<Label Height="[float]16" Id="95d399ecd74544039046fa6b09fb64ce" LabelOwner="[UIModel]66db519df5724b6abe32b6cb766d6952" Left="[float]17" Text="[string]Pin name" Top="[float]15" Width="[float]49" xmlns="http://www.ni.com/PanelCommon" />
 		</ScreenSurface>
 	</Screen>
 </SourceFile>

--- a/examples/nifgen_standard_function/NIFgenStandardFunction.seq
+++ b/examples/nifgen_standard_function/NIFgenStandardFunction.seq
@@ -1668,8 +1668,1727 @@
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='18'>
 			<NoneStepAdditions classname='NoneModule' isroottypedef='true' typecategory='3' timestamp='1650060850' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'/>
 		</typedef>
-		<protected>E@=3DJX4100hYLECF=cD@0@mKSEo_1KL_F1\27T`:Vj[VeF&lt;IHk9JiadX16MZ;_J&gt;IF\\oNI0P8K[eBRiD_OWonMbCH68W?Ej6HH^@m4QS@`K0=h9T1&lt;0PaQY&gt;ITBU1IX6C&lt;LBQCD:&lt;MGU&lt;8_B78S;jg^9]BlU;GU6Qh9gK_1OA4c=a7C2606Q79hL&lt;b9@R@T1?nR5o8`94_L;IIk`9T;ef25A8&lt;G;nd`9[5R`L5Y4lB&gt;]V;]cYlM6MI`;kP&gt;G:K\RIC9jI=XVM_0@b_eSQFjWW^&lt;m[H0i[Z5nV@kmeIO^:ij2V&gt;9cOfBSIN8ZAHJ9&lt;Gg[;oo\b3^&gt;JDf^__YgkgO1`m3cVA4nb^dfYLWn?2dd[4`AJPLd`Lk_L@oeMG41EECO^N8^2[n?jSnF9;5jDH9UjHf]A]JZhd\]T?GNDf60I=FF?f:dk?U^hJo[UODYBcBD[aXn_h0:md&lt;a_57k_OHj8&gt;fjYh=Ah?fGAS4NNaU^6CFj?gkOGdf@eI?&gt;;OUDUfIJo\^^Dc;&gt;S^XFZLGHAfj49EPKjoPEbibZUXDA0f6gak9YTnMlj8[nG\YQMJmSC7lE\njJ\NN[\ORnf[ZAQ]hjAHLT\G&lt;l_U&lt;NGnHLXe5nAeGcoojCKdEWeoYf:n&lt;3LW@8X</protected>
-		<protected>E@=3@Jc4110h]L]MGk_K3hBo3k7LAg`jl0V&gt;&gt;m4?ZlL]DC\B4kMO_J76J&gt;c7aKREM\6A6[;^;Tg=CRolUAjB8T7?mI]^IKR0;ACDh&lt;@LQBc3nn8=W=NlUh0CMdO`[l?&gt;@SDi1O@9&gt;iLlHgl8B]fLnYD=mM0g9lBlb_icfX`c\eIPPolgY:3`U:2o3ioLh\df_Oom@_KK;KmclQ]IIbRU_8V8P?KCh?9RiOISXRSH?]6hn;=69K517@W&lt;3?gSI`9BPRCWH6cPCllLL\S4Jg&gt;RhHI_j`_mnm]M]mMF`gP]bg158AF;ec]_YeffZgjID&lt;&gt;Dh?3YWM;bCg&gt;JQkkY[9i[=_2ZS9Fi]GVV?eLKJ_gjjMmmT\:K=ml9P&lt;VaPJnOfldhmmCoi6]f][e`dmbd:nmlAlcnCcoc;V7?Xl9co[&lt;^e_N?nN&lt;&gt;7LdgP3GoC3o&lt;eRW_AV7g377M5OoYmQ_nMkfRnobhaG\YFV&lt;RaUM&gt;GK4Ii_=N6O5Cf@M@0&gt;h=h2iC2WbVC]ihQd8AN4Z`lIhDRioVfM6WAB=?TBOi7NYT[T6gO1XjWhUm&gt;92emMI_OggJIkhGXbd0Wg&gt;XO&gt;cF&lt;Xbo1@BiMRkPJWk3SKm2RMg9Ea_W:IkMVM&gt;gXKgLW^5blEc[;D=Ri`O?a&gt;67^S[[o1IPDllk0J?^O_7oPmLlfigS\BAOV&lt;&gt;^[6GSoQ5io]iAoIP9Woj=WD&lt;N6d=^I]XFVkgFFNl&gt;N[nm]eJYPJ9f&lt;IC`N5Fa7G&lt;NT=RW_&lt;9`Y&lt;ZS6fLY&gt;:=B&gt;o3Ug:mP@?oki_L7VAldDHh^]:615VJ6[DFQ2h8llEj`VI:ia&gt;0H3G5&gt;Z@oT2DgO4j9b[]jEGd:^Z;kgSDT\jD2CC&gt;Lo:H=FEgA6Y1[dEIFF4CBGVFDEk;5_:m^A6C7^a2]M4mHU`RIlBiRTUNn&gt;QU=S0dW3@6l_d`dE:3fB0nlO;=^6_gh_o[KQDh`V9Ng4T`L:7Z]TjjcUhW4R21=Zj&lt;BQ:iP51CjhQ9o6MhV3XRfeb\m0=R&lt;CKDiECh:Z`iR&lt;QF;UaceY\R9WmUXZAb[g[C&lt;7fRGVY\AP=lWIG7QX8l:66fCP&lt;j2SIfbYGhg1hBONN^n_fejc]a&lt;oUdOC&lt;EZaK]4Ua3&lt;XfIBF7EYbZT&lt;eHo&gt;n[B_XCfB=1bTe3l2W=U9WMT\=9Um2GGUHno7?D_go5nnjjj^mOoe2[oIeKWo\Bk_&gt;ijL2LTMcWLb&lt;:V1_k7^9OC3OZb9SPnCkKDSf\3hLk5T=R&gt;bK8jRKIHH=[9CVSO5C[U7h[EWC=jH_e_fhZ11VI=V:i?;PGeRZY\SGcUW8E3cRbM62i&lt;=N?b=Qo9_fBXln1JNOR?7gTIJ9GZ&lt;4oT[KdJTk&lt;Q]85IS&gt;n];LSBEGAQYo[fOBeD&lt;X5A99g;W=B?ZZXHg5hBOkPYgffd9C&lt;@oZjJRLZ]G^do^[8KJo?knDI3Qh04D]LF811Dh3`ckD[b[ffib^5@d7j1gT;;D0GfR\D&gt;TCZo0[BhAXDb&gt;9I;[KUSO&lt;iJlT:2Dhc4[FELW`@BR08SdU;LQYMgBQPJFa:J[9aHX6^Q^0m=J30Y7lMdC\P6mgS8Y1iHA&lt;NU96Mc:7;nVC2b6jO3G]?:QFbbK9AIYE[O\=MP]92;L55c&lt;;HYe2jR0M]E`&gt;BY[hmgMXbQi?VOC8ZB5\_T1LA5aooNBY75hn7ZiGHD8en?dDc0ZE1iU3Vf6;l]Y8R@@GQEH6:G;diVjc2o]3Cj18cTXIj8:AIeNXAI@9AM@83JBFbDA6BRSMKJFcXn;kRO4Z`H&gt;2AG7:6NP9Ch=?i=9d:EfbUBW;4_f73NGfQE]NY[;7KcE&gt;D95X?KkXahKfImE;SXae?CUe=G;HRb`VZLULDdiAc]&lt;lWd:V7c\bVmbFD=:e2;fZ\B6CC7Y5gc^kXPSN9ZY0PZiT7YebS0V_i@DHGk6C1oUCDKGPZJGRI_i@41@\aATiYI;UK\e=JZKdZ\VfXUZTQM0eF8Q[Y&lt;MT&gt;UFdVJR_d9Xdg\38WJ&gt;Q[&gt;UN;F@;DF8LZQ@?&lt;dU@R[mf9D3:@SdI3&gt;SmhaSH=he6]&lt;V@`AJS?ZmSTEILjXABb9eH8X9`CR5Ef36[G4=mYiREKb5jiVREO5hN96Z\\P:`2^AQgg;TA?@NGIRd?YncGSE?a7?^BTP=W=NUG2lQlXEHB5aNo&gt;lYaF@g7FF?[]S;oQF8HLOnAW@;^[QnR[PFPfdfV:USJHVlG\LQXK&gt;[bHXFaEf03PK52BDdAA\QdM\Dn[[&lt;DR1IXY]X9hDf5D5XLnWmCNja&gt;3MLbTgTB46a\V23QQb&gt;3lGoSoee5lHJAJ\HLX\J=5n&lt;f?Q2KDnTFEB38in&lt;0V&gt;knN4J]Wb^H:niJ=n8A1@`l]aoLIX?GkKYdai=g_67QWQnFE:@g?:CmkXN4FDBZ`E&lt;=^]0C&lt;VkP]OT:@&gt;Y4Th&lt;V5L&lt;C3]``D\9\TD=RPXH@93VhJ1BXeO?666&lt;22Rbd:82&lt;Hj[UI&gt;5_P5;6d0Q1G:@24T&lt;23AjNLU1P7J1R7JNSlj0APNHRXU69R@@8_0P]gmF2;HXn\:jKVULTZDKTEVfYUf98YgXB[IDNjfTR&gt;iYQ`VU&gt;&gt;m:[&gt;lEU2:UmoJJ30kJfB?e4L[985bKYJIOLlNEPJ7a3J]@i4mgoAdh_AX6aJ\26QenfLe4CN6&gt;YDDK6K[::VOK9226oQ4L@SBi1OEb;@g;l`]jWiUTi0jignJ[[FBSfc?Gjn4XkVZn6K=7a=6e4K[fZ1;aXYGQbIFKmZ=h0@h]&gt;S2V;CM2h6JV`2&gt;Cla`73g?85Ol2TCU&lt;RiOmFV6HK=of2mS&gt;LYiK4gnhAemPOhP1UACUEc`_8[kadgB93FN`bnCeaQB_DLoJCll2nml1jcoUV&lt;l`1R\9Tf0jKOVFUeZ5X@_4@Tb[JYaI`4Go2mIQkgW:59&lt;ik8M&lt;`Gie4f[hhc3@HM=7Tj\TPcTfE;bZ]LF5`X&lt;[j[WeN`99Iaj6=B9h\o0fm&gt;mZYSe:\;=nOfR9o3XASO`SH8R5W0oHN[Bd3h]hoXR&lt;_1_LFiXjZFf[E@TcIOiQVldl?njP@&gt;h7hKl=7ibRdZM\H@XE6nC=8W6L4gd3hLW9CRL?b3nZk6Y&lt;N[7A]3iQVWhbHNFUD5n@HPocd;SWbOj=m:BS3;D=Fm1^?PBT76HUjHR]F@Sc[c66cI_MEk4^?UBT97PP:Cg3^Q8]8a&gt;KQO6Q2OA7HoR&gt;WHX&lt;a6&lt;9o&gt;J08&lt;&gt;V_j[c5ihH]7\5;UDHgdC7oeF38PS4gDP\R4cd]R:G@81EBI7O1:Y&gt;i_FAh&lt;jaaV\b3ZRZHS\^l[YBZ:J8aAYI?LF70YWW\YCjHj7S;W[JQjHFmYafMk0MRRSe&lt;i97R^o3m=eP9Q8g5Wl^;N`YVmJ50:bR`jT6Ya&lt;FKW@B4AaHcjCn0JjE]CWG@;o9V?\U;TVHEnljbH0GPZ:SQaD^b\jNikkAKS:46h\0ffLEVA8&lt;2eH=2II1[Sjj8lEAdQX7h[H4BcZlUo3DGWej1UM^W:`l7d^dTH6PjFaBPcd51l7C1gnQh\`EoHUT50&gt;i2XW8U3Hah3GQHC6bh0o86b;g4gFD45VR3H?HHdM&gt;Im\cXjfR&lt;hVZd44;@@`GO_U`Vk::2MUfQhDiRQ;iPPUD:5_UUAo^DcLAjaG4dkQL@2_Q&lt;h6[eU\MV\::l2ljQKIBMnB]8&lt;3m8&lt;m=?&lt;9^_5iF\5Len;[WkHdP_foaY41M\jhA3?3\BWUGj&gt;:i9[&gt;?QUMY3&lt;XKKFLF&lt;[82956A8ZhQUR&lt;ifQ4bI5O@&lt;6b=3aOB`]eEJBSGF]Ccd=KK@36N\b_e5YF0^AT2=ma121V[cn99]G170DNCBY=@5?ea=54J&gt;[H1X5^GP;_Y&lt;B5&gt;GZ5e]96ZCg05R^@icDGg\iVA9iZRA:lXQEf@QZNX=FDP=ifEHe0CMBll6&lt;Z2=h[dClahh4R=SSSoDAe]2\[1HZVSecL6EFTbB8J[cGDH9elQ54S1FUQ;e2BSBci;ebWGVW?\7mW]7i[?BEnddfLUmOJcjFNcjfLehW\mUg^kF&gt;\bHE;1_2Q^4KECFhHNc1mYP3`&lt;N2ig^b9\j769f[28=4aQTLlFl=D3E6b\=_R=_^N5HTb&lt;J3=S;Y5HV:3F6i1nlc1CFk9[[cYl[&gt;F9?mbR@m\l1i5Q6l6O1dg?&lt;5Wg1::\dF9`TOGWHCRkD==]bV15k2RY8i`bV1oU\1]Fdf52TbkSJhEPVBLF[\d;\OjXn1IXockKoCf=nna;n5=_o1K^MYgSDlRO:U`?4BDZ;RDXkKjV]=j=`dYmJ4&lt;o\b?C8`Loi;5_7eKOmNoFA]?kioKmZXP&gt;?@OMEE_[\ImYeAE:HTO\;X:I0W;fe\U_o9GfQbgk`mFX[@m\g=ZKIG]]hfbgNkIK_F:ZQ?OkfIKJH[O\ihZROIOIcS5I`m3fEdU3JG6A=:kdY1=WiE;WhIW;]n:PVFmjf06cG\l1`6GZDU]dG;J:JZK=EVA5C\d;I6chmfOn&lt;d;nFMPO5^Hg&lt;L@nGR@8@^OaX`?HgXF45nR@=[d@j3WgS?HDOeV\neeEn:neZ__gQ?HH:]`?;H\g3A3IWiAkY61me30_i2CL7=YO9``_6H@l`\K6`f=3jk61Nm3P76;kY61ma3PKl&lt;\K&lt;6f=:36;Om30TnQP7P_O9``_7HXdWTm3\PB7`f=3kk61@6f^`\K6QJ1oK9dOfNi[Za=PUgoQj_leOgNBNl]MPgY9NkW]^mcf4\E?G5[_[lE?DejcgMO`g&gt;Kk^616]eWdeiIkm&gt;JcjFNcffLenBFN]cfLWF[]?i=6Tb_Hk8oNT`_HL\Hg:&lt;Zjkc5O5`PnoSRYPk45U=43e7hlMjHLfTJgVAlMNMTccCnHmI^daiKn@fkkVM^gI\b&lt;?_jXmN1eOhYLPmJ&gt;M^&gt;oMma73eUoMibZ_HoigZh[@l`^4b6?J&gt;hXQTlmM:olW5oOoV2WR9o?\?gk]RD^T;;]9BhfQZd;[A\YK;^B@\JN_W@E&gt;DjHeU]8oW3KU:g9kM64IUIh\V0k:FjnUXXH99l?I3gCA&lt;E`&lt;d=lA&lt;aYVa?YdS&lt;ZVl8AgkXP&lt;g:LJ69WLX^RR2;XTfCXag6Q7g@OooCHP=4l5n]G4?JU?0W&gt;h8[cQdWULnLZ;&gt;L4aHackI&lt;]JSiCNVXMlEP^la7T[f&lt;L13cd_mD7c?U&gt;ZFnG25NQ=BkES`Y&gt;ZZN^7;UD;k0C\T]]&lt;YV5`0o2b&lt;aYA7TbS5h;O3^lR@GRe:Em3lHjmgdJPNU`D6WSSah^_3@e_SHa8W8l[3dGOY_AaF7O&gt;MiSJBLBFDO:@BmBXEejGeI1O_DOLK^ToPOSBRN?nRN=0RX@l`EX@1VmeJ`^fnRDZXebH7SJGiJ`:15Q=k=]_im&gt;mn&gt;^RW=o6f5gSC^fO8@2=LR853\TP0cBJ0&lt;de@5j`0RQTV858WBST9H@QA9n@86MZBQ6Ad13dPT=h14d6A2bfi:&lt;&gt;;B3749M@iQ@@8;3STP;5So&lt;B1o2AQ21EmdA5nP0?62fmX3j&lt;D=1U0iZdPh4a=R1`_H0AgTj==2eAZPe=4b;c`ieQPiB1NR0P&gt;9FM7B&gt;1`274Ol3djf`lT6&lt;@]32L]TH1KChT=lZ431e4JhJ=IH1[0RA?0@86Yb`7I34V&lt;X]=GST0&lt;Qb&lt;2204`6O2CSPa9SQ4d1`dbVEE2OdAA_ZcBlFSU6&lt;45X==0LB&lt;7G2K`0@1\j02FU6A54O6a0^484FePE&lt;PPZ0B5f`I_8=:a4UX08DBC`:0I&gt;5Y6PXTP?Tb6&lt;7&gt;iA6YK8m4CV6n@6GY8XaPXBCJ090QP86VR6@GD2im]]fK[o35kiI_jf256S&lt;LdQUL:jlXXT6VN4;8;8RAI=0]R5K27fRR=HAP&lt;C08W2mm1g;2gD6Yd4QR4fSF?J_@C;SQ^mbbESk@OG9^I^gWgKK&lt;TF307_jkMm&gt;effE\hRcYJ]ACT&gt;?5_48RjZ2SPIa]6;FATF:&gt;]l=e1A=kPDV1J&gt;XP2kPlj7bZQ`[OXW0D\3&lt;QV=\T:]H8Ol4OS60Fa;m[CF:K3FRicE6C7[URWZU37Z[ZLUDI\PXH_FEJ2377WUW6V=&gt;F&lt;ZL8QBLPDdh0S9OAC1?@6JNZ:\a`USk;:iJ7Y8YZ]eVAWO[1LeCTMhd=n\HC;6Y7A7YF]eZ[3=6AWJEb7IE3WI=D_cFAYLhFdAbc5XJlQEnU[HgHKICM3o`]RF6]l`8;RhCRXh82Xn30845648B0JPBI[DH\S4J6U&lt;n6e:\FAR=6B[DIHSTl30XLA0QLhnd98Rg9nlU^&gt;9@3S29`leT&lt;IdI0If722n82&gt;;U`ahOEilDL:G\FRN\l=:jFTDi2TfN7EImHQJoJZlS]BD]oXOciWB4FmFfZ6dO\b&gt;Y=B4P5EAD1_iFlNJASLe7^9b&gt;@:`]PUjTToY]c8BF2V4`[`X11aBL2&lt;?9IARQ&lt;4cK[71AX4oXQ@_2h@;hmf90BM0De;:]6?]5@@Y`7&gt;V=UL5`PILYECZTYJ@=IfdV0bIPTf6djDZ8UJTch2Oh;;L8_HSlXn?Yfb5T&gt;GYNN59aJ8WV9I]c[K:AW]H[75m20L4ZgfDn&gt;&lt;gf62HQIJ6oT[K&gt;m:CfFl=&gt;9o;LiNS`PF\OV9ScUJCJ?Q5VlfM`5m`CNGh2;0K3Nh[eX_QFNh[5;Y\Wc]f2Q:akThimldSm_\_Pdm]583E;C\:FoP\8Ln=ZTXZ`i\;4F?f7f9&gt;oc1MhiR:D5YmQj3eLH:Tc3ce&gt;Vc4fDDRX]a5jA=bKK&lt;Cc\Mo7ceD&gt;`e</protected>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='19'>
+			<NI_MeasurementParameter classname='Obj' isroottypedef='true' typecategory='2' timestamp='1669042099' typeversion='21.0.5.4' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0'>
+				<subprops>
+					<Name classname='Str'>
+						<value/>
+					</Name>
+					<ArgumentValue typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</ArgumentValue>
+					<Direction classname='Str'>
+						<value/>
+					</Direction>
+					<Log classname='Bool'>
+						<value>false</value>
+					</Log>
+					<Dimension classname='Num'>
+						<value representation='UInt64'>0</value>
+					</Dimension>
+					<Type classname='Str'>
+						<value/>
+					</Type>
+					<ID classname='Num'>
+						<value representation='Int64'>0</value>
+					</ID>
+					<TypeSpecialization classname='Str'>
+						<value/>
+					</TypeSpecialization>
+				</subprops>
+			</NI_MeasurementParameter>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='20'>
+			<NI_Measurement classname='StepType' isroottypedef='true' typecategory='1' timestamp='1670875325' typeversion='21.0.5.8' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='2'>
+				<subprops>
+					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
+						<value>ResStr("MEASUREMENT_STEP_TYPE", "MEASUREMENT_DESCRIPTION_NAME")</value>
+					</DescriptionFormat>
+					<DefaultNameFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
+						<value>ResStr("MEASUREMENT_STEP_TYPE", "MEASUREMENT_DEF_STEP_NAME")</value>
+					</DefaultNameFormat>
+					<BlockStartTypes classname='Str' valueflags='4194328' structureflags='524288'>
+						<value/>
+					</BlockStartTypes>
+					<BlockEndTypes classname='Str' valueflags='4194328' structureflags='524288'>
+						<value/>
+					</BlockEndTypes>
+					<AppliesToBlockStructure classname='Bool' valueflags='4194328' structureflags='524288'>
+						<value>false</value>
+					</AppliesToBlockStructure>
+					<Menu typename='StepTypeMenu' xsi:type='StepTypeMenu' classname='Obj'>
+						<subprops>
+							<CanBeSubstepType classname='Bool'>
+								<value>false</value>
+							</CanBeSubstepType>
+							<CanOnlyBeSubstepType classname='Bool'>
+								<value>false</value>
+							</CanOnlyBeSubstepType>
+							<Category classname='Str'>
+								<value>""</value>
+							</Category>
+							<ItemName classname='ExprValue'>
+								<value>ResStr("MEASUREMENT_STEP_TYPE","MEASUREMENT_INSERT_MENU_ITEM_NAME")</value>
+							</ItemName>
+							<SingularItemName classname='Str'>
+								<value>""</value>
+							</SingularItemName>
+							<SeparatorBeforeCategory classname='Bool'>
+								<value>false</value>
+							</SeparatorBeforeCategory>
+							<SeparatorBeforeItemName classname='Bool'>
+								<value>false</value>
+							</SeparatorBeforeItemName>
+							<Group classname='Str'>
+								<value/>
+							</Group>
+						</subprops>
+					</Menu>
+					<Substeps typename='StepTypeSubstepsArray' xsi:type='StepTypeSubstepsArray' classname='Objs'>
+						<value lbound='[0]' ubound='[1]'>
+							<value>
+								<Step typename='Substep' xsi:type='Substep' name='OnNewStep'>
+									<subprops>
+										<TS classname='Obj'>
+											<subprops>
+												<Id classname='Str'>
+													<value>ID#:j5wyx+k17RGnWgDgQ7lGAD</value>
+												</Id>
+												<Icon classname='Str'>
+													<value/>
+												</Icon>
+												<SData typename='DotNetStepAdditions' xsi:type='DotNetStepAdditions' classname='DotNetModule' structureflags='2097152'>
+													<subprops>
+														<Calls classname='Objs'>
+															<value lbound='[0]' ubound='[1]'>
+																<elemproto>
+																	<_NAME_IN_ATTRIBUTE_ name='' classname='DotNetCall' structureflags='0'/>
+																</elemproto>
+																<value>
+																	<DotNetCall typename='DotNetCall' xsi:type='DotNetCall' name=''>
+																		<subprops>
+																			<ClassName classname='Str'>
+																				<value>NationalInstruments.MeasurementLink.NewStepHandler</value>
+																			</ClassName>
+																			<MemberType classname='Num'>
+																				<value>4</value>
+																			</MemberType>
+																			<Static classname='Bool'>
+																				<value>false</value>
+																			</Static>
+																			<MemberName classname='Str'>
+																				<value>NewStepHandler</value>
+																			</MemberName>
+																			<Params classname='Objs'>
+																				<value lbound='[0]' ubound='[0]'>
+																					<elemproto>
+																						<_NAME_IN_ATTRIBUTE_ name='' classname='DotNetParameter' structureflags='0'/>
+																					</elemproto>
+																					<value>
+																						<DotNetParameter typename='DotNetParameter' xsi:type='DotNetParameter' name=''>
+																							<subprops>
+																								<Name classname='Str'>
+																									<value>Return Value</value>
+																								</Name>
+																								<ArgVal classname='ExprValue'>
+																									<value/>
+																								</ArgVal>
+																								<ArgDisplayVal classname='ExprValue'>
+																									<value/>
+																								</ArgDisplayVal>
+																								<Type classname='Num'>
+																									<value>0</value>
+																								</Type>
+																								<TypeName classname='Str'>
+																									<value>NationalInstruments.MeasurementLink.NewStepHandler</value>
+																								</TypeName>
+																								<Flags classname='Num'>
+																									<value>6</value>
+																								</Flags>
+																								<IsOptional classname='Bool'>
+																									<value>false</value>
+																								</IsOptional>
+																								<CallDispose classname='Bool'>
+																									<value>true</value>
+																								</CallDispose>
+																								<NumDimensions classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</NumDimensions>
+																								<MultiElement classname='Objs'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</MultiElement>
+																								<AdditionalResults classname='Obj'>
+																									<subprops>
+																										<Input classname='DotNetParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
+																													<value>1</value>
+																												</CheckedState>
+																											</subprops>
+																										</Input>
+																										<Output classname='DotNetParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
+																													<value>1</value>
+																												</CheckedState>
+																											</subprops>
+																										</Output>
+																									</subprops>
+																								</AdditionalResults>
+																							</subprops>
+																						</DotNetParameter>
+																					</value>
+																				</value>
+																			</Params>
+																			<AdditionalResult classname='DotNetCallResult'>
+																				<subprops>
+																					<Condition classname='ExprValue'>
+																						<value/>
+																					</Condition>
+																					<Flags classname='Num'>
+																						<value>8192</value>
+																					</Flags>
+																					<CheckedState classname='Num'>
+																						<value>1</value>
+																					</CheckedState>
+																				</subprops>
+																			</AdditionalResult>
+																		</subprops>
+																	</DotNetCall>
+																</value>
+																<value>
+																	<DotNetCall typename='DotNetCall' xsi:type='DotNetCall' name=''>
+																		<subprops>
+																			<ClassName classname='Str'>
+																				<value>NationalInstruments.MeasurementLink.NewStepHandler</value>
+																			</ClassName>
+																			<MemberType classname='Num'>
+																				<value>1</value>
+																			</MemberType>
+																			<Static classname='Bool'>
+																				<value>false</value>
+																			</Static>
+																			<MemberName classname='Str'>
+																				<value>OnNewStep</value>
+																			</MemberName>
+																			<Params classname='Objs'>
+																				<value lbound='[0]' ubound='[0]'>
+																					<elemproto>
+																						<_NAME_IN_ATTRIBUTE_ name='' classname='DotNetParameter' structureflags='0'/>
+																					</elemproto>
+																					<value>
+																						<DotNetParameter typename='DotNetParameter' xsi:type='DotNetParameter' name=''>
+																							<subprops>
+																								<Name classname='Str'>
+																									<value>sequenceContext</value>
+																								</Name>
+																								<ArgVal classname='ExprValue'>
+																									<value>ThisContext</value>
+																								</ArgVal>
+																								<ArgDisplayVal classname='ExprValue'>
+																									<value/>
+																								</ArgDisplayVal>
+																								<Type classname='Num'>
+																									<value>0</value>
+																								</Type>
+																								<TypeName classname='Str'>
+																									<value>NationalInstruments.TestStand.Interop.API.SequenceContext</value>
+																								</TypeName>
+																								<Flags classname='Num'>
+																									<value>0</value>
+																								</Flags>
+																								<IsOptional classname='Bool'>
+																									<value>false</value>
+																								</IsOptional>
+																								<CallDispose classname='Bool'>
+																									<value>false</value>
+																								</CallDispose>
+																								<NumDimensions classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</NumDimensions>
+																								<MultiElement classname='Objs'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</MultiElement>
+																								<AdditionalResults classname='Obj'>
+																									<subprops>
+																										<Input classname='DotNetParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
+																													<value>1</value>
+																												</CheckedState>
+																											</subprops>
+																										</Input>
+																										<Output classname='DotNetParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
+																													<value>1</value>
+																												</CheckedState>
+																											</subprops>
+																										</Output>
+																									</subprops>
+																								</AdditionalResults>
+																							</subprops>
+																						</DotNetParameter>
+																					</value>
+																				</value>
+																			</Params>
+																			<AdditionalResult classname='DotNetCallResult'>
+																				<subprops>
+																					<Condition classname='ExprValue'>
+																						<value/>
+																					</Condition>
+																					<Flags classname='Num'>
+																						<value>8192</value>
+																					</Flags>
+																					<CheckedState classname='Num'>
+																						<value>1</value>
+																					</CheckedState>
+																				</subprops>
+																			</AdditionalResult>
+																		</subprops>
+																	</DotNetCall>
+																</value>
+															</value>
+														</Calls>
+														<AssemblyPath classname='PathValue'>
+															<value>NationalInstruments.MeasurementLink.TestStandMeasurementClient.dll</value>
+														</AssemblyPath>
+														<AssemblyStrongName classname='Str'>
+															<value/>
+														</AssemblyStrongName>
+														<AssemblyLocation classname='Num'>
+															<value>0</value>
+														</AssemblyLocation>
+														<ClassName classname='Str'>
+															<value>NationalInstruments.MeasurementLink.NewStepHandler</value>
+														</ClassName>
+														<IsStruct classname='Bool'>
+															<value>false</value>
+														</IsStruct>
+														<StructDef classname='DotNetParameter'>
+															<subprops>
+																<Name classname='Str'>
+																	<value>_notNamed</value>
+																</Name>
+																<ArgVal classname='ExprValue'>
+																	<value/>
+																</ArgVal>
+																<ArgDisplayVal classname='ExprValue'>
+																	<value/>
+																</ArgDisplayVal>
+																<Type classname='Num'>
+																	<value>0</value>
+																</Type>
+																<TypeName classname='Str'>
+																	<value/>
+																</TypeName>
+																<Flags classname='Num'>
+																	<value>0</value>
+																</Flags>
+																<IsOptional classname='Bool'>
+																	<value>false</value>
+																</IsOptional>
+																<CallDispose classname='Bool'>
+																	<value>false</value>
+																</CallDispose>
+																<NumDimensions classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</NumDimensions>
+																<MultiElement classname='Objs'>
+																	<value lbound='[0]' ubound='[]'/>
+																</MultiElement>
+																<AdditionalResults classname='Obj'>
+																	<subprops>
+																		<Input classname='DotNetParameterResult'>
+																			<subprops>
+																				<Condition classname='ExprValue'>
+																					<value/>
+																				</Condition>
+																				<Flags classname='Num'>
+																					<value>8192</value>
+																				</Flags>
+																				<CheckedState classname='Num'>
+																					<value>1</value>
+																				</CheckedState>
+																			</subprops>
+																		</Input>
+																		<Output classname='DotNetParameterResult'>
+																			<subprops>
+																				<Condition classname='ExprValue'>
+																					<value/>
+																				</Condition>
+																				<Flags classname='Num'>
+																					<value>8192</value>
+																				</Flags>
+																				<CheckedState classname='Num'>
+																					<value>1</value>
+																				</CheckedState>
+																			</subprops>
+																		</Output>
+																	</subprops>
+																</AdditionalResults>
+															</subprops>
+														</StructDef>
+														<RemoteSpecifiedByExpr classname='Bool'>
+															<value>false</value>
+														</RemoteSpecifiedByExpr>
+														<UseLoadSpec classname='Bool'>
+															<value>false</value>
+														</UseLoadSpec>
+														<ModuleSrcPath classname='PathValue'>
+															<value/>
+														</ModuleSrcPath>
+														<ModulePrjPath classname='PathValue'>
+															<value/>
+														</ModulePrjPath>
+														<ModuleSlnPath classname='PathValue'>
+															<value/>
+														</ModuleSlnPath>
+														<FunctionName classname='Str'>
+															<value/>
+														</FunctionName>
+													</subprops>
+												</SData>
+												<PreCond classname='ExprValue'>
+													<value/>
+												</PreCond>
+												<LoadOpt classname='Str'>
+													<value>PreloadWhenExecuted</value>
+												</LoadOpt>
+												<UnloadOpt classname='Str'>
+													<value>UnloadWithFile</value>
+												</UnloadOpt>
+												<Mode classname='Str'>
+													<value>Normal</value>
+												</Mode>
+												<WindowActivation classname='Str'>
+													<value>None</value>
+												</WindowActivation>
+												<ResultOption classname='Num'>
+													<value>1</value>
+												</ResultOption>
+												<StepFCSeqF classname='Bool'>
+													<value>true</value>
+												</StepFCSeqF>
+												<IgnoreRTE classname='Bool'>
+													<value>false</value>
+												</IgnoreRTE>
+												<UseMutex classname='Bool'>
+													<value>false</value>
+												</UseMutex>
+												<MutexNameOrRef classname='ExprValue'>
+													<value/>
+												</MutexNameOrRef>
+												<BatchSyncOpt classname='Num'>
+													<value>0</value>
+												</BatchSyncOpt>
+												<SwitchEnabled classname='Bool'>
+													<value>false</value>
+												</SwitchEnabled>
+												<VirtualDeviceName classname='ExprValue'>
+													<value/>
+												</VirtualDeviceName>
+												<SwitchOperation classname='Num'>
+													<value>1</value>
+												</SwitchOperation>
+												<RouteGroupConnect classname='ExprValue'>
+													<value/>
+												</RouteGroupConnect>
+												<RouteGroupDisconnect classname='ExprValue'>
+													<value/>
+												</RouteGroupDisconnect>
+												<MulticonnectMode classname='Num'>
+													<value>1</value>
+												</MulticonnectMode>
+												<OperationOrder classname='Num'>
+													<value>2</value>
+												</OperationOrder>
+												<ConnectionLifetime classname='Num'>
+													<value>4</value>
+												</ConnectionLifetime>
+												<WaitForDebounce classname='Bool'>
+													<value>true</value>
+												</WaitForDebounce>
+												<PassAct classname='Str'>
+													<value>Next</value>
+												</PassAct>
+												<FailAct classname='Str'>
+													<value>Next</value>
+												</FailAct>
+												<PassActTarget classname='ExprValue'>
+													<value/>
+												</PassActTarget>
+												<FailActTarget classname='ExprValue'>
+													<value/>
+												</FailActTarget>
+												<CustExpr classname='ExprValue'>
+													<value/>
+												</CustExpr>
+												<CustTrueAct classname='Str'>
+													<value>Next</value>
+												</CustTrueAct>
+												<CustFalseAct classname='Str'>
+													<value>Next</value>
+												</CustFalseAct>
+												<CustTrueActTarget classname='ExprValue'>
+													<value/>
+												</CustTrueActTarget>
+												<CustFalseActTarget classname='ExprValue'>
+													<value/>
+												</CustFalseActTarget>
+												<LoopType classname='Str'>
+													<value>NoLooping</value>
+												</LoopType>
+												<LoopWhile classname='ExprValue'>
+													<value/>
+												</LoopWhile>
+												<LoopStatus classname='ExprValue'>
+													<value/>
+												</LoopStatus>
+												<LoopIncrement classname='ExprValue'>
+													<value>RunState.LoopIndex += 1</value>
+												</LoopIncrement>
+												<LoopInitialize classname='ExprValue'>
+													<value>RunState.LoopIndex = 0</value>
+												</LoopInitialize>
+												<LoopOpt classname='Num'>
+													<value>0</value>
+												</LoopOpt>
+												<PreExpr classname='ExprValue'>
+													<value/>
+												</PreExpr>
+												<PostExpr classname='ExprValue'>
+													<value/>
+												</PostExpr>
+												<StatusExpr classname='ExprValue'>
+													<value/>
+												</StatusExpr>
+												<CanSpecifyModule classname='Bool'>
+													<value>true</value>
+												</CanSpecifyModule>
+												<CanEditCode classname='Bool'>
+													<value>true</value>
+												</CanEditCode>
+												<CanEditModulePrototype classname='Bool'>
+													<value>true</value>
+												</CanEditModulePrototype>
+												<CanEditParameterAdditionalResults classname='Bool'>
+													<value>true</value>
+												</CanEditParameterAdditionalResults>
+												<PrecondIntExe classname='Num'>
+													<value>0</value>
+												</PrecondIntExe>
+												<CustomResults classname='Objs'>
+													<value lbound='[0]' ubound='[]'>
+														<elemproto>
+															<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+																<subprops>
+																	<Name classname='ExprValue'>
+																		<value/>
+																	</Name>
+																	<ValueToLog classname='ExprValue'>
+																		<value/>
+																	</ValueToLog>
+																	<Condition classname='ExprValue'>
+																		<value/>
+																	</Condition>
+																	<Flags classname='Num'>
+																		<value>8192</value>
+																	</Flags>
+																	<CheckedState classname='Num'>
+																		<value>2</value>
+																	</CheckedState>
+																	<Type classname='PropertyObjectType'>
+																		<subprops>
+																			<ValueType classname='Num'>
+																				<value>3</value>
+																			</ValueType>
+																			<IsObject classname='Bool'>
+																				<value>true</value>
+																			</IsObject>
+																			<TypeName classname='Str'>
+																				<value/>
+																			</TypeName>
+																			<ElementType classname='Objs'>
+																				<value lbound='[0]' ubound='[]'/>
+																			</ElementType>
+																			<ArrayDimensions classname='ArrayDimensions'>
+																				<subprops>
+																					<LowerBounds classname='Nums'>
+																						<value lbound='[0]' ubound='[]'/>
+																					</LowerBounds>
+																					<UpperBounds classname='Nums'>
+																						<value lbound='[0]' ubound='[]'/>
+																					</UpperBounds>
+																				</subprops>
+																			</ArrayDimensions>
+																			<Representation classname='Num'>
+																				<value>1</value>
+																			</Representation>
+																			<ClassName classname='Str'>
+																				<value/>
+																			</ClassName>
+																		</subprops>
+																	</Type>
+																	<Elements classname='Objs'>
+																		<value lbound='[0]' ubound='[]'/>
+																	</Elements>
+																	<IsAnyType classname='Bool'>
+																		<value>true</value>
+																	</IsAnyType>
+																</subprops>
+															</_NAME_IN_ATTRIBUTE_>
+														</elemproto>
+													</value>
+												</CustomResults>
+												<AdditionalResultsHints classname='Objs'>
+													<value lbound='[0]' ubound='[]'>
+														<elemproto>
+															<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+																<subprops>
+																	<Name classname='ExprValue'>
+																		<value/>
+																	</Name>
+																	<ValueToLog classname='ExprValue'>
+																		<value/>
+																	</ValueToLog>
+																	<Condition classname='ExprValue'>
+																		<value/>
+																	</Condition>
+																	<Flags classname='Num'>
+																		<value>8192</value>
+																	</Flags>
+																	<CheckedState classname='Num'>
+																		<value>2</value>
+																	</CheckedState>
+																	<Type classname='PropertyObjectType'>
+																		<subprops>
+																			<ValueType classname='Num'>
+																				<value>3</value>
+																			</ValueType>
+																			<IsObject classname='Bool'>
+																				<value>true</value>
+																			</IsObject>
+																			<TypeName classname='Str'>
+																				<value/>
+																			</TypeName>
+																			<ElementType classname='Objs'>
+																				<value lbound='[0]' ubound='[]'/>
+																			</ElementType>
+																			<ArrayDimensions classname='ArrayDimensions'>
+																				<subprops>
+																					<LowerBounds classname='Nums'>
+																						<value lbound='[0]' ubound='[]'/>
+																					</LowerBounds>
+																					<UpperBounds classname='Nums'>
+																						<value lbound='[0]' ubound='[]'/>
+																					</UpperBounds>
+																				</subprops>
+																			</ArrayDimensions>
+																			<Representation classname='Num'>
+																				<value>1</value>
+																			</Representation>
+																			<ClassName classname='Str'>
+																				<value/>
+																			</ClassName>
+																		</subprops>
+																	</Type>
+																	<Elements classname='Objs'>
+																		<value lbound='[0]' ubound='[]'/>
+																	</Elements>
+																	<IsAnyType classname='Bool'>
+																		<value>true</value>
+																	</IsAnyType>
+																</subprops>
+															</_NAME_IN_ATTRIBUTE_>
+														</elemproto>
+													</value>
+												</AdditionalResultsHints>
+											</subprops>
+										</TS>
+										<Result classname='Obj'>
+											<subprops>
+												<Error classname='Obj'>
+													<subprops>
+														<Code classname='Num'>
+															<value>0</value>
+														</Code>
+														<Msg classname='Str'>
+															<value/>
+														</Msg>
+														<Occurred classname='Bool'>
+															<value>false</value>
+														</Occurred>
+													</subprops>
+												</Error>
+												<Status classname='Str'>
+													<value/>
+												</Status>
+												<ReportText classname='Str'>
+													<value/>
+												</ReportText>
+												<Common classname='Obj'/>
+											</subprops>
+										</Result>
+									</subprops>
+								</Step>
+							</value>
+							<value>
+								<Step typename='PostSubstep' xsi:type='PostSubstep' name='Post'>
+									<subprops>
+										<TS classname='Obj'>
+											<subprops>
+												<Id classname='Str'>
+													<value>ID#:MS2zjF1W7BGpWXoj8F8wtC</value>
+												</Id>
+												<Icon classname='Str'>
+													<value/>
+												</Icon>
+												<SData typename='DotNetStepAdditions' xsi:type='DotNetStepAdditions' classname='DotNetModule' structureflags='2097152'>
+													<subprops>
+														<Calls classname='Objs'>
+															<value lbound='[0]' ubound='[1]'>
+																<elemproto>
+																	<_NAME_IN_ATTRIBUTE_ name='' classname='DotNetCall' structureflags='0'/>
+																</elemproto>
+																<value>
+																	<DotNetCall typename='DotNetCall' xsi:type='DotNetCall' name=''>
+																		<subprops>
+																			<ClassName classname='Str'>
+																				<value>NationalInstruments.MeasurementLink.MeasurementStepExecution</value>
+																			</ClassName>
+																			<MemberType classname='Num'>
+																				<value>4</value>
+																			</MemberType>
+																			<Static classname='Bool'>
+																				<value>false</value>
+																			</Static>
+																			<MemberName classname='Str'>
+																				<value>MeasurementStepExecution</value>
+																			</MemberName>
+																			<Params classname='Objs'>
+																				<value lbound='[0]' ubound='[0]'>
+																					<elemproto>
+																						<_NAME_IN_ATTRIBUTE_ name='' classname='DotNetParameter' structureflags='0'/>
+																					</elemproto>
+																					<value>
+																						<DotNetParameter typename='DotNetParameter' xsi:type='DotNetParameter' name=''>
+																							<subprops>
+																								<Name classname='Str'>
+																									<value>Return Value</value>
+																								</Name>
+																								<ArgVal classname='ExprValue'>
+																									<value/>
+																								</ArgVal>
+																								<ArgDisplayVal classname='ExprValue'>
+																									<value/>
+																								</ArgDisplayVal>
+																								<Type classname='Num'>
+																									<value>0</value>
+																								</Type>
+																								<TypeName classname='Str'>
+																									<value>NationalInstruments.MeasurementLink.MeasurementStepExecution</value>
+																								</TypeName>
+																								<Flags classname='Num'>
+																									<value>6</value>
+																								</Flags>
+																								<IsOptional classname='Bool'>
+																									<value>false</value>
+																								</IsOptional>
+																								<CallDispose classname='Bool'>
+																									<value>true</value>
+																								</CallDispose>
+																								<NumDimensions classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</NumDimensions>
+																								<MultiElement classname='Objs'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</MultiElement>
+																								<AdditionalResults classname='Obj'>
+																									<subprops>
+																										<Input classname='DotNetParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
+																													<value>1</value>
+																												</CheckedState>
+																											</subprops>
+																										</Input>
+																										<Output classname='DotNetParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
+																													<value>1</value>
+																												</CheckedState>
+																											</subprops>
+																										</Output>
+																									</subprops>
+																								</AdditionalResults>
+																							</subprops>
+																						</DotNetParameter>
+																					</value>
+																				</value>
+																			</Params>
+																			<AdditionalResult classname='DotNetCallResult'>
+																				<subprops>
+																					<Condition classname='ExprValue'>
+																						<value/>
+																					</Condition>
+																					<Flags classname='Num'>
+																						<value>8192</value>
+																					</Flags>
+																					<CheckedState classname='Num'>
+																						<value>1</value>
+																					</CheckedState>
+																				</subprops>
+																			</AdditionalResult>
+																		</subprops>
+																	</DotNetCall>
+																</value>
+																<value>
+																	<DotNetCall typename='DotNetCall' xsi:type='DotNetCall' name=''>
+																		<subprops>
+																			<ClassName classname='Str'>
+																				<value>NationalInstruments.MeasurementLink.MeasurementStepExecution</value>
+																			</ClassName>
+																			<MemberType classname='Num'>
+																				<value>1</value>
+																			</MemberType>
+																			<Static classname='Bool'>
+																				<value>false</value>
+																			</Static>
+																			<MemberName classname='Str'>
+																				<value>Execute</value>
+																			</MemberName>
+																			<Params classname='Objs'>
+																				<value lbound='[0]' ubound='[0]'>
+																					<elemproto>
+																						<_NAME_IN_ATTRIBUTE_ name='' classname='DotNetParameter' structureflags='0'/>
+																					</elemproto>
+																					<value>
+																						<DotNetParameter typename='DotNetParameter' xsi:type='DotNetParameter' name=''>
+																							<subprops>
+																								<Name classname='Str'>
+																									<value>sequenceContext</value>
+																								</Name>
+																								<ArgVal classname='ExprValue'>
+																									<value>ThisContext</value>
+																								</ArgVal>
+																								<ArgDisplayVal classname='ExprValue'>
+																									<value/>
+																								</ArgDisplayVal>
+																								<Type classname='Num'>
+																									<value>0</value>
+																								</Type>
+																								<TypeName classname='Str'>
+																									<value>NationalInstruments.TestStand.Interop.API.SequenceContext</value>
+																								</TypeName>
+																								<Flags classname='Num'>
+																									<value>0</value>
+																								</Flags>
+																								<IsOptional classname='Bool'>
+																									<value>false</value>
+																								</IsOptional>
+																								<CallDispose classname='Bool'>
+																									<value>false</value>
+																								</CallDispose>
+																								<NumDimensions classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</NumDimensions>
+																								<MultiElement classname='Objs'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</MultiElement>
+																								<AdditionalResults classname='Obj'>
+																									<subprops>
+																										<Input classname='DotNetParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
+																													<value>1</value>
+																												</CheckedState>
+																											</subprops>
+																										</Input>
+																										<Output classname='DotNetParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
+																													<value>1</value>
+																												</CheckedState>
+																											</subprops>
+																										</Output>
+																									</subprops>
+																								</AdditionalResults>
+																							</subprops>
+																						</DotNetParameter>
+																					</value>
+																				</value>
+																			</Params>
+																			<AdditionalResult classname='DotNetCallResult'>
+																				<subprops>
+																					<Condition classname='ExprValue'>
+																						<value/>
+																					</Condition>
+																					<Flags classname='Num'>
+																						<value>8192</value>
+																					</Flags>
+																					<CheckedState classname='Num'>
+																						<value>1</value>
+																					</CheckedState>
+																				</subprops>
+																			</AdditionalResult>
+																		</subprops>
+																	</DotNetCall>
+																</value>
+															</value>
+														</Calls>
+														<AssemblyPath classname='PathValue'>
+															<value>NationalInstruments.MeasurementLink.TestStandMeasurementClient.dll</value>
+														</AssemblyPath>
+														<AssemblyStrongName classname='Str'>
+															<value/>
+														</AssemblyStrongName>
+														<AssemblyLocation classname='Num'>
+															<value>0</value>
+														</AssemblyLocation>
+														<ClassName classname='Str'>
+															<value>NationalInstruments.MeasurementLink.MeasurementStepExecution</value>
+														</ClassName>
+														<IsStruct classname='Bool'>
+															<value>false</value>
+														</IsStruct>
+														<StructDef classname='DotNetParameter'>
+															<subprops>
+																<Name classname='Str'>
+																	<value>_notNamed</value>
+																</Name>
+																<ArgVal classname='ExprValue'>
+																	<value/>
+																</ArgVal>
+																<ArgDisplayVal classname='ExprValue'>
+																	<value/>
+																</ArgDisplayVal>
+																<Type classname='Num'>
+																	<value>0</value>
+																</Type>
+																<TypeName classname='Str'>
+																	<value/>
+																</TypeName>
+																<Flags classname='Num'>
+																	<value>0</value>
+																</Flags>
+																<IsOptional classname='Bool'>
+																	<value>false</value>
+																</IsOptional>
+																<CallDispose classname='Bool'>
+																	<value>false</value>
+																</CallDispose>
+																<NumDimensions classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</NumDimensions>
+																<MultiElement classname='Objs'>
+																	<value lbound='[0]' ubound='[]'/>
+																</MultiElement>
+																<AdditionalResults classname='Obj'>
+																	<subprops>
+																		<Input classname='DotNetParameterResult'>
+																			<subprops>
+																				<Condition classname='ExprValue'>
+																					<value/>
+																				</Condition>
+																				<Flags classname='Num'>
+																					<value>8192</value>
+																				</Flags>
+																				<CheckedState classname='Num'>
+																					<value>1</value>
+																				</CheckedState>
+																			</subprops>
+																		</Input>
+																		<Output classname='DotNetParameterResult'>
+																			<subprops>
+																				<Condition classname='ExprValue'>
+																					<value/>
+																				</Condition>
+																				<Flags classname='Num'>
+																					<value>8192</value>
+																				</Flags>
+																				<CheckedState classname='Num'>
+																					<value>1</value>
+																				</CheckedState>
+																			</subprops>
+																		</Output>
+																	</subprops>
+																</AdditionalResults>
+															</subprops>
+														</StructDef>
+														<RemoteSpecifiedByExpr classname='Bool'>
+															<value>false</value>
+														</RemoteSpecifiedByExpr>
+														<UseLoadSpec classname='Bool'>
+															<value>true</value>
+														</UseLoadSpec>
+														<ModuleSrcPath classname='PathValue'>
+															<value/>
+														</ModuleSrcPath>
+														<ModulePrjPath classname='PathValue'>
+															<value/>
+														</ModulePrjPath>
+														<ModuleSlnPath classname='PathValue'>
+															<value/>
+														</ModuleSlnPath>
+														<FunctionName classname='Str'>
+															<value/>
+														</FunctionName>
+													</subprops>
+												</SData>
+												<PreCond classname='ExprValue'>
+													<value/>
+												</PreCond>
+												<LoadOpt classname='Str'>
+													<value>PreloadWhenExecuted</value>
+												</LoadOpt>
+												<UnloadOpt classname='Str'>
+													<value>UnloadWithFile</value>
+												</UnloadOpt>
+												<Mode classname='Str'>
+													<value>Normal</value>
+												</Mode>
+												<WindowActivation classname='Str'>
+													<value>None</value>
+												</WindowActivation>
+												<ResultOption classname='Num'>
+													<value>1</value>
+												</ResultOption>
+												<StepFCSeqF classname='Bool'>
+													<value>true</value>
+												</StepFCSeqF>
+												<IgnoreRTE classname='Bool'>
+													<value>false</value>
+												</IgnoreRTE>
+												<UseMutex classname='Bool'>
+													<value>false</value>
+												</UseMutex>
+												<MutexNameOrRef classname='ExprValue'>
+													<value/>
+												</MutexNameOrRef>
+												<BatchSyncOpt classname='Num'>
+													<value>0</value>
+												</BatchSyncOpt>
+												<SwitchEnabled classname='Bool'>
+													<value>false</value>
+												</SwitchEnabled>
+												<VirtualDeviceName classname='ExprValue'>
+													<value/>
+												</VirtualDeviceName>
+												<SwitchOperation classname='Num'>
+													<value>1</value>
+												</SwitchOperation>
+												<RouteGroupConnect classname='ExprValue'>
+													<value/>
+												</RouteGroupConnect>
+												<RouteGroupDisconnect classname='ExprValue'>
+													<value/>
+												</RouteGroupDisconnect>
+												<MulticonnectMode classname='Num'>
+													<value>1</value>
+												</MulticonnectMode>
+												<OperationOrder classname='Num'>
+													<value>2</value>
+												</OperationOrder>
+												<ConnectionLifetime classname='Num'>
+													<value>4</value>
+												</ConnectionLifetime>
+												<WaitForDebounce classname='Bool'>
+													<value>true</value>
+												</WaitForDebounce>
+												<PassAct classname='Str'>
+													<value>Next</value>
+												</PassAct>
+												<FailAct classname='Str'>
+													<value>Next</value>
+												</FailAct>
+												<PassActTarget classname='ExprValue'>
+													<value/>
+												</PassActTarget>
+												<FailActTarget classname='ExprValue'>
+													<value/>
+												</FailActTarget>
+												<CustExpr classname='ExprValue'>
+													<value/>
+												</CustExpr>
+												<CustTrueAct classname='Str'>
+													<value>Next</value>
+												</CustTrueAct>
+												<CustFalseAct classname='Str'>
+													<value>Next</value>
+												</CustFalseAct>
+												<CustTrueActTarget classname='ExprValue'>
+													<value/>
+												</CustTrueActTarget>
+												<CustFalseActTarget classname='ExprValue'>
+													<value/>
+												</CustFalseActTarget>
+												<LoopType classname='Str'>
+													<value>NoLooping</value>
+												</LoopType>
+												<LoopWhile classname='ExprValue'>
+													<value/>
+												</LoopWhile>
+												<LoopStatus classname='ExprValue'>
+													<value/>
+												</LoopStatus>
+												<LoopIncrement classname='ExprValue'>
+													<value>RunState.LoopIndex += 1</value>
+												</LoopIncrement>
+												<LoopInitialize classname='ExprValue'>
+													<value>RunState.LoopIndex = 0</value>
+												</LoopInitialize>
+												<LoopOpt classname='Num'>
+													<value>0</value>
+												</LoopOpt>
+												<PreExpr classname='ExprValue'>
+													<value/>
+												</PreExpr>
+												<PostExpr classname='ExprValue'>
+													<value/>
+												</PostExpr>
+												<StatusExpr classname='ExprValue'>
+													<value/>
+												</StatusExpr>
+												<CanSpecifyModule classname='Bool'>
+													<value>true</value>
+												</CanSpecifyModule>
+												<CanEditCode classname='Bool'>
+													<value>true</value>
+												</CanEditCode>
+												<CanEditModulePrototype classname='Bool'>
+													<value>true</value>
+												</CanEditModulePrototype>
+												<CanEditParameterAdditionalResults classname='Bool'>
+													<value>true</value>
+												</CanEditParameterAdditionalResults>
+												<PrecondIntExe classname='Num'>
+													<value>0</value>
+												</PrecondIntExe>
+												<CustomResults classname='Objs'>
+													<value lbound='[0]' ubound='[]'>
+														<elemproto>
+															<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+																<subprops>
+																	<Name classname='ExprValue'>
+																		<value/>
+																	</Name>
+																	<ValueToLog classname='ExprValue'>
+																		<value/>
+																	</ValueToLog>
+																	<Condition classname='ExprValue'>
+																		<value/>
+																	</Condition>
+																	<Flags classname='Num'>
+																		<value>8192</value>
+																	</Flags>
+																	<CheckedState classname='Num'>
+																		<value>2</value>
+																	</CheckedState>
+																	<Type classname='PropertyObjectType'>
+																		<subprops>
+																			<ValueType classname='Num'>
+																				<value>3</value>
+																			</ValueType>
+																			<IsObject classname='Bool'>
+																				<value>true</value>
+																			</IsObject>
+																			<TypeName classname='Str'>
+																				<value/>
+																			</TypeName>
+																			<ElementType classname='Objs'>
+																				<value lbound='[0]' ubound='[]'/>
+																			</ElementType>
+																			<ArrayDimensions classname='ArrayDimensions'>
+																				<subprops>
+																					<LowerBounds classname='Nums'>
+																						<value lbound='[0]' ubound='[]'/>
+																					</LowerBounds>
+																					<UpperBounds classname='Nums'>
+																						<value lbound='[0]' ubound='[]'/>
+																					</UpperBounds>
+																				</subprops>
+																			</ArrayDimensions>
+																			<Representation classname='Num'>
+																				<value>1</value>
+																			</Representation>
+																			<ClassName classname='Str'>
+																				<value/>
+																			</ClassName>
+																		</subprops>
+																	</Type>
+																	<Elements classname='Objs'>
+																		<value lbound='[0]' ubound='[]'/>
+																	</Elements>
+																	<IsAnyType classname='Bool'>
+																		<value>true</value>
+																	</IsAnyType>
+																</subprops>
+															</_NAME_IN_ATTRIBUTE_>
+														</elemproto>
+													</value>
+												</CustomResults>
+												<AdditionalResultsHints classname='Objs'>
+													<value lbound='[0]' ubound='[]'>
+														<elemproto>
+															<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+																<subprops>
+																	<Name classname='ExprValue'>
+																		<value/>
+																	</Name>
+																	<ValueToLog classname='ExprValue'>
+																		<value/>
+																	</ValueToLog>
+																	<Condition classname='ExprValue'>
+																		<value/>
+																	</Condition>
+																	<Flags classname='Num'>
+																		<value>8192</value>
+																	</Flags>
+																	<CheckedState classname='Num'>
+																		<value>2</value>
+																	</CheckedState>
+																	<Type classname='PropertyObjectType'>
+																		<subprops>
+																			<ValueType classname='Num'>
+																				<value>3</value>
+																			</ValueType>
+																			<IsObject classname='Bool'>
+																				<value>true</value>
+																			</IsObject>
+																			<TypeName classname='Str'>
+																				<value/>
+																			</TypeName>
+																			<ElementType classname='Objs'>
+																				<value lbound='[0]' ubound='[]'/>
+																			</ElementType>
+																			<ArrayDimensions classname='ArrayDimensions'>
+																				<subprops>
+																					<LowerBounds classname='Nums'>
+																						<value lbound='[0]' ubound='[]'/>
+																					</LowerBounds>
+																					<UpperBounds classname='Nums'>
+																						<value lbound='[0]' ubound='[]'/>
+																					</UpperBounds>
+																				</subprops>
+																			</ArrayDimensions>
+																			<Representation classname='Num'>
+																				<value>1</value>
+																			</Representation>
+																			<ClassName classname='Str'>
+																				<value/>
+																			</ClassName>
+																		</subprops>
+																	</Type>
+																	<Elements classname='Objs'>
+																		<value lbound='[0]' ubound='[]'/>
+																	</Elements>
+																	<IsAnyType classname='Bool'>
+																		<value>true</value>
+																	</IsAnyType>
+																</subprops>
+															</_NAME_IN_ATTRIBUTE_>
+														</elemproto>
+													</value>
+												</AdditionalResultsHints>
+											</subprops>
+										</TS>
+										<Result classname='Obj'>
+											<subprops>
+												<Error classname='Obj'>
+													<subprops>
+														<Code classname='Num'>
+															<value>0</value>
+														</Code>
+														<Msg classname='Str'>
+															<value/>
+														</Msg>
+														<Occurred classname='Bool'>
+															<value>false</value>
+														</Occurred>
+													</subprops>
+												</Error>
+												<Status classname='Str'>
+													<value/>
+												</Status>
+												<ReportText classname='Str'>
+													<value/>
+												</ReportText>
+												<Common classname='Obj'/>
+											</subprops>
+										</Result>
+									</subprops>
+								</Step>
+							</value>
+						</value>
+					</Substeps>
+					<CodeTemplates classname='Str' valueflags='4194328' structureflags='524288'>
+						<value>DefaultLabVIEWNXG|DefaultLabVIEW|DefaultCVI|DefaultVB.NET|DefaultCSharp.NET|DefaultC++.NET|DefaultVC++_Template|DefaultHTB72_Template|DefaultHTB80_Template|Default_Template</value>
+					</CodeTemplates>
+					<AdditionalResultsHints classname='Objs' valueflags='4194328' structureflags='524288'>
+						<value lbound='[0]' ubound='[]'>
+							<elemproto>
+								<_NAME_IN_ATTRIBUTE_ typename='NI_CustomResult' xsi:type='NI_CustomResult' name='' classname='CustomResult'>
+									<subprops>
+										<Name classname='ExprValue'>
+											<value/>
+										</Name>
+										<ValueToLog classname='ExprValue'>
+											<value/>
+										</ValueToLog>
+										<Condition classname='ExprValue'>
+											<value/>
+										</Condition>
+										<Flags classname='Num'>
+											<value>8192</value>
+										</Flags>
+										<CheckedState classname='Num'>
+											<value>2</value>
+										</CheckedState>
+										<Type classname='PropertyObjectType'>
+											<subprops>
+												<ValueType classname='Num'>
+													<value>3</value>
+												</ValueType>
+												<IsObject classname='Bool'>
+													<value>true</value>
+												</IsObject>
+												<TypeName classname='Str'>
+													<value/>
+												</TypeName>
+												<ElementType classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</ElementType>
+												<ArrayDimensions classname='ArrayDimensions'>
+													<subprops>
+														<LowerBounds classname='Nums'>
+															<value lbound='[0]' ubound='[]'/>
+														</LowerBounds>
+														<UpperBounds classname='Nums'>
+															<value lbound='[0]' ubound='[]'/>
+														</UpperBounds>
+													</subprops>
+												</ArrayDimensions>
+												<Representation classname='Num'>
+													<value>1</value>
+												</Representation>
+												<ClassName classname='Str'>
+													<value/>
+												</ClassName>
+											</subprops>
+										</Type>
+										<Elements classname='Objs'>
+											<value lbound='[0]' ubound='[]'/>
+										</Elements>
+										<IsAnyType classname='Bool'>
+											<value>true</value>
+										</IsAnyType>
+									</subprops>
+								</_NAME_IN_ATTRIBUTE_>
+							</elemproto>
+						</value>
+					</AdditionalResultsHints>
+					<TS typename='TEInf' xsi:type='TEInf' classname='Obj' flagsforinstances='262168'>
+						<subprops>
+							<Id classname='Str'>
+								<value/>
+							</Id>
+							<Icon classname='Str'>
+								<value>Measurement\Measurement.ico</value>
+							</Icon>
+							<SData typename='NoneStepAdditions' xsi:type='NoneStepAdditions' classname='NoneModule' flagsforinstances='2097152' instanceoverrideflags='7274521' structureflags='2097152'/>
+							<PreCond classname='ExprValue'>
+								<value/>
+							</PreCond>
+							<LoadOpt classname='Str'>
+								<value>PreloadWhenExecuted</value>
+							</LoadOpt>
+							<UnloadOpt classname='Str'>
+								<value>UnloadWithFile</value>
+							</UnloadOpt>
+							<Mode classname='Str'>
+								<value>Normal</value>
+							</Mode>
+							<WindowActivation classname='Str'>
+								<value>None</value>
+							</WindowActivation>
+							<ResultOption classname='Num'>
+								<value>1</value>
+							</ResultOption>
+							<StepFCSeqF classname='Bool'>
+								<value>true</value>
+							</StepFCSeqF>
+							<IgnoreRTE classname='Bool'>
+								<value>false</value>
+							</IgnoreRTE>
+							<UseMutex classname='Bool'>
+								<value>false</value>
+							</UseMutex>
+							<MutexNameOrRef classname='ExprValue'>
+								<value/>
+							</MutexNameOrRef>
+							<BatchSyncOpt classname='Num'>
+								<value>0</value>
+							</BatchSyncOpt>
+							<SwitchEnabled classname='Bool'>
+								<value>false</value>
+							</SwitchEnabled>
+							<VirtualDeviceName classname='ExprValue'>
+								<value/>
+							</VirtualDeviceName>
+							<SwitchOperation classname='Num'>
+								<value>1</value>
+							</SwitchOperation>
+							<RouteGroupConnect classname='ExprValue'>
+								<value/>
+							</RouteGroupConnect>
+							<RouteGroupDisconnect classname='ExprValue'>
+								<value/>
+							</RouteGroupDisconnect>
+							<MulticonnectMode classname='Num'>
+								<value>1</value>
+							</MulticonnectMode>
+							<OperationOrder classname='Num'>
+								<value>2</value>
+							</OperationOrder>
+							<ConnectionLifetime classname='Num'>
+								<value>4</value>
+							</ConnectionLifetime>
+							<WaitForDebounce classname='Bool'>
+								<value>true</value>
+							</WaitForDebounce>
+							<PassAct classname='Str'>
+								<value>Next</value>
+							</PassAct>
+							<FailAct classname='Str'>
+								<value>Next</value>
+							</FailAct>
+							<PassActTarget classname='ExprValue'>
+								<value/>
+							</PassActTarget>
+							<FailActTarget classname='ExprValue'>
+								<value/>
+							</FailActTarget>
+							<CustExpr classname='ExprValue'>
+								<value/>
+							</CustExpr>
+							<CustTrueAct classname='Str'>
+								<value>Next</value>
+							</CustTrueAct>
+							<CustFalseAct classname='Str'>
+								<value>Next</value>
+							</CustFalseAct>
+							<CustTrueActTarget classname='ExprValue'>
+								<value/>
+							</CustTrueActTarget>
+							<CustFalseActTarget classname='ExprValue'>
+								<value/>
+							</CustFalseActTarget>
+							<LoopType classname='Str'>
+								<value>NoLooping</value>
+							</LoopType>
+							<LoopWhile classname='ExprValue'>
+								<value/>
+							</LoopWhile>
+							<LoopStatus classname='ExprValue'>
+								<value/>
+							</LoopStatus>
+							<LoopIncrement classname='ExprValue'>
+								<value>RunState.LoopIndex += 1</value>
+							</LoopIncrement>
+							<LoopInitialize classname='ExprValue'>
+								<value>RunState.LoopIndex = 0</value>
+							</LoopInitialize>
+							<LoopOpt classname='Num'>
+								<value>0</value>
+							</LoopOpt>
+							<PreExpr classname='ExprValue'>
+								<value/>
+							</PreExpr>
+							<PostExpr classname='ExprValue'>
+								<value/>
+							</PostExpr>
+							<StatusExpr classname='ExprValue'>
+								<value/>
+							</StatusExpr>
+							<CanSpecifyModule classname='Bool' valueflags='131072' structureflags='131072'>
+								<value>true</value>
+							</CanSpecifyModule>
+							<CanEditCode classname='Bool'>
+								<value>true</value>
+							</CanEditCode>
+							<CanEditModulePrototype classname='Bool'>
+								<value>true</value>
+							</CanEditModulePrototype>
+							<CanEditParameterAdditionalResults classname='Bool'>
+								<value>true</value>
+							</CanEditParameterAdditionalResults>
+							<PrecondIntExe classname='Num'>
+								<value>0</value>
+							</PrecondIntExe>
+							<Requirements classname='Obj' flagsforinstances='1' valueflags='1' structureflags='2097152'>
+								<subprops>
+									<Links classname='Strs' flagsforinstances='71303168' instanceoverrideflags='72286233' valueflags='71303168'>
+										<value lbound='[0]' ubound='[]'/>
+									</Links>
+								</subprops>
+							</Requirements>
+							<CustomResults classname='Objs'>
+								<value lbound='[0]' ubound='[]'>
+									<elemproto>
+										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+											<subprops>
+												<Name classname='ExprValue'>
+													<value/>
+												</Name>
+												<ValueToLog classname='ExprValue'>
+													<value/>
+												</ValueToLog>
+												<Condition classname='ExprValue'>
+													<value/>
+												</Condition>
+												<Flags classname='Num'>
+													<value>8192</value>
+												</Flags>
+												<CheckedState classname='Num'>
+													<value>2</value>
+												</CheckedState>
+												<Type classname='PropertyObjectType'>
+													<subprops>
+														<ValueType classname='Num'>
+															<value>3</value>
+														</ValueType>
+														<IsObject classname='Bool'>
+															<value>true</value>
+														</IsObject>
+														<TypeName classname='Str'>
+															<value/>
+														</TypeName>
+														<ElementType classname='Objs'>
+															<value lbound='[0]' ubound='[]'/>
+														</ElementType>
+														<ArrayDimensions classname='ArrayDimensions'>
+															<subprops>
+																<LowerBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</LowerBounds>
+																<UpperBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</UpperBounds>
+															</subprops>
+														</ArrayDimensions>
+														<Representation classname='Num'>
+															<value>1</value>
+														</Representation>
+														<ClassName classname='Str'>
+															<value/>
+														</ClassName>
+													</subprops>
+												</Type>
+												<Elements classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</Elements>
+												<IsAnyType classname='Bool'>
+													<value>true</value>
+												</IsAnyType>
+											</subprops>
+										</_NAME_IN_ATTRIBUTE_>
+									</elemproto>
+								</value>
+							</CustomResults>
+							<AdditionalResultsHints classname='Objs'>
+								<value lbound='[0]' ubound='[]'>
+									<elemproto>
+										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+											<subprops>
+												<Name classname='ExprValue'>
+													<value/>
+												</Name>
+												<ValueToLog classname='ExprValue'>
+													<value/>
+												</ValueToLog>
+												<Condition classname='ExprValue'>
+													<value/>
+												</Condition>
+												<Flags classname='Num'>
+													<value>8192</value>
+												</Flags>
+												<CheckedState classname='Num'>
+													<value>2</value>
+												</CheckedState>
+												<Type classname='PropertyObjectType'>
+													<subprops>
+														<ValueType classname='Num'>
+															<value>3</value>
+														</ValueType>
+														<IsObject classname='Bool'>
+															<value>true</value>
+														</IsObject>
+														<TypeName classname='Str'>
+															<value/>
+														</TypeName>
+														<ElementType classname='Objs'>
+															<value lbound='[0]' ubound='[]'/>
+														</ElementType>
+														<ArrayDimensions classname='ArrayDimensions'>
+															<subprops>
+																<LowerBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</LowerBounds>
+																<UpperBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</UpperBounds>
+															</subprops>
+														</ArrayDimensions>
+														<Representation classname='Num'>
+															<value>1</value>
+														</Representation>
+														<ClassName classname='Str'>
+															<value/>
+														</ClassName>
+													</subprops>
+												</Type>
+												<Elements classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</Elements>
+												<IsAnyType classname='Bool'>
+													<value>true</value>
+												</IsAnyType>
+											</subprops>
+										</_NAME_IN_ATTRIBUTE_>
+									</elemproto>
+								</value>
+							</AdditionalResultsHints>
+						</subprops>
+					</TS>
+					<NI_Data typename='StepTypeNIData' xsi:type='StepTypeNIData' classname='Obj'>
+						<subprops>
+							<EditPanels classname='Strs'>
+								<value lbound='[0]' ubound='[0]'>
+									<value arrayindex='[0]'>NationalInstruments.MeasurementLink.TestStandMeasurementClient.dll|NationalInstruments.MeasurementLink.MeasurementStepPanelInfo</value>
+								</value>
+							</EditPanels>
+						</subprops>
+					</NI_Data>
+					<Result classname='Obj' flagsforinstances='4194304' valueflags='4194304'>
+						<subprops>
+							<Error typename='Error' xsi:type='Error' classname='Obj' flagsforinstances='4194304' valueflags='4194304'>
+								<subprops>
+									<Code classname='Num'>
+										<value>0</value>
+									</Code>
+									<Msg classname='Str'>
+										<value/>
+									</Msg>
+									<Occurred classname='Bool'>
+										<value>false</value>
+									</Occurred>
+								</subprops>
+							</Error>
+							<Status classname='Str' flagsforinstances='4194304' valueflags='4194304'>
+								<value/>
+							</Status>
+							<ReportText classname='Str' flagsforinstances='4194304' valueflags='4194304'>
+								<value/>
+							</ReportText>
+							<Common typename='CommonResults' xsi:type='CommonResults' classname='Obj'/>
+						</subprops>
+					</Result>
+					<CanEncapsulate classname='Bool' valueflags='4194328' structureflags='524288'>
+						<value>false</value>
+					</CanEncapsulate>
+					<Measurement classname='Obj' flagsforinstances='24'>
+						<subprops>
+							<Name classname='Str'>
+								<value/>
+							</Name>
+							<Parameters classname='Objs'>
+								<value lbound='[0]' ubound='[]'>
+									<elemproto>
+										<_NAME_IN_ATTRIBUTE_ typename='NI_MeasurementParameter' name='' classname='Obj'>
+											<subprops>
+												<Name classname='Str'>
+													<value/>
+												</Name>
+												<ArgumentValue classname='ExprValue'>
+													<value/>
+												</ArgumentValue>
+												<Direction classname='Str'>
+													<value/>
+												</Direction>
+												<Log classname='Bool'>
+													<value>false</value>
+												</Log>
+												<Dimension classname='Num'>
+													<value representation='UInt64'>0</value>
+												</Dimension>
+												<Type classname='Str'>
+													<value/>
+												</Type>
+												<ID classname='Num'>
+													<value representation='Int64'>0</value>
+												</ID>
+												<TypeSpecialization classname='Str'>
+													<value/>
+												</TypeSpecialization>
+											</subprops>
+										</_NAME_IN_ATTRIBUTE_>
+									</elemproto>
+								</value>
+							</Parameters>
+						</subprops>
+					</Measurement>
+				</subprops>
+			</NI_Measurement>
+		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='22'>
 			<EditSubstep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
 				<subprops>

--- a/examples/nifgen_standard_function/NIFgenStandardFunction.seq
+++ b/examples/nifgen_standard_function/NIFgenStandardFunction.seq
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<teststandfileheader type='SequenceFile' fileversion='962' productname='TestStand' productversion='2021 (21.0.0.49156)' compatibleversion='21.0.0.0' buildversion='21.0.0.49156' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.ni.com/TestStand/21.0.0/SequenceFile">
+<teststandfileheader type='SequenceFile' fileversion='962' productname='TestStand' productversion='2021 SP1 (21.1.0.49154)' compatibleversion='21.0.0.0' buildversion='21.0.0.49156' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.ni.com/TestStand/21.0.0/SequenceFile">
 	<typelist>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='1'>
-			<Expression classname='ExprValue' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
+			<Expression classname='ExprValue' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436'>
 				<value/>
 			</Expression>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='2'>
-			<StepTypeMenu classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
+			<StepTypeMenu classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
 				<subprops>
 					<CanBeSubstepType classname='Bool'>
 						<value>false</value>
@@ -37,12 +37,12 @@
 			</StepTypeMenu>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='3'>
-			<StepTypeSubstepsArray classname='Objs' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4849688' valueflags='24'>
+			<StepTypeSubstepsArray classname='Objs' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4849688' valueflags='24'>
 				<value lbound='[0]' ubound='[]'/>
 			</StepTypeSubstepsArray>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='4'>
-			<NI_ArrayDimensions classname='ArrayDimensions' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_ArrayDimensions classname='ArrayDimensions' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<LowerBounds classname='Nums'>
 						<value lbound='[0]' ubound='[]'/>
@@ -54,7 +54,7 @@
 			</NI_ArrayDimensions>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='5'>
-			<NI_PropertyObjectType classname='PropertyObjectType' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_PropertyObjectType classname='PropertyObjectType' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<ValueType classname='Num'>
 						<value>3</value>
@@ -88,7 +88,7 @@
 			</NI_PropertyObjectType>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='6'>
-			<NI_CustomResult classname='CustomResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_CustomResult classname='CustomResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Name typename='Expression' xsi:type='Expression' classname='ExprValue'>
 						<value/>
@@ -148,7 +148,7 @@
 			</NI_CustomResult>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='7'>
-			<TEInf classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4456472' instanceoverrideflags='4456472' valueflags='24'>
+			<TEInf classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4456472' instanceoverrideflags='4456472' valueflags='24'>
 				<subprops>
 					<Id classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
 						<value/>
@@ -423,7 +423,7 @@
 			</TEInf>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='8'>
-			<StepTypeNIData classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
+			<StepTypeNIData classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
 				<subprops>
 					<EditPanels classname='Strs'>
 						<value lbound='[0]' ubound='[]'/>
@@ -432,7 +432,7 @@
 			</StepTypeNIData>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='9'>
-			<Error classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
+			<Error classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436'>
 				<extdata controllername='STRUCT' allowstructpassing='true' packingoption='8' exclude='false' type='0' arraystorage='0' strbuffersize='256' strstorage='0'/>
 				<extdata controllername='CLUST' allowclusterpassing='true' exclude='false' memberlabel=''/>
 				<extdata controllername='DNSTRUCT' allowstructpassing='true' exclude='false' membername=''/>
@@ -463,10 +463,10 @@
 			</Error>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='10'>
-			<CommonResults classname='Obj' isroottypedef='true' typecategory='3' timestamp='1465572565' typeversion='3.1.0.100' typelastmodversion='21.0.0.49156' typeminprodversion='3.1.0.0' typeflags='33554432' flagsforinstances='4194304' valueflags='4194304'/>
+			<CommonResults classname='Obj' isroottypedef='true' typecategory='3' timestamp='1465572565' typeversion='3.1.0.100' typelastmodversion='21.1.0.49154' typeminprodversion='3.1.0.0' typeflags='33554432' flagsforinstances='4194304' valueflags='4194304'/>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='11'>
-			<Substep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
+			<Substep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
 				<subprops>
 					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
 						<value>"%ModuleDescription"</value>
@@ -891,7 +891,7 @@
 			</Substep>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='12'>
-			<NI_DotNetParameterResult classname='DotNetParameterResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_DotNetParameterResult classname='DotNetParameterResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
 						<value/>
@@ -907,7 +907,7 @@
 			</NI_DotNetParameterResult>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='13'>
-			<DotNetParameter classname='DotNetParameter' isroottypedef='true' typecategory='3' timestamp='1650061192' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<DotNetParameter classname='DotNetParameter' isroottypedef='true' typecategory='3' timestamp='1650061192' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Name classname='Str'>
 						<value>_notNamed</value>
@@ -974,7 +974,7 @@
 			</DotNetParameter>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='14'>
-			<NI_DotNetCallResult classname='DotNetCallResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_DotNetCallResult classname='DotNetCallResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
 						<value/>
@@ -990,7 +990,7 @@
 			</NI_DotNetCallResult>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='15'>
-			<DotNetCall classname='DotNetCall' isroottypedef='true' typecategory='3' timestamp='1650061192' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<DotNetCall classname='DotNetCall' isroottypedef='true' typecategory='3' timestamp='1650061192' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<ClassName classname='Str'>
 						<value/>
@@ -1091,12 +1091,12 @@
 			</DotNetCall>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='0'>
-			<Path classname='PathValue' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
+			<Path classname='PathValue' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436'>
 				<value/>
 			</Path>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='16'>
-			<DotNetStepAdditions classname='DotNetModule' isroottypedef='true' typecategory='3' timestamp='1650061192' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<DotNetStepAdditions classname='DotNetModule' isroottypedef='true' typecategory='3' timestamp='1650061192' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Calls classname='Objs'>
 						<value lbound='[0]' ubound='[]'>
@@ -1241,7 +1241,7 @@
 			</DotNetStepAdditions>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='17'>
-			<PostSubstep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
+			<PostSubstep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
 				<subprops>
 					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
 						<value>"%ModuleDescription"</value>
@@ -1666,1731 +1666,12 @@
 			</PostSubstep>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='18'>
-			<NoneStepAdditions classname='NoneModule' isroottypedef='true' typecategory='3' timestamp='1650060850' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'/>
+			<NoneStepAdditions classname='NoneModule' isroottypedef='true' typecategory='3' timestamp='1650060850' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'/>
 		</typedef>
-		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='19'>
-			<NI_MeasurementParameter classname='Obj' isroottypedef='true' typecategory='2' timestamp='1669042099' typeversion='21.0.5.4' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0'>
-				<subprops>
-					<Name classname='Str'>
-						<value/>
-					</Name>
-					<ArgumentValue typename='Expression' xsi:type='Expression' classname='ExprValue'>
-						<value/>
-					</ArgumentValue>
-					<Direction classname='Str'>
-						<value/>
-					</Direction>
-					<Log classname='Bool'>
-						<value>false</value>
-					</Log>
-					<Dimension classname='Num'>
-						<value representation='UInt64'>0</value>
-					</Dimension>
-					<Type classname='Str'>
-						<value/>
-					</Type>
-					<ID classname='Num'>
-						<value representation='Int64'>0</value>
-					</ID>
-					<TypeSpecialization classname='Str'>
-						<value/>
-					</TypeSpecialization>
-				</subprops>
-			</NI_MeasurementParameter>
-		</typedef>
-		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='20'>
-			<NI_Measurement classname='StepType' isroottypedef='true' typecategory='1' timestamp='1670875325' typeversion='21.0.5.8' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='2'>
-				<subprops>
-					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
-						<value>ResStr("MEASUREMENT_STEP_TYPE", "MEASUREMENT_DESCRIPTION_NAME")</value>
-					</DescriptionFormat>
-					<DefaultNameFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
-						<value>ResStr("MEASUREMENT_STEP_TYPE", "MEASUREMENT_DEF_STEP_NAME")</value>
-					</DefaultNameFormat>
-					<BlockStartTypes classname='Str' valueflags='4194328' structureflags='524288'>
-						<value/>
-					</BlockStartTypes>
-					<BlockEndTypes classname='Str' valueflags='4194328' structureflags='524288'>
-						<value/>
-					</BlockEndTypes>
-					<AppliesToBlockStructure classname='Bool' valueflags='4194328' structureflags='524288'>
-						<value>false</value>
-					</AppliesToBlockStructure>
-					<Menu typename='StepTypeMenu' xsi:type='StepTypeMenu' classname='Obj'>
-						<subprops>
-							<CanBeSubstepType classname='Bool'>
-								<value>false</value>
-							</CanBeSubstepType>
-							<CanOnlyBeSubstepType classname='Bool'>
-								<value>false</value>
-							</CanOnlyBeSubstepType>
-							<Category classname='Str'>
-								<value>""</value>
-							</Category>
-							<ItemName classname='ExprValue'>
-								<value>ResStr("MEASUREMENT_STEP_TYPE","MEASUREMENT_INSERT_MENU_ITEM_NAME")</value>
-							</ItemName>
-							<SingularItemName classname='Str'>
-								<value>""</value>
-							</SingularItemName>
-							<SeparatorBeforeCategory classname='Bool'>
-								<value>false</value>
-							</SeparatorBeforeCategory>
-							<SeparatorBeforeItemName classname='Bool'>
-								<value>false</value>
-							</SeparatorBeforeItemName>
-							<Group classname='Str'>
-								<value/>
-							</Group>
-						</subprops>
-					</Menu>
-					<Substeps typename='StepTypeSubstepsArray' xsi:type='StepTypeSubstepsArray' classname='Objs'>
-						<value lbound='[0]' ubound='[1]'>
-							<value>
-								<Step typename='Substep' xsi:type='Substep' name='OnNewStep'>
-									<subprops>
-										<TS classname='Obj'>
-											<subprops>
-												<Id classname='Str'>
-													<value>ID#:j5wyx+k17RGnWgDgQ7lGAD</value>
-												</Id>
-												<Icon classname='Str'>
-													<value/>
-												</Icon>
-												<SData typename='DotNetStepAdditions' xsi:type='DotNetStepAdditions' classname='DotNetModule' structureflags='2097152'>
-													<subprops>
-														<Calls classname='Objs'>
-															<value lbound='[0]' ubound='[1]'>
-																<elemproto>
-																	<_NAME_IN_ATTRIBUTE_ name='' classname='DotNetCall' structureflags='0'/>
-																</elemproto>
-																<value>
-																	<DotNetCall typename='DotNetCall' xsi:type='DotNetCall' name=''>
-																		<subprops>
-																			<ClassName classname='Str'>
-																				<value>NationalInstruments.MeasurementLink.NewStepHandler</value>
-																			</ClassName>
-																			<MemberType classname='Num'>
-																				<value>4</value>
-																			</MemberType>
-																			<Static classname='Bool'>
-																				<value>false</value>
-																			</Static>
-																			<MemberName classname='Str'>
-																				<value>NewStepHandler</value>
-																			</MemberName>
-																			<Params classname='Objs'>
-																				<value lbound='[0]' ubound='[0]'>
-																					<elemproto>
-																						<_NAME_IN_ATTRIBUTE_ name='' classname='DotNetParameter' structureflags='0'/>
-																					</elemproto>
-																					<value>
-																						<DotNetParameter typename='DotNetParameter' xsi:type='DotNetParameter' name=''>
-																							<subprops>
-																								<Name classname='Str'>
-																									<value>Return Value</value>
-																								</Name>
-																								<ArgVal classname='ExprValue'>
-																									<value/>
-																								</ArgVal>
-																								<ArgDisplayVal classname='ExprValue'>
-																									<value/>
-																								</ArgDisplayVal>
-																								<Type classname='Num'>
-																									<value>0</value>
-																								</Type>
-																								<TypeName classname='Str'>
-																									<value>NationalInstruments.MeasurementLink.NewStepHandler</value>
-																								</TypeName>
-																								<Flags classname='Num'>
-																									<value>6</value>
-																								</Flags>
-																								<IsOptional classname='Bool'>
-																									<value>false</value>
-																								</IsOptional>
-																								<CallDispose classname='Bool'>
-																									<value>true</value>
-																								</CallDispose>
-																								<NumDimensions classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</NumDimensions>
-																								<MultiElement classname='Objs'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</MultiElement>
-																								<AdditionalResults classname='Obj'>
-																									<subprops>
-																										<Input classname='DotNetParameterResult'>
-																											<subprops>
-																												<Condition classname='ExprValue'>
-																													<value/>
-																												</Condition>
-																												<Flags classname='Num'>
-																													<value>8192</value>
-																												</Flags>
-																												<CheckedState classname='Num'>
-																													<value>1</value>
-																												</CheckedState>
-																											</subprops>
-																										</Input>
-																										<Output classname='DotNetParameterResult'>
-																											<subprops>
-																												<Condition classname='ExprValue'>
-																													<value/>
-																												</Condition>
-																												<Flags classname='Num'>
-																													<value>8192</value>
-																												</Flags>
-																												<CheckedState classname='Num'>
-																													<value>1</value>
-																												</CheckedState>
-																											</subprops>
-																										</Output>
-																									</subprops>
-																								</AdditionalResults>
-																							</subprops>
-																						</DotNetParameter>
-																					</value>
-																				</value>
-																			</Params>
-																			<AdditionalResult classname='DotNetCallResult'>
-																				<subprops>
-																					<Condition classname='ExprValue'>
-																						<value/>
-																					</Condition>
-																					<Flags classname='Num'>
-																						<value>8192</value>
-																					</Flags>
-																					<CheckedState classname='Num'>
-																						<value>1</value>
-																					</CheckedState>
-																				</subprops>
-																			</AdditionalResult>
-																		</subprops>
-																	</DotNetCall>
-																</value>
-																<value>
-																	<DotNetCall typename='DotNetCall' xsi:type='DotNetCall' name=''>
-																		<subprops>
-																			<ClassName classname='Str'>
-																				<value>NationalInstruments.MeasurementLink.NewStepHandler</value>
-																			</ClassName>
-																			<MemberType classname='Num'>
-																				<value>1</value>
-																			</MemberType>
-																			<Static classname='Bool'>
-																				<value>false</value>
-																			</Static>
-																			<MemberName classname='Str'>
-																				<value>OnNewStep</value>
-																			</MemberName>
-																			<Params classname='Objs'>
-																				<value lbound='[0]' ubound='[0]'>
-																					<elemproto>
-																						<_NAME_IN_ATTRIBUTE_ name='' classname='DotNetParameter' structureflags='0'/>
-																					</elemproto>
-																					<value>
-																						<DotNetParameter typename='DotNetParameter' xsi:type='DotNetParameter' name=''>
-																							<subprops>
-																								<Name classname='Str'>
-																									<value>sequenceContext</value>
-																								</Name>
-																								<ArgVal classname='ExprValue'>
-																									<value>ThisContext</value>
-																								</ArgVal>
-																								<ArgDisplayVal classname='ExprValue'>
-																									<value/>
-																								</ArgDisplayVal>
-																								<Type classname='Num'>
-																									<value>0</value>
-																								</Type>
-																								<TypeName classname='Str'>
-																									<value>NationalInstruments.TestStand.Interop.API.SequenceContext</value>
-																								</TypeName>
-																								<Flags classname='Num'>
-																									<value>0</value>
-																								</Flags>
-																								<IsOptional classname='Bool'>
-																									<value>false</value>
-																								</IsOptional>
-																								<CallDispose classname='Bool'>
-																									<value>false</value>
-																								</CallDispose>
-																								<NumDimensions classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</NumDimensions>
-																								<MultiElement classname='Objs'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</MultiElement>
-																								<AdditionalResults classname='Obj'>
-																									<subprops>
-																										<Input classname='DotNetParameterResult'>
-																											<subprops>
-																												<Condition classname='ExprValue'>
-																													<value/>
-																												</Condition>
-																												<Flags classname='Num'>
-																													<value>8192</value>
-																												</Flags>
-																												<CheckedState classname='Num'>
-																													<value>1</value>
-																												</CheckedState>
-																											</subprops>
-																										</Input>
-																										<Output classname='DotNetParameterResult'>
-																											<subprops>
-																												<Condition classname='ExprValue'>
-																													<value/>
-																												</Condition>
-																												<Flags classname='Num'>
-																													<value>8192</value>
-																												</Flags>
-																												<CheckedState classname='Num'>
-																													<value>1</value>
-																												</CheckedState>
-																											</subprops>
-																										</Output>
-																									</subprops>
-																								</AdditionalResults>
-																							</subprops>
-																						</DotNetParameter>
-																					</value>
-																				</value>
-																			</Params>
-																			<AdditionalResult classname='DotNetCallResult'>
-																				<subprops>
-																					<Condition classname='ExprValue'>
-																						<value/>
-																					</Condition>
-																					<Flags classname='Num'>
-																						<value>8192</value>
-																					</Flags>
-																					<CheckedState classname='Num'>
-																						<value>1</value>
-																					</CheckedState>
-																				</subprops>
-																			</AdditionalResult>
-																		</subprops>
-																	</DotNetCall>
-																</value>
-															</value>
-														</Calls>
-														<AssemblyPath classname='PathValue'>
-															<value>NationalInstruments.MeasurementLink.TestStandMeasurementClient.dll</value>
-														</AssemblyPath>
-														<AssemblyStrongName classname='Str'>
-															<value/>
-														</AssemblyStrongName>
-														<AssemblyLocation classname='Num'>
-															<value>0</value>
-														</AssemblyLocation>
-														<ClassName classname='Str'>
-															<value>NationalInstruments.MeasurementLink.NewStepHandler</value>
-														</ClassName>
-														<IsStruct classname='Bool'>
-															<value>false</value>
-														</IsStruct>
-														<StructDef classname='DotNetParameter'>
-															<subprops>
-																<Name classname='Str'>
-																	<value>_notNamed</value>
-																</Name>
-																<ArgVal classname='ExprValue'>
-																	<value/>
-																</ArgVal>
-																<ArgDisplayVal classname='ExprValue'>
-																	<value/>
-																</ArgDisplayVal>
-																<Type classname='Num'>
-																	<value>0</value>
-																</Type>
-																<TypeName classname='Str'>
-																	<value/>
-																</TypeName>
-																<Flags classname='Num'>
-																	<value>0</value>
-																</Flags>
-																<IsOptional classname='Bool'>
-																	<value>false</value>
-																</IsOptional>
-																<CallDispose classname='Bool'>
-																	<value>false</value>
-																</CallDispose>
-																<NumDimensions classname='Nums'>
-																	<value lbound='[0]' ubound='[]'/>
-																</NumDimensions>
-																<MultiElement classname='Objs'>
-																	<value lbound='[0]' ubound='[]'/>
-																</MultiElement>
-																<AdditionalResults classname='Obj'>
-																	<subprops>
-																		<Input classname='DotNetParameterResult'>
-																			<subprops>
-																				<Condition classname='ExprValue'>
-																					<value/>
-																				</Condition>
-																				<Flags classname='Num'>
-																					<value>8192</value>
-																				</Flags>
-																				<CheckedState classname='Num'>
-																					<value>1</value>
-																				</CheckedState>
-																			</subprops>
-																		</Input>
-																		<Output classname='DotNetParameterResult'>
-																			<subprops>
-																				<Condition classname='ExprValue'>
-																					<value/>
-																				</Condition>
-																				<Flags classname='Num'>
-																					<value>8192</value>
-																				</Flags>
-																				<CheckedState classname='Num'>
-																					<value>1</value>
-																				</CheckedState>
-																			</subprops>
-																		</Output>
-																	</subprops>
-																</AdditionalResults>
-															</subprops>
-														</StructDef>
-														<RemoteSpecifiedByExpr classname='Bool'>
-															<value>false</value>
-														</RemoteSpecifiedByExpr>
-														<UseLoadSpec classname='Bool'>
-															<value>false</value>
-														</UseLoadSpec>
-														<ModuleSrcPath classname='PathValue'>
-															<value/>
-														</ModuleSrcPath>
-														<ModulePrjPath classname='PathValue'>
-															<value/>
-														</ModulePrjPath>
-														<ModuleSlnPath classname='PathValue'>
-															<value/>
-														</ModuleSlnPath>
-														<FunctionName classname='Str'>
-															<value/>
-														</FunctionName>
-													</subprops>
-												</SData>
-												<PreCond classname='ExprValue'>
-													<value/>
-												</PreCond>
-												<LoadOpt classname='Str'>
-													<value>PreloadWhenExecuted</value>
-												</LoadOpt>
-												<UnloadOpt classname='Str'>
-													<value>UnloadWithFile</value>
-												</UnloadOpt>
-												<Mode classname='Str'>
-													<value>Normal</value>
-												</Mode>
-												<WindowActivation classname='Str'>
-													<value>None</value>
-												</WindowActivation>
-												<ResultOption classname='Num'>
-													<value>1</value>
-												</ResultOption>
-												<StepFCSeqF classname='Bool'>
-													<value>true</value>
-												</StepFCSeqF>
-												<IgnoreRTE classname='Bool'>
-													<value>false</value>
-												</IgnoreRTE>
-												<UseMutex classname='Bool'>
-													<value>false</value>
-												</UseMutex>
-												<MutexNameOrRef classname='ExprValue'>
-													<value/>
-												</MutexNameOrRef>
-												<BatchSyncOpt classname='Num'>
-													<value>0</value>
-												</BatchSyncOpt>
-												<SwitchEnabled classname='Bool'>
-													<value>false</value>
-												</SwitchEnabled>
-												<VirtualDeviceName classname='ExprValue'>
-													<value/>
-												</VirtualDeviceName>
-												<SwitchOperation classname='Num'>
-													<value>1</value>
-												</SwitchOperation>
-												<RouteGroupConnect classname='ExprValue'>
-													<value/>
-												</RouteGroupConnect>
-												<RouteGroupDisconnect classname='ExprValue'>
-													<value/>
-												</RouteGroupDisconnect>
-												<MulticonnectMode classname='Num'>
-													<value>1</value>
-												</MulticonnectMode>
-												<OperationOrder classname='Num'>
-													<value>2</value>
-												</OperationOrder>
-												<ConnectionLifetime classname='Num'>
-													<value>4</value>
-												</ConnectionLifetime>
-												<WaitForDebounce classname='Bool'>
-													<value>true</value>
-												</WaitForDebounce>
-												<PassAct classname='Str'>
-													<value>Next</value>
-												</PassAct>
-												<FailAct classname='Str'>
-													<value>Next</value>
-												</FailAct>
-												<PassActTarget classname='ExprValue'>
-													<value/>
-												</PassActTarget>
-												<FailActTarget classname='ExprValue'>
-													<value/>
-												</FailActTarget>
-												<CustExpr classname='ExprValue'>
-													<value/>
-												</CustExpr>
-												<CustTrueAct classname='Str'>
-													<value>Next</value>
-												</CustTrueAct>
-												<CustFalseAct classname='Str'>
-													<value>Next</value>
-												</CustFalseAct>
-												<CustTrueActTarget classname='ExprValue'>
-													<value/>
-												</CustTrueActTarget>
-												<CustFalseActTarget classname='ExprValue'>
-													<value/>
-												</CustFalseActTarget>
-												<LoopType classname='Str'>
-													<value>NoLooping</value>
-												</LoopType>
-												<LoopWhile classname='ExprValue'>
-													<value/>
-												</LoopWhile>
-												<LoopStatus classname='ExprValue'>
-													<value/>
-												</LoopStatus>
-												<LoopIncrement classname='ExprValue'>
-													<value>RunState.LoopIndex += 1</value>
-												</LoopIncrement>
-												<LoopInitialize classname='ExprValue'>
-													<value>RunState.LoopIndex = 0</value>
-												</LoopInitialize>
-												<LoopOpt classname='Num'>
-													<value>0</value>
-												</LoopOpt>
-												<PreExpr classname='ExprValue'>
-													<value/>
-												</PreExpr>
-												<PostExpr classname='ExprValue'>
-													<value/>
-												</PostExpr>
-												<StatusExpr classname='ExprValue'>
-													<value/>
-												</StatusExpr>
-												<CanSpecifyModule classname='Bool'>
-													<value>true</value>
-												</CanSpecifyModule>
-												<CanEditCode classname='Bool'>
-													<value>true</value>
-												</CanEditCode>
-												<CanEditModulePrototype classname='Bool'>
-													<value>true</value>
-												</CanEditModulePrototype>
-												<CanEditParameterAdditionalResults classname='Bool'>
-													<value>true</value>
-												</CanEditParameterAdditionalResults>
-												<PrecondIntExe classname='Num'>
-													<value>0</value>
-												</PrecondIntExe>
-												<CustomResults classname='Objs'>
-													<value lbound='[0]' ubound='[]'>
-														<elemproto>
-															<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-																<subprops>
-																	<Name classname='ExprValue'>
-																		<value/>
-																	</Name>
-																	<ValueToLog classname='ExprValue'>
-																		<value/>
-																	</ValueToLog>
-																	<Condition classname='ExprValue'>
-																		<value/>
-																	</Condition>
-																	<Flags classname='Num'>
-																		<value>8192</value>
-																	</Flags>
-																	<CheckedState classname='Num'>
-																		<value>2</value>
-																	</CheckedState>
-																	<Type classname='PropertyObjectType'>
-																		<subprops>
-																			<ValueType classname='Num'>
-																				<value>3</value>
-																			</ValueType>
-																			<IsObject classname='Bool'>
-																				<value>true</value>
-																			</IsObject>
-																			<TypeName classname='Str'>
-																				<value/>
-																			</TypeName>
-																			<ElementType classname='Objs'>
-																				<value lbound='[0]' ubound='[]'/>
-																			</ElementType>
-																			<ArrayDimensions classname='ArrayDimensions'>
-																				<subprops>
-																					<LowerBounds classname='Nums'>
-																						<value lbound='[0]' ubound='[]'/>
-																					</LowerBounds>
-																					<UpperBounds classname='Nums'>
-																						<value lbound='[0]' ubound='[]'/>
-																					</UpperBounds>
-																				</subprops>
-																			</ArrayDimensions>
-																			<Representation classname='Num'>
-																				<value>1</value>
-																			</Representation>
-																			<ClassName classname='Str'>
-																				<value/>
-																			</ClassName>
-																		</subprops>
-																	</Type>
-																	<Elements classname='Objs'>
-																		<value lbound='[0]' ubound='[]'/>
-																	</Elements>
-																	<IsAnyType classname='Bool'>
-																		<value>true</value>
-																	</IsAnyType>
-																</subprops>
-															</_NAME_IN_ATTRIBUTE_>
-														</elemproto>
-													</value>
-												</CustomResults>
-												<AdditionalResultsHints classname='Objs'>
-													<value lbound='[0]' ubound='[]'>
-														<elemproto>
-															<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-																<subprops>
-																	<Name classname='ExprValue'>
-																		<value/>
-																	</Name>
-																	<ValueToLog classname='ExprValue'>
-																		<value/>
-																	</ValueToLog>
-																	<Condition classname='ExprValue'>
-																		<value/>
-																	</Condition>
-																	<Flags classname='Num'>
-																		<value>8192</value>
-																	</Flags>
-																	<CheckedState classname='Num'>
-																		<value>2</value>
-																	</CheckedState>
-																	<Type classname='PropertyObjectType'>
-																		<subprops>
-																			<ValueType classname='Num'>
-																				<value>3</value>
-																			</ValueType>
-																			<IsObject classname='Bool'>
-																				<value>true</value>
-																			</IsObject>
-																			<TypeName classname='Str'>
-																				<value/>
-																			</TypeName>
-																			<ElementType classname='Objs'>
-																				<value lbound='[0]' ubound='[]'/>
-																			</ElementType>
-																			<ArrayDimensions classname='ArrayDimensions'>
-																				<subprops>
-																					<LowerBounds classname='Nums'>
-																						<value lbound='[0]' ubound='[]'/>
-																					</LowerBounds>
-																					<UpperBounds classname='Nums'>
-																						<value lbound='[0]' ubound='[]'/>
-																					</UpperBounds>
-																				</subprops>
-																			</ArrayDimensions>
-																			<Representation classname='Num'>
-																				<value>1</value>
-																			</Representation>
-																			<ClassName classname='Str'>
-																				<value/>
-																			</ClassName>
-																		</subprops>
-																	</Type>
-																	<Elements classname='Objs'>
-																		<value lbound='[0]' ubound='[]'/>
-																	</Elements>
-																	<IsAnyType classname='Bool'>
-																		<value>true</value>
-																	</IsAnyType>
-																</subprops>
-															</_NAME_IN_ATTRIBUTE_>
-														</elemproto>
-													</value>
-												</AdditionalResultsHints>
-											</subprops>
-										</TS>
-										<Result classname='Obj'>
-											<subprops>
-												<Error classname='Obj'>
-													<subprops>
-														<Code classname='Num'>
-															<value>0</value>
-														</Code>
-														<Msg classname='Str'>
-															<value/>
-														</Msg>
-														<Occurred classname='Bool'>
-															<value>false</value>
-														</Occurred>
-													</subprops>
-												</Error>
-												<Status classname='Str'>
-													<value/>
-												</Status>
-												<ReportText classname='Str'>
-													<value/>
-												</ReportText>
-												<Common classname='Obj'/>
-											</subprops>
-										</Result>
-									</subprops>
-								</Step>
-							</value>
-							<value>
-								<Step typename='PostSubstep' xsi:type='PostSubstep' name='Post'>
-									<subprops>
-										<TS classname='Obj'>
-											<subprops>
-												<Id classname='Str'>
-													<value>ID#:MS2zjF1W7BGpWXoj8F8wtC</value>
-												</Id>
-												<Icon classname='Str'>
-													<value/>
-												</Icon>
-												<SData typename='DotNetStepAdditions' xsi:type='DotNetStepAdditions' classname='DotNetModule' structureflags='2097152'>
-													<subprops>
-														<Calls classname='Objs'>
-															<value lbound='[0]' ubound='[1]'>
-																<elemproto>
-																	<_NAME_IN_ATTRIBUTE_ name='' classname='DotNetCall' structureflags='0'/>
-																</elemproto>
-																<value>
-																	<DotNetCall typename='DotNetCall' xsi:type='DotNetCall' name=''>
-																		<subprops>
-																			<ClassName classname='Str'>
-																				<value>NationalInstruments.MeasurementLink.MeasurementStepExecution</value>
-																			</ClassName>
-																			<MemberType classname='Num'>
-																				<value>4</value>
-																			</MemberType>
-																			<Static classname='Bool'>
-																				<value>false</value>
-																			</Static>
-																			<MemberName classname='Str'>
-																				<value>MeasurementStepExecution</value>
-																			</MemberName>
-																			<Params classname='Objs'>
-																				<value lbound='[0]' ubound='[0]'>
-																					<elemproto>
-																						<_NAME_IN_ATTRIBUTE_ name='' classname='DotNetParameter' structureflags='0'/>
-																					</elemproto>
-																					<value>
-																						<DotNetParameter typename='DotNetParameter' xsi:type='DotNetParameter' name=''>
-																							<subprops>
-																								<Name classname='Str'>
-																									<value>Return Value</value>
-																								</Name>
-																								<ArgVal classname='ExprValue'>
-																									<value/>
-																								</ArgVal>
-																								<ArgDisplayVal classname='ExprValue'>
-																									<value/>
-																								</ArgDisplayVal>
-																								<Type classname='Num'>
-																									<value>0</value>
-																								</Type>
-																								<TypeName classname='Str'>
-																									<value>NationalInstruments.MeasurementLink.MeasurementStepExecution</value>
-																								</TypeName>
-																								<Flags classname='Num'>
-																									<value>6</value>
-																								</Flags>
-																								<IsOptional classname='Bool'>
-																									<value>false</value>
-																								</IsOptional>
-																								<CallDispose classname='Bool'>
-																									<value>true</value>
-																								</CallDispose>
-																								<NumDimensions classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</NumDimensions>
-																								<MultiElement classname='Objs'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</MultiElement>
-																								<AdditionalResults classname='Obj'>
-																									<subprops>
-																										<Input classname='DotNetParameterResult'>
-																											<subprops>
-																												<Condition classname='ExprValue'>
-																													<value/>
-																												</Condition>
-																												<Flags classname='Num'>
-																													<value>8192</value>
-																												</Flags>
-																												<CheckedState classname='Num'>
-																													<value>1</value>
-																												</CheckedState>
-																											</subprops>
-																										</Input>
-																										<Output classname='DotNetParameterResult'>
-																											<subprops>
-																												<Condition classname='ExprValue'>
-																													<value/>
-																												</Condition>
-																												<Flags classname='Num'>
-																													<value>8192</value>
-																												</Flags>
-																												<CheckedState classname='Num'>
-																													<value>1</value>
-																												</CheckedState>
-																											</subprops>
-																										</Output>
-																									</subprops>
-																								</AdditionalResults>
-																							</subprops>
-																						</DotNetParameter>
-																					</value>
-																				</value>
-																			</Params>
-																			<AdditionalResult classname='DotNetCallResult'>
-																				<subprops>
-																					<Condition classname='ExprValue'>
-																						<value/>
-																					</Condition>
-																					<Flags classname='Num'>
-																						<value>8192</value>
-																					</Flags>
-																					<CheckedState classname='Num'>
-																						<value>1</value>
-																					</CheckedState>
-																				</subprops>
-																			</AdditionalResult>
-																		</subprops>
-																	</DotNetCall>
-																</value>
-																<value>
-																	<DotNetCall typename='DotNetCall' xsi:type='DotNetCall' name=''>
-																		<subprops>
-																			<ClassName classname='Str'>
-																				<value>NationalInstruments.MeasurementLink.MeasurementStepExecution</value>
-																			</ClassName>
-																			<MemberType classname='Num'>
-																				<value>1</value>
-																			</MemberType>
-																			<Static classname='Bool'>
-																				<value>false</value>
-																			</Static>
-																			<MemberName classname='Str'>
-																				<value>Execute</value>
-																			</MemberName>
-																			<Params classname='Objs'>
-																				<value lbound='[0]' ubound='[0]'>
-																					<elemproto>
-																						<_NAME_IN_ATTRIBUTE_ name='' classname='DotNetParameter' structureflags='0'/>
-																					</elemproto>
-																					<value>
-																						<DotNetParameter typename='DotNetParameter' xsi:type='DotNetParameter' name=''>
-																							<subprops>
-																								<Name classname='Str'>
-																									<value>sequenceContext</value>
-																								</Name>
-																								<ArgVal classname='ExprValue'>
-																									<value>ThisContext</value>
-																								</ArgVal>
-																								<ArgDisplayVal classname='ExprValue'>
-																									<value/>
-																								</ArgDisplayVal>
-																								<Type classname='Num'>
-																									<value>0</value>
-																								</Type>
-																								<TypeName classname='Str'>
-																									<value>NationalInstruments.TestStand.Interop.API.SequenceContext</value>
-																								</TypeName>
-																								<Flags classname='Num'>
-																									<value>0</value>
-																								</Flags>
-																								<IsOptional classname='Bool'>
-																									<value>false</value>
-																								</IsOptional>
-																								<CallDispose classname='Bool'>
-																									<value>false</value>
-																								</CallDispose>
-																								<NumDimensions classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</NumDimensions>
-																								<MultiElement classname='Objs'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</MultiElement>
-																								<AdditionalResults classname='Obj'>
-																									<subprops>
-																										<Input classname='DotNetParameterResult'>
-																											<subprops>
-																												<Condition classname='ExprValue'>
-																													<value/>
-																												</Condition>
-																												<Flags classname='Num'>
-																													<value>8192</value>
-																												</Flags>
-																												<CheckedState classname='Num'>
-																													<value>1</value>
-																												</CheckedState>
-																											</subprops>
-																										</Input>
-																										<Output classname='DotNetParameterResult'>
-																											<subprops>
-																												<Condition classname='ExprValue'>
-																													<value/>
-																												</Condition>
-																												<Flags classname='Num'>
-																													<value>8192</value>
-																												</Flags>
-																												<CheckedState classname='Num'>
-																													<value>1</value>
-																												</CheckedState>
-																											</subprops>
-																										</Output>
-																									</subprops>
-																								</AdditionalResults>
-																							</subprops>
-																						</DotNetParameter>
-																					</value>
-																				</value>
-																			</Params>
-																			<AdditionalResult classname='DotNetCallResult'>
-																				<subprops>
-																					<Condition classname='ExprValue'>
-																						<value/>
-																					</Condition>
-																					<Flags classname='Num'>
-																						<value>8192</value>
-																					</Flags>
-																					<CheckedState classname='Num'>
-																						<value>1</value>
-																					</CheckedState>
-																				</subprops>
-																			</AdditionalResult>
-																		</subprops>
-																	</DotNetCall>
-																</value>
-															</value>
-														</Calls>
-														<AssemblyPath classname='PathValue'>
-															<value>NationalInstruments.MeasurementLink.TestStandMeasurementClient.dll</value>
-														</AssemblyPath>
-														<AssemblyStrongName classname='Str'>
-															<value/>
-														</AssemblyStrongName>
-														<AssemblyLocation classname='Num'>
-															<value>0</value>
-														</AssemblyLocation>
-														<ClassName classname='Str'>
-															<value>NationalInstruments.MeasurementLink.MeasurementStepExecution</value>
-														</ClassName>
-														<IsStruct classname='Bool'>
-															<value>false</value>
-														</IsStruct>
-														<StructDef classname='DotNetParameter'>
-															<subprops>
-																<Name classname='Str'>
-																	<value>_notNamed</value>
-																</Name>
-																<ArgVal classname='ExprValue'>
-																	<value/>
-																</ArgVal>
-																<ArgDisplayVal classname='ExprValue'>
-																	<value/>
-																</ArgDisplayVal>
-																<Type classname='Num'>
-																	<value>0</value>
-																</Type>
-																<TypeName classname='Str'>
-																	<value/>
-																</TypeName>
-																<Flags classname='Num'>
-																	<value>0</value>
-																</Flags>
-																<IsOptional classname='Bool'>
-																	<value>false</value>
-																</IsOptional>
-																<CallDispose classname='Bool'>
-																	<value>false</value>
-																</CallDispose>
-																<NumDimensions classname='Nums'>
-																	<value lbound='[0]' ubound='[]'/>
-																</NumDimensions>
-																<MultiElement classname='Objs'>
-																	<value lbound='[0]' ubound='[]'/>
-																</MultiElement>
-																<AdditionalResults classname='Obj'>
-																	<subprops>
-																		<Input classname='DotNetParameterResult'>
-																			<subprops>
-																				<Condition classname='ExprValue'>
-																					<value/>
-																				</Condition>
-																				<Flags classname='Num'>
-																					<value>8192</value>
-																				</Flags>
-																				<CheckedState classname='Num'>
-																					<value>1</value>
-																				</CheckedState>
-																			</subprops>
-																		</Input>
-																		<Output classname='DotNetParameterResult'>
-																			<subprops>
-																				<Condition classname='ExprValue'>
-																					<value/>
-																				</Condition>
-																				<Flags classname='Num'>
-																					<value>8192</value>
-																				</Flags>
-																				<CheckedState classname='Num'>
-																					<value>1</value>
-																				</CheckedState>
-																			</subprops>
-																		</Output>
-																	</subprops>
-																</AdditionalResults>
-															</subprops>
-														</StructDef>
-														<RemoteSpecifiedByExpr classname='Bool'>
-															<value>false</value>
-														</RemoteSpecifiedByExpr>
-														<UseLoadSpec classname='Bool'>
-															<value>true</value>
-														</UseLoadSpec>
-														<ModuleSrcPath classname='PathValue'>
-															<value/>
-														</ModuleSrcPath>
-														<ModulePrjPath classname='PathValue'>
-															<value/>
-														</ModulePrjPath>
-														<ModuleSlnPath classname='PathValue'>
-															<value/>
-														</ModuleSlnPath>
-														<FunctionName classname='Str'>
-															<value/>
-														</FunctionName>
-													</subprops>
-												</SData>
-												<PreCond classname='ExprValue'>
-													<value/>
-												</PreCond>
-												<LoadOpt classname='Str'>
-													<value>PreloadWhenExecuted</value>
-												</LoadOpt>
-												<UnloadOpt classname='Str'>
-													<value>UnloadWithFile</value>
-												</UnloadOpt>
-												<Mode classname='Str'>
-													<value>Normal</value>
-												</Mode>
-												<WindowActivation classname='Str'>
-													<value>None</value>
-												</WindowActivation>
-												<ResultOption classname='Num'>
-													<value>1</value>
-												</ResultOption>
-												<StepFCSeqF classname='Bool'>
-													<value>true</value>
-												</StepFCSeqF>
-												<IgnoreRTE classname='Bool'>
-													<value>false</value>
-												</IgnoreRTE>
-												<UseMutex classname='Bool'>
-													<value>false</value>
-												</UseMutex>
-												<MutexNameOrRef classname='ExprValue'>
-													<value/>
-												</MutexNameOrRef>
-												<BatchSyncOpt classname='Num'>
-													<value>0</value>
-												</BatchSyncOpt>
-												<SwitchEnabled classname='Bool'>
-													<value>false</value>
-												</SwitchEnabled>
-												<VirtualDeviceName classname='ExprValue'>
-													<value/>
-												</VirtualDeviceName>
-												<SwitchOperation classname='Num'>
-													<value>1</value>
-												</SwitchOperation>
-												<RouteGroupConnect classname='ExprValue'>
-													<value/>
-												</RouteGroupConnect>
-												<RouteGroupDisconnect classname='ExprValue'>
-													<value/>
-												</RouteGroupDisconnect>
-												<MulticonnectMode classname='Num'>
-													<value>1</value>
-												</MulticonnectMode>
-												<OperationOrder classname='Num'>
-													<value>2</value>
-												</OperationOrder>
-												<ConnectionLifetime classname='Num'>
-													<value>4</value>
-												</ConnectionLifetime>
-												<WaitForDebounce classname='Bool'>
-													<value>true</value>
-												</WaitForDebounce>
-												<PassAct classname='Str'>
-													<value>Next</value>
-												</PassAct>
-												<FailAct classname='Str'>
-													<value>Next</value>
-												</FailAct>
-												<PassActTarget classname='ExprValue'>
-													<value/>
-												</PassActTarget>
-												<FailActTarget classname='ExprValue'>
-													<value/>
-												</FailActTarget>
-												<CustExpr classname='ExprValue'>
-													<value/>
-												</CustExpr>
-												<CustTrueAct classname='Str'>
-													<value>Next</value>
-												</CustTrueAct>
-												<CustFalseAct classname='Str'>
-													<value>Next</value>
-												</CustFalseAct>
-												<CustTrueActTarget classname='ExprValue'>
-													<value/>
-												</CustTrueActTarget>
-												<CustFalseActTarget classname='ExprValue'>
-													<value/>
-												</CustFalseActTarget>
-												<LoopType classname='Str'>
-													<value>NoLooping</value>
-												</LoopType>
-												<LoopWhile classname='ExprValue'>
-													<value/>
-												</LoopWhile>
-												<LoopStatus classname='ExprValue'>
-													<value/>
-												</LoopStatus>
-												<LoopIncrement classname='ExprValue'>
-													<value>RunState.LoopIndex += 1</value>
-												</LoopIncrement>
-												<LoopInitialize classname='ExprValue'>
-													<value>RunState.LoopIndex = 0</value>
-												</LoopInitialize>
-												<LoopOpt classname='Num'>
-													<value>0</value>
-												</LoopOpt>
-												<PreExpr classname='ExprValue'>
-													<value/>
-												</PreExpr>
-												<PostExpr classname='ExprValue'>
-													<value/>
-												</PostExpr>
-												<StatusExpr classname='ExprValue'>
-													<value/>
-												</StatusExpr>
-												<CanSpecifyModule classname='Bool'>
-													<value>true</value>
-												</CanSpecifyModule>
-												<CanEditCode classname='Bool'>
-													<value>true</value>
-												</CanEditCode>
-												<CanEditModulePrototype classname='Bool'>
-													<value>true</value>
-												</CanEditModulePrototype>
-												<CanEditParameterAdditionalResults classname='Bool'>
-													<value>true</value>
-												</CanEditParameterAdditionalResults>
-												<PrecondIntExe classname='Num'>
-													<value>0</value>
-												</PrecondIntExe>
-												<CustomResults classname='Objs'>
-													<value lbound='[0]' ubound='[]'>
-														<elemproto>
-															<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-																<subprops>
-																	<Name classname='ExprValue'>
-																		<value/>
-																	</Name>
-																	<ValueToLog classname='ExprValue'>
-																		<value/>
-																	</ValueToLog>
-																	<Condition classname='ExprValue'>
-																		<value/>
-																	</Condition>
-																	<Flags classname='Num'>
-																		<value>8192</value>
-																	</Flags>
-																	<CheckedState classname='Num'>
-																		<value>2</value>
-																	</CheckedState>
-																	<Type classname='PropertyObjectType'>
-																		<subprops>
-																			<ValueType classname='Num'>
-																				<value>3</value>
-																			</ValueType>
-																			<IsObject classname='Bool'>
-																				<value>true</value>
-																			</IsObject>
-																			<TypeName classname='Str'>
-																				<value/>
-																			</TypeName>
-																			<ElementType classname='Objs'>
-																				<value lbound='[0]' ubound='[]'/>
-																			</ElementType>
-																			<ArrayDimensions classname='ArrayDimensions'>
-																				<subprops>
-																					<LowerBounds classname='Nums'>
-																						<value lbound='[0]' ubound='[]'/>
-																					</LowerBounds>
-																					<UpperBounds classname='Nums'>
-																						<value lbound='[0]' ubound='[]'/>
-																					</UpperBounds>
-																				</subprops>
-																			</ArrayDimensions>
-																			<Representation classname='Num'>
-																				<value>1</value>
-																			</Representation>
-																			<ClassName classname='Str'>
-																				<value/>
-																			</ClassName>
-																		</subprops>
-																	</Type>
-																	<Elements classname='Objs'>
-																		<value lbound='[0]' ubound='[]'/>
-																	</Elements>
-																	<IsAnyType classname='Bool'>
-																		<value>true</value>
-																	</IsAnyType>
-																</subprops>
-															</_NAME_IN_ATTRIBUTE_>
-														</elemproto>
-													</value>
-												</CustomResults>
-												<AdditionalResultsHints classname='Objs'>
-													<value lbound='[0]' ubound='[]'>
-														<elemproto>
-															<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-																<subprops>
-																	<Name classname='ExprValue'>
-																		<value/>
-																	</Name>
-																	<ValueToLog classname='ExprValue'>
-																		<value/>
-																	</ValueToLog>
-																	<Condition classname='ExprValue'>
-																		<value/>
-																	</Condition>
-																	<Flags classname='Num'>
-																		<value>8192</value>
-																	</Flags>
-																	<CheckedState classname='Num'>
-																		<value>2</value>
-																	</CheckedState>
-																	<Type classname='PropertyObjectType'>
-																		<subprops>
-																			<ValueType classname='Num'>
-																				<value>3</value>
-																			</ValueType>
-																			<IsObject classname='Bool'>
-																				<value>true</value>
-																			</IsObject>
-																			<TypeName classname='Str'>
-																				<value/>
-																			</TypeName>
-																			<ElementType classname='Objs'>
-																				<value lbound='[0]' ubound='[]'/>
-																			</ElementType>
-																			<ArrayDimensions classname='ArrayDimensions'>
-																				<subprops>
-																					<LowerBounds classname='Nums'>
-																						<value lbound='[0]' ubound='[]'/>
-																					</LowerBounds>
-																					<UpperBounds classname='Nums'>
-																						<value lbound='[0]' ubound='[]'/>
-																					</UpperBounds>
-																				</subprops>
-																			</ArrayDimensions>
-																			<Representation classname='Num'>
-																				<value>1</value>
-																			</Representation>
-																			<ClassName classname='Str'>
-																				<value/>
-																			</ClassName>
-																		</subprops>
-																	</Type>
-																	<Elements classname='Objs'>
-																		<value lbound='[0]' ubound='[]'/>
-																	</Elements>
-																	<IsAnyType classname='Bool'>
-																		<value>true</value>
-																	</IsAnyType>
-																</subprops>
-															</_NAME_IN_ATTRIBUTE_>
-														</elemproto>
-													</value>
-												</AdditionalResultsHints>
-											</subprops>
-										</TS>
-										<Result classname='Obj'>
-											<subprops>
-												<Error classname='Obj'>
-													<subprops>
-														<Code classname='Num'>
-															<value>0</value>
-														</Code>
-														<Msg classname='Str'>
-															<value/>
-														</Msg>
-														<Occurred classname='Bool'>
-															<value>false</value>
-														</Occurred>
-													</subprops>
-												</Error>
-												<Status classname='Str'>
-													<value/>
-												</Status>
-												<ReportText classname='Str'>
-													<value/>
-												</ReportText>
-												<Common classname='Obj'/>
-											</subprops>
-										</Result>
-									</subprops>
-								</Step>
-							</value>
-						</value>
-					</Substeps>
-					<CodeTemplates classname='Str' valueflags='4194328' structureflags='524288'>
-						<value>DefaultLabVIEWNXG|DefaultLabVIEW|DefaultCVI|DefaultVB.NET|DefaultCSharp.NET|DefaultC++.NET|DefaultVC++_Template|DefaultHTB72_Template|DefaultHTB80_Template|Default_Template</value>
-					</CodeTemplates>
-					<AdditionalResultsHints classname='Objs' valueflags='4194328' structureflags='524288'>
-						<value lbound='[0]' ubound='[]'>
-							<elemproto>
-								<_NAME_IN_ATTRIBUTE_ typename='NI_CustomResult' xsi:type='NI_CustomResult' name='' classname='CustomResult'>
-									<subprops>
-										<Name classname='ExprValue'>
-											<value/>
-										</Name>
-										<ValueToLog classname='ExprValue'>
-											<value/>
-										</ValueToLog>
-										<Condition classname='ExprValue'>
-											<value/>
-										</Condition>
-										<Flags classname='Num'>
-											<value>8192</value>
-										</Flags>
-										<CheckedState classname='Num'>
-											<value>2</value>
-										</CheckedState>
-										<Type classname='PropertyObjectType'>
-											<subprops>
-												<ValueType classname='Num'>
-													<value>3</value>
-												</ValueType>
-												<IsObject classname='Bool'>
-													<value>true</value>
-												</IsObject>
-												<TypeName classname='Str'>
-													<value/>
-												</TypeName>
-												<ElementType classname='Objs'>
-													<value lbound='[0]' ubound='[]'/>
-												</ElementType>
-												<ArrayDimensions classname='ArrayDimensions'>
-													<subprops>
-														<LowerBounds classname='Nums'>
-															<value lbound='[0]' ubound='[]'/>
-														</LowerBounds>
-														<UpperBounds classname='Nums'>
-															<value lbound='[0]' ubound='[]'/>
-														</UpperBounds>
-													</subprops>
-												</ArrayDimensions>
-												<Representation classname='Num'>
-													<value>1</value>
-												</Representation>
-												<ClassName classname='Str'>
-													<value/>
-												</ClassName>
-											</subprops>
-										</Type>
-										<Elements classname='Objs'>
-											<value lbound='[0]' ubound='[]'/>
-										</Elements>
-										<IsAnyType classname='Bool'>
-											<value>true</value>
-										</IsAnyType>
-									</subprops>
-								</_NAME_IN_ATTRIBUTE_>
-							</elemproto>
-						</value>
-					</AdditionalResultsHints>
-					<TS typename='TEInf' xsi:type='TEInf' classname='Obj' flagsforinstances='262168'>
-						<subprops>
-							<Id classname='Str'>
-								<value/>
-							</Id>
-							<Icon classname='Str'>
-								<value>Measurement\Measurement.ico</value>
-							</Icon>
-							<SData typename='NoneStepAdditions' xsi:type='NoneStepAdditions' classname='NoneModule' flagsforinstances='2097152' instanceoverrideflags='7274521' structureflags='2097152'/>
-							<PreCond classname='ExprValue'>
-								<value/>
-							</PreCond>
-							<LoadOpt classname='Str'>
-								<value>PreloadWhenExecuted</value>
-							</LoadOpt>
-							<UnloadOpt classname='Str'>
-								<value>UnloadWithFile</value>
-							</UnloadOpt>
-							<Mode classname='Str'>
-								<value>Normal</value>
-							</Mode>
-							<WindowActivation classname='Str'>
-								<value>None</value>
-							</WindowActivation>
-							<ResultOption classname='Num'>
-								<value>1</value>
-							</ResultOption>
-							<StepFCSeqF classname='Bool'>
-								<value>true</value>
-							</StepFCSeqF>
-							<IgnoreRTE classname='Bool'>
-								<value>false</value>
-							</IgnoreRTE>
-							<UseMutex classname='Bool'>
-								<value>false</value>
-							</UseMutex>
-							<MutexNameOrRef classname='ExprValue'>
-								<value/>
-							</MutexNameOrRef>
-							<BatchSyncOpt classname='Num'>
-								<value>0</value>
-							</BatchSyncOpt>
-							<SwitchEnabled classname='Bool'>
-								<value>false</value>
-							</SwitchEnabled>
-							<VirtualDeviceName classname='ExprValue'>
-								<value/>
-							</VirtualDeviceName>
-							<SwitchOperation classname='Num'>
-								<value>1</value>
-							</SwitchOperation>
-							<RouteGroupConnect classname='ExprValue'>
-								<value/>
-							</RouteGroupConnect>
-							<RouteGroupDisconnect classname='ExprValue'>
-								<value/>
-							</RouteGroupDisconnect>
-							<MulticonnectMode classname='Num'>
-								<value>1</value>
-							</MulticonnectMode>
-							<OperationOrder classname='Num'>
-								<value>2</value>
-							</OperationOrder>
-							<ConnectionLifetime classname='Num'>
-								<value>4</value>
-							</ConnectionLifetime>
-							<WaitForDebounce classname='Bool'>
-								<value>true</value>
-							</WaitForDebounce>
-							<PassAct classname='Str'>
-								<value>Next</value>
-							</PassAct>
-							<FailAct classname='Str'>
-								<value>Next</value>
-							</FailAct>
-							<PassActTarget classname='ExprValue'>
-								<value/>
-							</PassActTarget>
-							<FailActTarget classname='ExprValue'>
-								<value/>
-							</FailActTarget>
-							<CustExpr classname='ExprValue'>
-								<value/>
-							</CustExpr>
-							<CustTrueAct classname='Str'>
-								<value>Next</value>
-							</CustTrueAct>
-							<CustFalseAct classname='Str'>
-								<value>Next</value>
-							</CustFalseAct>
-							<CustTrueActTarget classname='ExprValue'>
-								<value/>
-							</CustTrueActTarget>
-							<CustFalseActTarget classname='ExprValue'>
-								<value/>
-							</CustFalseActTarget>
-							<LoopType classname='Str'>
-								<value>NoLooping</value>
-							</LoopType>
-							<LoopWhile classname='ExprValue'>
-								<value/>
-							</LoopWhile>
-							<LoopStatus classname='ExprValue'>
-								<value/>
-							</LoopStatus>
-							<LoopIncrement classname='ExprValue'>
-								<value>RunState.LoopIndex += 1</value>
-							</LoopIncrement>
-							<LoopInitialize classname='ExprValue'>
-								<value>RunState.LoopIndex = 0</value>
-							</LoopInitialize>
-							<LoopOpt classname='Num'>
-								<value>0</value>
-							</LoopOpt>
-							<PreExpr classname='ExprValue'>
-								<value/>
-							</PreExpr>
-							<PostExpr classname='ExprValue'>
-								<value/>
-							</PostExpr>
-							<StatusExpr classname='ExprValue'>
-								<value/>
-							</StatusExpr>
-							<CanSpecifyModule classname='Bool' valueflags='131072' structureflags='131072'>
-								<value>true</value>
-							</CanSpecifyModule>
-							<CanEditCode classname='Bool'>
-								<value>true</value>
-							</CanEditCode>
-							<CanEditModulePrototype classname='Bool'>
-								<value>true</value>
-							</CanEditModulePrototype>
-							<CanEditParameterAdditionalResults classname='Bool'>
-								<value>true</value>
-							</CanEditParameterAdditionalResults>
-							<PrecondIntExe classname='Num'>
-								<value>0</value>
-							</PrecondIntExe>
-							<Requirements classname='Obj' flagsforinstances='1' valueflags='1' structureflags='2097152'>
-								<subprops>
-									<Links classname='Strs' flagsforinstances='71303168' instanceoverrideflags='72286233' valueflags='71303168'>
-										<value lbound='[0]' ubound='[]'/>
-									</Links>
-								</subprops>
-							</Requirements>
-							<CustomResults classname='Objs'>
-								<value lbound='[0]' ubound='[]'>
-									<elemproto>
-										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-											<subprops>
-												<Name classname='ExprValue'>
-													<value/>
-												</Name>
-												<ValueToLog classname='ExprValue'>
-													<value/>
-												</ValueToLog>
-												<Condition classname='ExprValue'>
-													<value/>
-												</Condition>
-												<Flags classname='Num'>
-													<value>8192</value>
-												</Flags>
-												<CheckedState classname='Num'>
-													<value>2</value>
-												</CheckedState>
-												<Type classname='PropertyObjectType'>
-													<subprops>
-														<ValueType classname='Num'>
-															<value>3</value>
-														</ValueType>
-														<IsObject classname='Bool'>
-															<value>true</value>
-														</IsObject>
-														<TypeName classname='Str'>
-															<value/>
-														</TypeName>
-														<ElementType classname='Objs'>
-															<value lbound='[0]' ubound='[]'/>
-														</ElementType>
-														<ArrayDimensions classname='ArrayDimensions'>
-															<subprops>
-																<LowerBounds classname='Nums'>
-																	<value lbound='[0]' ubound='[]'/>
-																</LowerBounds>
-																<UpperBounds classname='Nums'>
-																	<value lbound='[0]' ubound='[]'/>
-																</UpperBounds>
-															</subprops>
-														</ArrayDimensions>
-														<Representation classname='Num'>
-															<value>1</value>
-														</Representation>
-														<ClassName classname='Str'>
-															<value/>
-														</ClassName>
-													</subprops>
-												</Type>
-												<Elements classname='Objs'>
-													<value lbound='[0]' ubound='[]'/>
-												</Elements>
-												<IsAnyType classname='Bool'>
-													<value>true</value>
-												</IsAnyType>
-											</subprops>
-										</_NAME_IN_ATTRIBUTE_>
-									</elemproto>
-								</value>
-							</CustomResults>
-							<AdditionalResultsHints classname='Objs'>
-								<value lbound='[0]' ubound='[]'>
-									<elemproto>
-										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-											<subprops>
-												<Name classname='ExprValue'>
-													<value/>
-												</Name>
-												<ValueToLog classname='ExprValue'>
-													<value/>
-												</ValueToLog>
-												<Condition classname='ExprValue'>
-													<value/>
-												</Condition>
-												<Flags classname='Num'>
-													<value>8192</value>
-												</Flags>
-												<CheckedState classname='Num'>
-													<value>2</value>
-												</CheckedState>
-												<Type classname='PropertyObjectType'>
-													<subprops>
-														<ValueType classname='Num'>
-															<value>3</value>
-														</ValueType>
-														<IsObject classname='Bool'>
-															<value>true</value>
-														</IsObject>
-														<TypeName classname='Str'>
-															<value/>
-														</TypeName>
-														<ElementType classname='Objs'>
-															<value lbound='[0]' ubound='[]'/>
-														</ElementType>
-														<ArrayDimensions classname='ArrayDimensions'>
-															<subprops>
-																<LowerBounds classname='Nums'>
-																	<value lbound='[0]' ubound='[]'/>
-																</LowerBounds>
-																<UpperBounds classname='Nums'>
-																	<value lbound='[0]' ubound='[]'/>
-																</UpperBounds>
-															</subprops>
-														</ArrayDimensions>
-														<Representation classname='Num'>
-															<value>1</value>
-														</Representation>
-														<ClassName classname='Str'>
-															<value/>
-														</ClassName>
-													</subprops>
-												</Type>
-												<Elements classname='Objs'>
-													<value lbound='[0]' ubound='[]'/>
-												</Elements>
-												<IsAnyType classname='Bool'>
-													<value>true</value>
-												</IsAnyType>
-											</subprops>
-										</_NAME_IN_ATTRIBUTE_>
-									</elemproto>
-								</value>
-							</AdditionalResultsHints>
-						</subprops>
-					</TS>
-					<NI_Data typename='StepTypeNIData' xsi:type='StepTypeNIData' classname='Obj'>
-						<subprops>
-							<EditPanels classname='Strs'>
-								<value lbound='[0]' ubound='[0]'>
-									<value arrayindex='[0]'>NationalInstruments.MeasurementLink.TestStandMeasurementClient.dll|NationalInstruments.MeasurementLink.MeasurementStepPanelInfo</value>
-								</value>
-							</EditPanels>
-						</subprops>
-					</NI_Data>
-					<Result classname='Obj' flagsforinstances='4194304' valueflags='4194304'>
-						<subprops>
-							<Error typename='Error' xsi:type='Error' classname='Obj' flagsforinstances='4194304' valueflags='4194304'>
-								<subprops>
-									<Code classname='Num'>
-										<value>0</value>
-									</Code>
-									<Msg classname='Str'>
-										<value/>
-									</Msg>
-									<Occurred classname='Bool'>
-										<value>false</value>
-									</Occurred>
-								</subprops>
-							</Error>
-							<Status classname='Str' flagsforinstances='4194304' valueflags='4194304'>
-								<value/>
-							</Status>
-							<ReportText classname='Str' flagsforinstances='4194304' valueflags='4194304'>
-								<value/>
-							</ReportText>
-							<Common typename='CommonResults' xsi:type='CommonResults' classname='Obj'/>
-						</subprops>
-					</Result>
-					<CanEncapsulate classname='Bool' valueflags='4194328' structureflags='524288'>
-						<value>false</value>
-					</CanEncapsulate>
-					<Measurement classname='Obj' flagsforinstances='24'>
-						<subprops>
-							<Name classname='Str'>
-								<value/>
-							</Name>
-							<Parameters classname='Objs'>
-								<value lbound='[0]' ubound='[]'>
-									<elemproto>
-										<_NAME_IN_ATTRIBUTE_ typename='NI_MeasurementParameter' name='' classname='Obj'>
-											<subprops>
-												<Name classname='Str'>
-													<value/>
-												</Name>
-												<ArgumentValue classname='ExprValue'>
-													<value/>
-												</ArgumentValue>
-												<Direction classname='Str'>
-													<value/>
-												</Direction>
-												<Log classname='Bool'>
-													<value>false</value>
-												</Log>
-												<Dimension classname='Num'>
-													<value representation='UInt64'>0</value>
-												</Dimension>
-												<Type classname='Str'>
-													<value/>
-												</Type>
-												<ID classname='Num'>
-													<value representation='Int64'>0</value>
-												</ID>
-												<TypeSpecialization classname='Str'>
-													<value/>
-												</TypeSpecialization>
-											</subprops>
-										</_NAME_IN_ATTRIBUTE_>
-									</elemproto>
-								</value>
-							</Parameters>
-						</subprops>
-					</Measurement>
-				</subprops>
-			</NI_Measurement>
-		</typedef>
+		<protected>E@=3DJX4100hYLECF=cD@0@mKSEo_1KL_F1\27T`:Vj[VeF&lt;IHk9JiadX16MZ;_J&gt;IF\\oNI0P8K[eBRiD_OWonMbCH68W?Ej6HH^@m4QS@`K0=h9T1&lt;0PaQY&gt;ITBU1IX6C&lt;LBQCD:&lt;MGU&lt;8_B78S;jg^9]BlU;GU6Qh9gK_1OA4c=a7C2606Q79hL&lt;b9@R@T1?nR5o8`94_L;IIk`9T;ef25A8&lt;G;nd`9[5R`L5Y4lB&gt;]V;]cYlM6MI`;kP&gt;G:K\RIC9jI=XVM_0@b_eSQFjWW^&lt;m[H0i[Z5nV@kmeIO^:ij2V&gt;9cOfBSIN8ZAHJ9&lt;Gg[;oo\b3^&gt;JDf^__YgkgO1`m3cVA4nb^dfYLWn?2dd[4`AJPLd`Lk_L@oeMG41EECO^N8^2[n?jSnF9;5jDH9UjHf]A]JZhd\]T?GNDf60I=FF?f:dk?U^hJo[UODYBcBD[aXn_h0:md&lt;a_57k_OHj8&gt;fjYh=Ah?fGAS4NNaU^6CFj?gkOGdf@eI?&gt;;OUDUfIJo\^^Dc;&gt;S^XFZLGHAfj49EPKjoPEbibZUXDA0f6gak9YTnMlj8[nG\YQMJmSC7lE\njJ\NN[\ORnf[ZAQ]hjAHLT\G&lt;l_U&lt;NGnHLXe5nAeGcoojCKdEWeoYf:n&lt;3LW@8X</protected>
+		<protected>E@=3@Jc4110h]L]MGk_K3hBo3k7LAg`jl0V&gt;&gt;m4?ZlL]DC\B4kMO_J76J&gt;c7aKREM\6A6[;^;Tg=CRolUAjB8T7?mI]^IKR0;ACDh&lt;@LQBc3nn8=W=NlUh0CMdO`[l?&gt;@SDi1O@9&gt;iLlHgl8B]fLnYD=mM0g9lBlb_icfX`c\eIPPolgY:3`U:2o3ioLh\df_Oom@_KK;KmclQ]IIbRU_8V8P?KCh?9RiOISXRSH?]6hn;=69K517@W&lt;3?gSI`9BPRCWH6cPCllLL\S4Jg&gt;RhHI_j`_mnm]M]mMF`gP]bg158AF;ec]_YeffZgjID&lt;&gt;Dh?3YWM;bCg&gt;JQkkY[9i[=_2ZS9Fi]GVV?eLKJ_gjjMmmT\:K=ml9P&lt;VaPJnOfldhmmCoi6]f][e`dmbd:nmlAlcnCcoc;V7?Xl9co[&lt;^e_N?nN&lt;&gt;7LdgP3GoC3o&lt;eRW_AV7g377M5OoYmQ_nMkfRnobhaG\YFV&lt;RaUM&gt;GK4Ii_=N6O5Cf@M@0&gt;h=h2iC2WbVC]ihQd8AN4Z`lIhDRioVfM6WAB=?TBOi7NYT[T6gO1XjWhUm&gt;92emMI_OggJIkhGXbd0Wg&gt;XO&gt;cF&lt;Xbo1@BiMRkPJWk3SKm2RMg9Ea_W:IkMVM&gt;gXKgLW^5blEc[;D=Ri`O?a&gt;67^S[[o1IPDllk0J?^O_7oPmLlfigS\BAOV&lt;&gt;^[6GSoQ5io]iAoIP9Woj=WD&lt;N6d=^I]XFVkgFFNl&gt;N[nm]eJYPJ9f&lt;IC`N5Fa7G&lt;NT=RW_&lt;9`Y&lt;ZS6fLY&gt;:=B&gt;o3Ug:mP@?oki_L7VAldDHh^]:615VJ6[DFQ2h8llEj`VI:ia&gt;0H3G5&gt;Z@oT2DgO4j9b[]jEGd:^Z;kgSDT\jD2CC&gt;Lo:H=FEgA6Y1[dEIFF4CBGVFDEk;5_:m^A6C7^a2]M4mHU`RIlBiRTUNn&gt;QU=S0dW3@6l_d`dE:3fB0nlO;=^6_gh_o[KQDh`V9Ng4T`L:7Z]TjjcUhW4R21=Zj&lt;BQ:iP51CjhQ9o6MhV3XRfeb\m0=R&lt;CKDiECh:Z`iR&lt;QF;UaceY\R9WmUXZAb[g[C&lt;7fRGVY\AP=lWIG7QX8l:66fCP&lt;j2SIfbYGhg1hBONN^n_fejc]a&lt;oUdOC&lt;EZaK]4Ua3&lt;XfIBF7EYbZT&lt;eHo&gt;n[B_XCfB=1bTe3l2W=U9WMT\=9Um2GGUHno7?D_go5nnjjj^mOoe2[oIeKWo\Bk_&gt;ijL2LTMcWLb&lt;:V1_k7^9OC3OZb9SPnCkKDSf\3hLk5T=R&gt;bK8jRKIHH=[9CVSO5C[U7h[EWC=jH_e_fhZ11VI=V:i?;PGeRZY\SGcUW8E3cRbM62i&lt;=N?b=Qo9_fBXln1JNOR?7gTIJ9GZ&lt;4oT[KdJTk&lt;Q]85IS&gt;n];LSBEGAQYo[fOBeD&lt;X5A99g;W=B?ZZXHg5hBOkPYgffd9C&lt;@oZjJRLZ]G^do^[8KJo?knDI3Qh04D]LF811Dh3`ckD[b[ffib^5@d7j1gT;;D0GfR\D&gt;TCZo0[BhAXDb&gt;9I;[KUSO&lt;iJlT:2Dhc4[FELW`@BR08SdU;LQYMgBQPJFa:J[9aHX6^Q^0m=J30Y7lMdC\P6mgS8Y1iHA&lt;NU96Mc:7;nVC2b6jO3G]?:QFbbK9AIYE[O\=MP]92;L55c&lt;;HYe2jR0M]E`&gt;BY[hmgMXbQi?VOC8ZB5\_T1LA5aooNBY75hn7ZiGHD8en?dDc0ZE1iU3Vf6;l]Y8R@@GQEH6:G;diVjc2o]3Cj18cTXIj8:AIeNXAI@9AM@83JBFbDA6BRSMKJFcXn;kRO4Z`H&gt;2AG7:6NP9Ch=?i=9d:EfbUBW;4_f73NGfQE]NY[;7KcE&gt;D95X?KkXahKfImE;SXae?CUe=G;HRb`VZLULDdiAc]&lt;lWd:V7c\bVmbFD=:e2;fZ\B6CC7Y5gc^kXPSN9ZY0PZiT7YebS0V_i@DHGk6C1oUCDKGPZJGRI_i@41@\aATiYI;UK\e=JZKdZ\VfXUZTQM0eF8Q[Y&lt;MT&gt;UFdVJR_d9Xdg\38WJ&gt;Q[&gt;UN;F@;DF8LZQ@?&lt;dU@R[mf9D3:@SdI3&gt;SmhaSH=he6]&lt;V@`AJS?ZmSTEILjXABb9eH8X9`CR5Ef36[G4=mYiREKb5jiVREO5hN96Z\\P:`2^AQgg;TA?@NGIRd?YncGSE?a7?^BTP=W=NUG2lQlXEHB5aNo&gt;lYaF@g7FF?[]S;oQF8HLOnAW@;^[QnR[PFPfdfV:USJHVlG\LQXK&gt;[bHXFaEf03PK52BDdAA\QdM\Dn[[&lt;DR1IXY]X9hDf5D5XLnWmCNja&gt;3MLbTgTB46a\V23QQb&gt;3lGoSoee5lHJAJ\HLX\J=5n&lt;f?Q2KDnTFEB38in&lt;0V&gt;knN4J]Wb^H:niJ=n8A1@`l]aoLIX?GkKYdai=g_67QWQnFE:@g?:CmkXN4FDBZ`E&lt;=^]0C&lt;VkP]OT:@&gt;Y4Th&lt;V5L&lt;C3]``D\9\TD=RPXH@93VhJ1BXeO?666&lt;22Rbd:82&lt;Hj[UI&gt;5_P5;6d0Q1G:@24T&lt;23AjNLU1P7J1R7JNSlj0APNHRXU69R@@8_0P]gmF2;HXn\:jKVULTZDKTEVfYUf98YgXB[IDNjfTR&gt;iYQ`VU&gt;&gt;m:[&gt;lEU2:UmoJJ30kJfB?e4L[985bKYJIOLlNEPJ7a3J]@i4mgoAdh_AX6aJ\26QenfLe4CN6&gt;YDDK6K[::VOK9226oQ4L@SBi1OEb;@g;l`]jWiUTi0jignJ[[FBSfc?Gjn4XkVZn6K=7a=6e4K[fZ1;aXYGQbIFKmZ=h0@h]&gt;S2V;CM2h6JV`2&gt;Cla`73g?85Ol2TCU&lt;RiOmFV6HK=of2mS&gt;LYiK4gnhAemPOhP1UACUEc`_8[kadgB93FN`bnCeaQB_DLoJCll2nml1jcoUV&lt;l`1R\9Tf0jKOVFUeZ5X@_4@Tb[JYaI`4Go2mIQkgW:59&lt;ik8M&lt;`Gie4f[hhc3@HM=7Tj\TPcTfE;bZ]LF5`X&lt;[j[WeN`99Iaj6=B9h\o0fm&gt;mZYSe:\;=nOfR9o3XASO`SH8R5W0oHN[Bd3h]hoXR&lt;_1_LFiXjZFf[E@TcIOiQVldl?njP@&gt;h7hKl=7ibRdZM\H@XE6nC=8W6L4gd3hLW9CRL?b3nZk6Y&lt;N[7A]3iQVWhbHNFUD5n@HPocd;SWbOj=m:BS3;D=Fm1^?PBT76HUjHR]F@Sc[c66cI_MEk4^?UBT97PP:Cg3^Q8]8a&gt;KQO6Q2OA7HoR&gt;WHX&lt;a6&lt;9o&gt;J08&lt;&gt;V_j[c5ihH]7\5;UDHgdC7oeF38PS4gDP\R4cd]R:G@81EBI7O1:Y&gt;i_FAh&lt;jaaV\b3ZRZHS\^l[YBZ:J8aAYI?LF70YWW\YCjHj7S;W[JQjHFmYafMk0MRRSe&lt;i97R^o3m=eP9Q8g5Wl^;N`YVmJ50:bR`jT6Ya&lt;FKW@B4AaHcjCn0JjE]CWG@;o9V?\U;TVHEnljbH0GPZ:SQaD^b\jNikkAKS:46h\0ffLEVA8&lt;2eH=2II1[Sjj8lEAdQX7h[H4BcZlUo3DGWej1UM^W:`l7d^dTH6PjFaBPcd51l7C1gnQh\`EoHUT50&gt;i2XW8U3Hah3GQHC6bh0o86b;g4gFD45VR3H?HHdM&gt;Im\cXjfR&lt;hVZd44;@@`GO_U`Vk::2MUfQhDiRQ;iPPUD:5_UUAo^DcLAjaG4dkQL@2_Q&lt;h6[eU\MV\::l2ljQKIBMnB]8&lt;3m8&lt;m=?&lt;9^_5iF\5Len;[WkHdP_foaY41M\jhA3?3\BWUGj&gt;:i9[&gt;?QUMY3&lt;XKKFLF&lt;[82956A8ZhQUR&lt;ifQ4bI5O@&lt;6b=3aOB`]eEJBSGF]Ccd=KK@36N\b_e5YF0^AT2=ma121V[cn99]G170DNCBY=@5?ea=54J&gt;[H1X5^GP;_Y&lt;B5&gt;GZ5e]96ZCg05R^@icDGg\iVA9iZRA:lXQEf@QZNX=FDP=ifEHe0CMBll6&lt;Z2=h[dClahh4R=SSSoDAe]2\[1HZVSecL6EFTbB8J[cGDH9elQ54S1FUQ;e2BSBci;ebWGVW?\7mW]7i[?BEnddfLUmOJcjFNcjfLehW\mUg^kF&gt;\bHE;1_2Q^4KECFhHNc1mYP3`&lt;N2ig^b9\j769f[28=4aQTLlFl=D3E6b\=_R=_^N5HTb&lt;J3=S;Y5HV:3F6i1nlc1CFk9[[cYl[&gt;F9?mbR@m\l1i5Q6l6O1dg?&lt;5Wg1::\dF9`TOGWHCRkD==]bV15k2RY8i`bV1oU\1]Fdf52TbkSJhEPVBLF[\d;\OjXn1IXockKoCf=nna;n5=_o1K^MYgSDlRO:U`?4BDZ;RDXkKjV]=j=`dYmJ4&lt;o\b?C8`Loi;5_7eKOmNoFA]?kioKmZXP&gt;?@OMEE_[\ImYeAE:HTO\;X:I0W;fe\U_o9GfQbgk`mFX[@m\g=ZKIG]]hfbgNkIK_F:ZQ?OkfIKJH[O\ihZROIOIcS5I`m3fEdU3JG6A=:kdY1=WiE;WhIW;]n:PVFmjf06cG\l1`6GZDU]dG;J:JZK=EVA5C\d;I6chmfOn&lt;d;nFMPO5^Hg&lt;L@nGR@8@^OaX`?HgXF45nR@=[d@j3WgS?HDOeV\neeEn:neZ__gQ?HH:]`?;H\g3A3IWiAkY61me30_i2CL7=YO9``_6H@l`\K6`f=3jk61Nm3P76;kY61ma3PKl&lt;\K&lt;6f=:36;Om30TnQP7P_O9``_7HXdWTm3\PB7`f=3kk61@6f^`\K6QJ1oK9dOfNi[Za=PUgoQj_leOgNBNl]MPgY9NkW]^mcf4\E?G5[_[lE?DejcgMO`g&gt;Kk^616]eWdeiIkm&gt;JcjFNcffLenBFN]cfLWF[]?i=6Tb_Hk8oNT`_HL\Hg:&lt;Zjkc5O5`PnoSRYPk45U=43e7hlMjHLfTJgVAlMNMTccCnHmI^daiKn@fkkVM^gI\b&lt;?_jXmN1eOhYLPmJ&gt;M^&gt;oMma73eUoMibZ_HoigZh[@l`^4b6?J&gt;hXQTlmM:olW5oOoV2WR9o?\?gk]RD^T;;]9BhfQZd;[A\YK;^B@\JN_W@E&gt;DjHeU]8oW3KU:g9kM64IUIh\V0k:FjnUXXH99l?I3gCA&lt;E`&lt;d=lA&lt;aYVa?YdS&lt;ZVl8AgkXP&lt;g:LJ69WLX^RR2;XTfCXag6Q7g@OooCHP=4l5n]G4?JU?0W&gt;h8[cQdWULnLZ;&gt;L4aHackI&lt;]JSiCNVXMlEP^la7T[f&lt;L13cd_mD7c?U&gt;ZFnG25NQ=BkES`Y&gt;ZZN^7;UD;k0C\T]]&lt;YV5`0o2b&lt;aYA7TbS5h;O3^lR@GRe:Em3lHjmgdJPNU`D6WSSah^_3@e_SHa8W8l[3dGOY_AaF7O&gt;MiSJBLBFDO:@BmBXEejGeI1O_DOLK^ToPOSBRN?nRN=0RX@l`EX@1VmeJ`^fnRDZXebH7SJGiJ`:15Q=k=]_im&gt;mn&gt;^RW=o6f5gSC^fO8@2=LR853\TP0cBJ0&lt;de@5j`0RQTV858WBST9H@QA9n@86MZBQ6Ad13dPT=h14d6A2bfi:&lt;&gt;;B3749M@iQ@@8;3STP;5So&lt;B1o2AQ21EmdA5nP0?62fmX3j&lt;D=1U0iZdPh4a=R1`_H0AgTj==2eAZPe=4b;c`ieQPiB1NR0P&gt;9FM7B&gt;1`274Ol3djf`lT6&lt;@]32L]TH1KChT=lZ431e4JhJ=IH1[0RA?0@86Yb`7I34V&lt;X]=GST0&lt;Qb&lt;2204`6O2CSPa9SQ4d1`dbVEE2OdAA_ZcBlFSU6&lt;45X==0LB&lt;7G2K`0@1\j02FU6A54O6a0^484FePE&lt;PPZ0B5f`I_8=:a4UX08DBC`:0I&gt;5Y6PXTP?Tb6&lt;7&gt;iA6YK8m4CV6n@6GY8XaPXBCJ090QP86VR6@GD2im]]fK[o35kiI_jf256S&lt;LdQUL:jlXXT6VN4;8;8RAI=0]R5K27fRR=HAP&lt;C08W2mm1g;2gD6Yd4QR4fSF?J_@C;SQ^mbbESk@OG9^I^gWgKK&lt;TF307_jkMm&gt;effE\hRcYJ]ACT&gt;?5_48RjZ2SPIa]6;FATF:&gt;]l=e1A=kPDV1J&gt;XP2kPlj7bZQ`[OXW0D\3&lt;QV=\T:]H8Ol4OS60Fa;m[CF:K3FRicE6C7[URWZU37Z[ZLUDI\PXH_FEJ2377WUW6V=&gt;F&lt;ZL8QBLPDdh0S9OAC1?@6JNZ:\a`USk;:iJ7Y8YZ]eVAWO[1LeCTMhd=n\HC;6Y7A7YF]eZ[3=6AWJEb7IE3WI=D_cFAYLhFdAbc5XJlQEnU[HgHKICM3o`]RF6]l`8;RhCRXh82Xn30845648B0JPBI[DH\S4J6U&lt;n6e:\FAR=6B[DIHSTl30XLA0QLhnd98Rg9nlU^&gt;9@3S29`leT&lt;IdI0If722n82&gt;;U`ahOEilDL:G\FRN\l=:jFTDi2TfN7EImHQJoJZlS]BD]oXOciWB4FmFfZ6dO\b&gt;Y=B4P5EAD1_iFlNJASLe7^9b&gt;@:`]PUjTToY]c8BF2V4`[`X11aBL2&lt;?9IARQ&lt;4cK[71AX4oXQ@_2h@;hmf90BM0De;:]6?]5@@Y`7&gt;V=UL5`PILYECZTYJ@=IfdV0bIPTf6djDZ8UJTch2Oh;;L8_HSlXn?Yfb5T&gt;GYNN59aJ8WV9I]c[K:AW]H[75m20L4ZgfDn&gt;&lt;gf62HQIJ6oT[K&gt;m:CfFl=&gt;9o;LiNS`PF\OV9ScUJCJ?Q5VlfM`5m`CNGh2;0K3Nh[eX_QFNh[5;Y\Wc]f2Q:akThimldSm_\_Pdm]583E;C\:FoP\8Ln=ZTXZ`i\;4F?f7f9&gt;oc1MhiR:D5YmQj3eLH:Tc3ce&gt;Vc4fDDRX]a5jA=bKK&lt;Cc\Mo7ceD&gt;`e</protected>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='22'>
-			<EditSubstep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1628813154' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
+			<EditSubstep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
 				<subprops>
 					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
 						<value>"%ModuleDescription"</value>
@@ -3824,7 +2105,7 @@
 			</EditSubstep>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='23'>
-			<NI_CommonCParameterResult classname='CommonCParameterResult' isroottypedef='true' typecategory='3' timestamp='1628813154' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_CommonCParameterResult classname='CommonCParameterResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
 						<value/>
@@ -3840,7 +2121,7 @@
 			</NI_CommonCParameterResult>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='24'>
-			<FCParameter classname='FCParameter' isroottypedef='true' typecategory='3' timestamp='1628813517' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<FCParameter classname='FCParameter' isroottypedef='true' typecategory='3' timestamp='1650060844' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Name classname='Str'>
 						<value>_notNamed</value>
@@ -3928,7 +2209,7 @@
 			</FCParameter>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='25'>
-			<FlexCStepAdditions classname='FCModule' isroottypedef='true' typecategory='3' timestamp='1628813517' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<FlexCStepAdditions classname='FCModule' isroottypedef='true' typecategory='3' timestamp='1650060844' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Call classname='ExternalCall'>
 						<subprops>
@@ -5740,7 +4021,7 @@
 			</Action>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='29'>
-			<NI_PythonParameterResult classname='PythonParameterResult' isroottypedef='true' typecategory='3' timestamp='1628813154' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_PythonParameterResult classname='PythonParameterResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
 						<value/>
@@ -5756,7 +4037,7 @@
 			</NI_PythonParameterResult>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='28'>
-			<NI_PythonParameter classname='CPythonParameter' isroottypedef='true' typecategory='3' timestamp='1628813556' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_PythonParameter classname='CPythonParameter' isroottypedef='true' typecategory='3' timestamp='1650060872' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Name classname='Str'>
 						<value>_notNamed</value>
@@ -5804,7 +4085,7 @@
 			</NI_PythonParameter>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='27'>
-			<PythonStepAdditions classname='CPythonModule' isroottypedef='true' typecategory='3' timestamp='1628813556' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<PythonStepAdditions classname='CPythonModule' isroottypedef='true' typecategory='3' timestamp='1650060872' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<PythonCall classname='CPythonCall'>
 						<subprops>
@@ -6269,7 +4550,7 @@
 																<value>ni.examples.NIFgenStandardFunction_Python</value>
 															</Name>
 															<Parameters classname='Objs'>
-																<value lbound='[0]' ubound='[5]'>
+																<value lbound='[0]' ubound='[4]'>
 																	<elemproto>
 																		<_NAME_IN_ATTRIBUTE_ name='' classname='Obj'>
 																			<subprops>
@@ -6313,7 +4594,7 @@
 																					<value>In</value>
 																				</Direction>
 																				<Log classname='Bool'>
-																					<value>false</value>
+																					<value>true</value>
 																				</Log>
 																				<Dimension classname='Num'>
 																					<value representation='UInt64'>0</value>
@@ -6343,7 +4624,7 @@
 																					<value>In</value>
 																				</Direction>
 																				<Log classname='Bool'>
-																					<value>false</value>
+																					<value>true</value>
 																				</Log>
 																				<Dimension classname='Num'>
 																					<value representation='UInt64'>0</value>
@@ -6373,7 +4654,7 @@
 																					<value>In</value>
 																				</Direction>
 																				<Log classname='Bool'>
-																					<value>false</value>
+																					<value>true</value>
 																				</Log>
 																				<Dimension classname='Num'>
 																					<value representation='UInt64'>0</value>
@@ -6403,7 +4684,7 @@
 																					<value>In</value>
 																				</Direction>
 																				<Log classname='Bool'>
-																					<value>false</value>
+																					<value>true</value>
 																				</Log>
 																				<Dimension classname='Num'>
 																					<value representation='UInt64'>0</value>
@@ -6433,7 +4714,7 @@
 																					<value>In</value>
 																				</Direction>
 																				<Log classname='Bool'>
-																					<value>false</value>
+																					<value>true</value>
 																				</Log>
 																				<Dimension classname='Num'>
 																					<value representation='UInt64'>0</value>
@@ -6443,36 +4724,6 @@
 																				</Type>
 																				<ID classname='Num'>
 																					<value representation='Int64'>5</value>
-																				</ID>
-																				<TypeSpecialization classname='Str'>
-																					<value>None</value>
-																				</TypeSpecialization>
-																			</subprops>
-																		</Obj>
-																	</value>
-																	<value>
-																		<Obj typename='NI_MeasurementParameter' name=''>
-																			<subprops>
-																				<Name classname='Str'>
-																					<value>abort_when_done</value>
-																				</Name>
-																				<ArgumentValue classname='ExprValue'>
-																					<value>True</value>
-																				</ArgumentValue>
-																				<Direction classname='Str'>
-																					<value>In</value>
-																				</Direction>
-																				<Log classname='Bool'>
-																					<value>false</value>
-																				</Log>
-																				<Dimension classname='Num'>
-																					<value representation='UInt64'>0</value>
-																				</Dimension>
-																				<Type classname='Str'>
-																					<value>TypeBool</value>
-																				</Type>
-																				<ID classname='Num'>
-																					<value representation='Int64'>6</value>
 																				</ID>
 																				<TypeSpecialization classname='Str'>
 																					<value>None</value>

--- a/examples/nifgen_standard_function/measurement.py
+++ b/examples/nifgen_standard_function/measurement.py
@@ -55,14 +55,12 @@ WAVEFORM_TYPE_TO_ENUM = {
 @measurement_service.configuration("frequency", nims.DataType.Double, 1.0e6)
 @measurement_service.configuration("amplitude", nims.DataType.Double, 2.0)
 @measurement_service.configuration("duration", nims.DataType.Double, 10.0)
-@measurement_service.configuration("abort_when_done", nims.DataType.Boolean, True)
 def measure(
     pin_name: str,
     waveform_type: str,
     frequency: float,
     amplitude: float,
     duration: float,
-    abort_when_done: bool,
 ) -> Tuple:
     """Generate a standard function waveform using an NI waveform generator."""
     logging.info(
@@ -115,10 +113,7 @@ def measure(
                 frequency,
             )
 
-            if abort_when_done:
-                stack.enter_context(session.initiate())
-            else:
-                session.initiate()
+            stack.enter_context(session.initiate())
 
         is_simulated = sessions[0].simulate
         deadline = time.time() + measurement_service.context.time_remaining


### PR DESCRIPTION
Signed-off-by: Chris Delpire <chris.delpire@ni.com>

- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Removes the abort_when_done parameter from our FGEN example measurement. We tested with hardware and determined that this parameter did not have any effect. 

I also updated the measui to remove the control for this parameter, and I tried updating the seq file. **Can someone else pull this down and validate it on their machine?** The diff is gnarly.

### Why should this Pull Request be merged?

We shouldn't ship an example with a non-functional parameter.

### What testing has been done?

Successfully ran TestStand sequence using simulated PXIe-5423 (2CH).

[AB#2273840](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2273840)