### PR TITLE
Replacing DriverError with Error. Adding additional error code for timeout exceeded error.

### DIFF
--- a/examples/nidcpower_source_dc_voltage/measurement.py
+++ b/examples/nidcpower_source_dc_voltage/measurement.py
@@ -127,7 +127,7 @@ def measure(
                 try:
                     channels.wait_for_event(nidcpower.enums.Event.SOURCE_COMPLETE, timeout=0.1)
                     break
-                except nidcpower.Error as e:
+                except nidcpower.errors.DriverError as e:
                     """
                     There is no native way to support cancellation when taking a DCPower
                     measurement. To support cancellation, we will be calling WaitForEvent

--- a/examples/nidcpower_source_dc_voltage/measurement.py
+++ b/examples/nidcpower_source_dc_voltage/measurement.py
@@ -17,6 +17,7 @@ import ni_measurementlink_service as nims
 
 
 NIDCPOWER_WAIT_FOR_EVENT_TIMEOUT_ERROR_CODE = -1074116059
+NIDCPOWER_TIMEOUT_EXCEEDED_ERROR_CODE = -1074097933
 
 measurement_info = nims.MeasurementInfo(
     display_name="NI-DCPower Source DC Voltage (Py)",
@@ -126,7 +127,7 @@ def measure(
                 try:
                     channels.wait_for_event(nidcpower.enums.Event.SOURCE_COMPLETE, timeout=0.1)
                     break
-                except nidcpower.DriverError as e:
+                except nidcpower.Error as e:
                     """
                     There is no native way to support cancellation when taking a DCPower
                     measurement. To support cancellation, we will be calling WaitForEvent
@@ -134,7 +135,10 @@ def measure(
                     will throw an exception if it times out, which is why we are catching
                     and doing nothing.
                     """
-                    if e.code == NIDCPOWER_WAIT_FOR_EVENT_TIMEOUT_ERROR_CODE:
+                    if (
+                        e.code == NIDCPOWER_WAIT_FOR_EVENT_TIMEOUT_ERROR_CODE
+                        or e.code == NIDCPOWER_TIMEOUT_EXCEEDED_ERROR_CODE
+                    ):
                         pass
                     else:
                         raise

--- a/examples/nifgen_standard_function/measurement.py
+++ b/examples/nifgen_standard_function/measurement.py
@@ -138,7 +138,7 @@ def measure(
             else:
                 try:
                     sessions[0].wait_until_done(hightime.timedelta(seconds=sleep_time))
-                except nifgen.Error as e:
+                except nifgen.errors.DriverError as e:
                     """
                     There is no native way to support cancellation when generating a waveform.
                     To support cancellation, we will be calling wait_until_done


### PR DESCRIPTION
Signed-off-by: Chris Delpire <chris.delpire@ni.com>

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

1. `nidcpower.DriverError` does not exist. ~It should be `nidcpower.Error`.~ It should be `nidcpower.errors.DriverError`. (Fixed fgen too)
2. When testing with real hardware and adding a source delay, the error code I got was `-1074097933` (`kErrorTimeoutExceeded`).

Fixed the error handling and added the additional error code check.

### Why should this Pull Request be merged?

Current example does not support source delay with hardware.

### What testing has been done?

Tested on a machine with an actual SMU device.