### PR TITLE
Updating MeasurementService __init__ to parse .serviceconfig.

### DIFF
--- a/examples/nidaqmx_analog_input/measurement.py
+++ b/examples/nidaqmx_analog_input/measurement.py
@@ -9,11 +9,11 @@ import nidaqmx
 
 import ni_measurementlink_service as nims
 
-parent_directory = pathlib.Path(__file__).resolve().parent
+service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
-    service_config_path=parent_directory / "NIDAQmxAnalogInput.serviceconfig",
+    service_config_path=service_directory / "NIDAQmxAnalogInput.serviceconfig",
     version="0.1.0.0",
-    ui_file_paths=[parent_directory / "NIDAQmxAnalogInput.measui"],
+    ui_file_paths=[service_directory / "NIDAQmxAnalogInput.measui"],
 )
 
 

--- a/examples/nidaqmx_analog_input/measurement.py
+++ b/examples/nidaqmx_analog_input/measurement.py
@@ -9,19 +9,13 @@ import nidaqmx
 
 import ni_measurementlink_service as nims
 
-measurement_info = nims.MeasurementInfo(
-    display_name="NI-DAQmx Analog Input (Py)",
+parent_directory = pathlib.Path(__file__).resolve().parent
+measurement_service = nims.MeasurementService(
+    service_config_path=parent_directory / "NIDAQmxAnalogInput.serviceconfig",
     version="0.1.0.0",
-    ui_file_paths=[pathlib.Path(__file__).resolve().parent / "NIDAQmxAnalogInput.measui"],
+    ui_file_paths=[parent_directory / "NIDAQmxAnalogInput.measui"],
 )
-
-service_info = nims.ServiceInfo(
-    service_class="ni.examples.NIDAQmxAnalogInput_Python",
-    description_url="",
-)
-
-measurement_service = nims.MeasurementService(measurement_info, service_info)
-
+service_options = ServiceOptions()
 
 @measurement_service.register_measurement
 @measurement_service.configuration("physical_channel", nims.DataType.String, "Dev1/ai0")

--- a/examples/nidaqmx_analog_input/measurement.py
+++ b/examples/nidaqmx_analog_input/measurement.py
@@ -15,7 +15,7 @@ measurement_service = nims.MeasurementService(
     version="0.1.0.0",
     ui_file_paths=[parent_directory / "NIDAQmxAnalogInput.measui"],
 )
-service_options = ServiceOptions()
+
 
 @measurement_service.register_measurement
 @measurement_service.configuration("physical_channel", nims.DataType.String, "Dev1/ai0")

--- a/examples/nidcpower_source_dc_voltage/measurement.py
+++ b/examples/nidcpower_source_dc_voltage/measurement.py
@@ -19,13 +19,13 @@ import ni_measurementlink_service as nims
 NIDCPOWER_WAIT_FOR_EVENT_TIMEOUT_ERROR_CODE = -1074116059
 NIDCPOWER_TIMEOUT_EXCEEDED_ERROR_CODE = -1074097933
 
-parent_directory = pathlib.Path(__file__).resolve().parent
+service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
-    service_config_path=parent_directory / "NIDCPowerSourceDCVoltage.serviceconfig",
+    service_config_path=service_directory / "NIDCPowerSourceDCVoltage.serviceconfig",
     version="0.1.0.0",
     ui_file_paths=[
-        parent_directory / "NIDCPowerSourceDCVoltage.measui",
-        parent_directory / "NIDCPowerSourceDCVoltageUI.vi",
+        service_directory / "NIDCPowerSourceDCVoltage.measui",
+        service_directory / "NIDCPowerSourceDCVoltageUI.vi",
     ],
 )
 service_options = ServiceOptions()

--- a/examples/nidcpower_source_dc_voltage/measurement.py
+++ b/examples/nidcpower_source_dc_voltage/measurement.py
@@ -19,21 +19,15 @@ import ni_measurementlink_service as nims
 NIDCPOWER_WAIT_FOR_EVENT_TIMEOUT_ERROR_CODE = -1074116059
 NIDCPOWER_TIMEOUT_EXCEEDED_ERROR_CODE = -1074097933
 
-measurement_info = nims.MeasurementInfo(
-    display_name="NI-DCPower Source DC Voltage (Py)",
+parent_directory = pathlib.Path(__file__).resolve().parent
+measurement_service = nims.MeasurementService(
+    service_config_path=parent_directory / "NIDCPowerSourceDCVoltage.serviceconfig",
     version="0.1.0.0",
     ui_file_paths=[
-        pathlib.Path(__file__).resolve().parent / "NIDCPowerSourceDCVoltage.measui",
-        pathlib.Path(__file__).resolve().parent / "NIDCPowerSourceDCVoltageUI.vi",
+        parent_directory / "NIDCPowerSourceDCVoltage.measui",
+        parent_directory / "NIDCPowerSourceDCVoltageUI.vi",
     ],
 )
-
-service_info = nims.ServiceInfo(
-    service_class="ni.examples.NIDCPowerSourceDCVoltage_Python",
-    description_url="",
-)
-
-measurement_service = nims.MeasurementService(measurement_info, service_info)
 service_options = ServiceOptions()
 
 

--- a/examples/nidmm_measurement/measurement.py
+++ b/examples/nidmm_measurement/measurement.py
@@ -14,18 +14,12 @@ from _helpers import ServiceOptions, str_to_enum
 
 import ni_measurementlink_service as nims
 
-measurement_info = nims.MeasurementInfo(
-    display_name="NI-DMM Measurement (Py)",
+parent_directory = pathlib.Path(__file__).resolve().parent
+measurement_service = nims.MeasurementService(
+    service_config_path=parent_directory / "NIDmmMeasurement.serviceconfig",
     version="0.1.0.0",
-    ui_file_paths=[pathlib.Path(__file__).resolve().parent / "NIDmmMeasurement.measui"],
+    ui_file_paths=[parent_directory / "NIDmmMeasurement.measui"]
 )
-
-service_info = nims.ServiceInfo(
-    service_class="ni.examples.NIDmmMeasurement_Python",
-    description_url="",
-)
-
-measurement_service = nims.MeasurementService(measurement_info, service_info)
 service_options = ServiceOptions()
 
 FUNCTION_TO_ENUM = {

--- a/examples/nidmm_measurement/measurement.py
+++ b/examples/nidmm_measurement/measurement.py
@@ -18,7 +18,7 @@ parent_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
     service_config_path=parent_directory / "NIDmmMeasurement.serviceconfig",
     version="0.1.0.0",
-    ui_file_paths=[parent_directory / "NIDmmMeasurement.measui"]
+    ui_file_paths=[parent_directory / "NIDmmMeasurement.measui"],
 )
 service_options = ServiceOptions()
 

--- a/examples/nidmm_measurement/measurement.py
+++ b/examples/nidmm_measurement/measurement.py
@@ -14,11 +14,11 @@ from _helpers import ServiceOptions, str_to_enum
 
 import ni_measurementlink_service as nims
 
-parent_directory = pathlib.Path(__file__).resolve().parent
+service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
-    service_config_path=parent_directory / "NIDmmMeasurement.serviceconfig",
+    service_config_path=service_directory / "NIDmmMeasurement.serviceconfig",
     version="0.1.0.0",
-    ui_file_paths=[parent_directory / "NIDmmMeasurement.measui"],
+    ui_file_paths=[service_directory / "NIDmmMeasurement.measui"],
 )
 service_options = ServiceOptions()
 

--- a/examples/nifgen_standard_function/measurement.py
+++ b/examples/nifgen_standard_function/measurement.py
@@ -18,18 +18,12 @@ import ni_measurementlink_service as nims
 NIFGEN_OPERATION_TIMED_OUT_ERROR_CODE = -1074098044
 NIFGEN_MAX_TIME_EXCEEDED_ERROR_CODE = -1074118637
 
-measurement_info = nims.MeasurementInfo(
-    display_name="NI-FGEN Standard Function (Py)",
+parent_directory = pathlib.Path(__file__).resolve().parent
+measurement_service = nims.MeasurementService(
+    service_config_path=parent_directory / "NIFgenStandardFunction.serviceconfig",
     version="0.1.0.0",
-    ui_file_paths=[pathlib.Path(__file__).resolve().parent / "NIFgenStandardFunction.measui"],
+    ui_file_paths=[parent_directory / "NIFgenStandardFunction.measui"],
 )
-
-service_info = nims.ServiceInfo(
-    service_class="ni.examples.NIFgenStandardFunction_Python",
-    description_url="",
-)
-
-measurement_service = nims.MeasurementService(measurement_info, service_info)
 service_options = ServiceOptions()
 
 WAVEFORM_TYPE_TO_ENUM = {

--- a/examples/nifgen_standard_function/measurement.py
+++ b/examples/nifgen_standard_function/measurement.py
@@ -18,11 +18,11 @@ import ni_measurementlink_service as nims
 NIFGEN_OPERATION_TIMED_OUT_ERROR_CODE = -1074098044
 NIFGEN_MAX_TIME_EXCEEDED_ERROR_CODE = -1074118637
 
-parent_directory = pathlib.Path(__file__).resolve().parent
+service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
-    service_config_path=parent_directory / "NIFgenStandardFunction.serviceconfig",
+    service_config_path=service_directory / "NIFgenStandardFunction.serviceconfig",
     version="0.1.0.0",
-    ui_file_paths=[parent_directory / "NIFgenStandardFunction.measui"],
+    ui_file_paths=[service_directory / "NIFgenStandardFunction.measui"],
 )
 service_options = ServiceOptions()
 

--- a/examples/niscope_acquire_waveform/measurement.py
+++ b/examples/niscope_acquire_waveform/measurement.py
@@ -14,18 +14,12 @@ from _helpers import ServiceOptions, str_to_enum
 
 import ni_measurementlink_service as nims
 
-measurement_info = nims.MeasurementInfo(
-    display_name="NI-SCOPE Acquire Waveform (Py)",
+parent_directory = pathlib.Path(__file__).resolve().parent
+measurement_service = nims.MeasurementService(
+    service_config_path=parent_directory / "NIScopeAcquireWaveform.serviceconfig",
     version="0.1.0.0",
-    ui_file_paths=[pathlib.Path(__file__).resolve().parent / "NIScopeAcquireWaveform.measui"],
+    ui_file_paths=[parent_directory / "NIScopeAcquireWaveform.measui"],
 )
-
-service_info = nims.ServiceInfo(
-    service_class="ni.examples.NIScopeAcquireWaveform_Python",
-    description_url="",
-)
-
-measurement_service = nims.MeasurementService(measurement_info, service_info)
 service_options = ServiceOptions()
 
 VERTICAL_COUPLING_TO_ENUM = {

--- a/examples/niscope_acquire_waveform/measurement.py
+++ b/examples/niscope_acquire_waveform/measurement.py
@@ -14,11 +14,11 @@ from _helpers import ServiceOptions, str_to_enum
 
 import ni_measurementlink_service as nims
 
-parent_directory = pathlib.Path(__file__).resolve().parent
+service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
-    service_config_path=parent_directory / "NIScopeAcquireWaveform.serviceconfig",
+    service_config_path=service_directory / "NIScopeAcquireWaveform.serviceconfig",
     version="0.1.0.0",
-    ui_file_paths=[parent_directory / "NIScopeAcquireWaveform.measui"],
+    ui_file_paths=[service_directory / "NIScopeAcquireWaveform.measui"],
 )
 service_options = ServiceOptions()
 

--- a/examples/niswitch_control_relays/measurement.py
+++ b/examples/niswitch_control_relays/measurement.py
@@ -12,11 +12,11 @@ from _helpers import ServiceOptions
 
 import ni_measurementlink_service as nims
 
-parent_directory = pathlib.Path(__file__).resolve().parent
+service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
-    service_config_path=parent_directory / "NISwitchControlRelays.serviceconfig",
+    service_config_path=service_directory / "NISwitchControlRelays.serviceconfig",
     version="0.1.0.0",
-    ui_file_paths=[parent_directory / "NISwitchControlRelays.measui"],
+    ui_file_paths=[service_directory / "NISwitchControlRelays.measui"],
 )
 service_options = ServiceOptions()
 

--- a/examples/niswitch_control_relays/measurement.py
+++ b/examples/niswitch_control_relays/measurement.py
@@ -20,6 +20,7 @@ measurement_service = nims.MeasurementService(
 )
 service_options = ServiceOptions()
 
+
 @measurement_service.register_measurement
 @measurement_service.configuration("relay_names", nims.DataType.String, "SiteRelay1")
 @measurement_service.configuration("close_relay", nims.DataType.Boolean, True)

--- a/examples/niswitch_control_relays/measurement.py
+++ b/examples/niswitch_control_relays/measurement.py
@@ -12,20 +12,13 @@ from _helpers import ServiceOptions
 
 import ni_measurementlink_service as nims
 
-measurement_info = nims.MeasurementInfo(
-    display_name="NI-SWITCH Control Relays (Py)",
+parent_directory = pathlib.Path(__file__).resolve().parent
+measurement_service = nims.MeasurementService(
+    service_config_path=parent_directory / "NISwitchControlRelays.serviceconfig",
     version="0.1.0.0",
-    ui_file_paths=[pathlib.Path(__file__).resolve().parent / "NISwitchControlRelays.measui"],
+    ui_file_paths=[parent_directory / "NISwitchControlRelays.measui"],
 )
-
-service_info = nims.ServiceInfo(
-    service_class="ni.examples.NISwitchControlRelays_Python",
-    description_url="",
-)
-
-measurement_service = nims.MeasurementService(measurement_info, service_info)
 service_options = ServiceOptions()
-
 
 @measurement_service.register_measurement
 @measurement_service.configuration("relay_names", nims.DataType.String, "SiteRelay1")

--- a/examples/nivisa_dmm_measurement/measurement.py
+++ b/examples/nivisa_dmm_measurement/measurement.py
@@ -20,18 +20,12 @@ from _visa_helpers import (
 
 import ni_measurementlink_service as nims
 
-measurement_info = nims.MeasurementInfo(
-    display_name="NI-VISA DMM Measurement (Py)",
+parent_directory = pathlib.Path(__file__).resolve().parent
+measurement_service = nims.MeasurementService(
+    service_config_path=parent_directory / "NIVisaDmmMeasurement.serviceconfig",
     version="0.1.0.0",
-    ui_file_paths=[pathlib.Path(__file__).resolve().parent / "NIVisaDmmMeasurement.measui"],
+    ui_file_paths=[parent_directory / "NIVisaDmmMeasurement.measui"],
 )
-
-service_info = nims.ServiceInfo(
-    service_class="ni.examples.NIVisaDmmMeasurement_Python",
-    description_url="",
-)
-
-measurement_service = nims.MeasurementService(measurement_info, service_info)
 service_options = ServiceOptions()
 
 

--- a/examples/nivisa_dmm_measurement/measurement.py
+++ b/examples/nivisa_dmm_measurement/measurement.py
@@ -20,11 +20,11 @@ from _visa_helpers import (
 
 import ni_measurementlink_service as nims
 
-parent_directory = pathlib.Path(__file__).resolve().parent
+service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
-    service_config_path=parent_directory / "NIVisaDmmMeasurement.serviceconfig",
+    service_config_path=service_directory / "NIVisaDmmMeasurement.serviceconfig",
     version="0.1.0.0",
-    ui_file_paths=[parent_directory / "NIVisaDmmMeasurement.measui"],
+    ui_file_paths=[service_directory / "NIVisaDmmMeasurement.measui"],
 )
 service_options = ServiceOptions()
 

--- a/examples/sample_measurement/measurement.py
+++ b/examples/sample_measurement/measurement.py
@@ -8,7 +8,7 @@ import click
 import ni_measurementlink_service as nims
 
 parent_directory = pathlib.Path(__file__).resolve().parent
-measurement_service = nims.MeasurementService(
+sample_measurement_service = nims.MeasurementService(
     service_config_path=parent_directory / "SampleMeasurement.serviceconfig",
     version="0.1.0.0",
     ui_file_paths=[

--- a/examples/sample_measurement/measurement.py
+++ b/examples/sample_measurement/measurement.py
@@ -7,22 +7,15 @@ import click
 
 import ni_measurementlink_service as nims
 
-measurement_info = nims.MeasurementInfo(
-    display_name="Sample Measurement (Py)",
+parent_directory = pathlib.Path(__file__).resolve().parent
+measurement_service = nims.MeasurementService(
+    service_config_path=parent_directory / "SampleMeasurement.serviceconfig",
     version="0.1.0.0",
     ui_file_paths=[
-        pathlib.Path(__file__).resolve().parent / "SampleMeasurement.measui",
-        pathlib.Path(__file__).resolve().parent / "SampleAllParameters.measui",
-        pathlib.Path(__file__).resolve().parent / "SampleMeasurement.vi",
+        parent_directory / "SampleMeasurement.measui",
+        parent_directory / "SampleAllParameters.measui",
+        parent_directory / "SampleMeasurement.vi",
     ],
-)
-
-service_info = nims.ServiceInfo(
-    service_class="ni.examples.SampleMeasurement_Python",
-    description_url="",
-)
-
-sample_measurement_service = nims.MeasurementService(measurement_info, service_info)
 
 
 @sample_measurement_service.register_measurement

--- a/examples/sample_measurement/measurement.py
+++ b/examples/sample_measurement/measurement.py
@@ -7,14 +7,14 @@ import click
 
 import ni_measurementlink_service as nims
 
-parent_directory = pathlib.Path(__file__).resolve().parent
+service_directory = pathlib.Path(__file__).resolve().parent
 sample_measurement_service = nims.MeasurementService(
-    service_config_path=parent_directory / "SampleMeasurement.serviceconfig",
+    service_config_path=service_directory / "SampleMeasurement.serviceconfig",
     version="0.1.0.0",
     ui_file_paths=[
-        parent_directory / "SampleMeasurement.measui",
-        parent_directory / "SampleAllParameters.measui",
-        parent_directory / "SampleMeasurement.vi",
+        service_directory / "SampleMeasurement.measui",
+        service_directory / "SampleAllParameters.measui",
+        service_directory / "SampleMeasurement.vi",
     ],
 )
 

--- a/examples/sample_measurement/measurement.py
+++ b/examples/sample_measurement/measurement.py
@@ -16,6 +16,7 @@ measurement_service = nims.MeasurementService(
         parent_directory / "SampleAllParameters.measui",
         parent_directory / "SampleMeasurement.vi",
     ],
+)
 
 
 @sample_measurement_service.register_measurement

--- a/ni_measurementlink_generator/ni_measurementlink_generator/templates/measurement.py.mako
+++ b/ni_measurementlink_generator/ni_measurementlink_generator/templates/measurement.py.mako
@@ -15,6 +15,7 @@ measurement_service = nims.MeasurementService(
     ui_file_paths=[service_directory / "${ui_file}"],
 )
 
+
 @measurement_service.register_measurement
 @measurement_service.configuration("Array in", nims.DataType.DoubleArray1D, [0.0])
 @measurement_service.output("Array out", nims.DataType.DoubleArray1D)

--- a/ni_measurementlink_generator/ni_measurementlink_generator/templates/measurement.py.mako
+++ b/ni_measurementlink_generator/ni_measurementlink_generator/templates/measurement.py.mako
@@ -8,11 +8,11 @@ import sys
 import click
 import ni_measurementlink_service as nims
 
-parent_directory = pathlib.Path(__file__).resolve().parent
+service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
-    service_config_path=parent_directory / "${display_name}.serviceconfig",
+    service_config_path=service_directory / "${display_name}.serviceconfig",
     version="0.1.0.0",
-    ui_file_paths=[parent_directory / "${ui_file}"],
+    ui_file_paths=[service_directory / "${ui_file}"],
 )
 
 @measurement_service.register_measurement

--- a/ni_measurementlink_generator/ni_measurementlink_generator/templates/measurement.py.mako
+++ b/ni_measurementlink_generator/ni_measurementlink_generator/templates/measurement.py.mako
@@ -8,19 +8,12 @@ import sys
 import click
 import ni_measurementlink_service as nims
 
-measurement_info = nims.MeasurementInfo(
-    display_name="${display_name}",
-    version="${version}",
-    ui_file_paths=[pathlib.Path(__file__).resolve().parent / "${ui_file}"],
+parent_directory = pathlib.Path(__file__).resolve().parent
+measurement_service = nims.MeasurementService(
+    service_config_path=parent_directory / "${display_name}.serviceconfig",
+    version="0.1.0.0",
+    ui_file_paths=[parent_directory / "${ui_file}"],
 )
-
-service_info = nims.ServiceInfo(
-    service_class="${service_class}",
-    description_url="${description_url}",
-)
-
-measurement_service = nims.MeasurementService(measurement_info, service_info)
-
 
 @measurement_service.register_measurement
 @measurement_service.configuration("Array in", nims.DataType.DoubleArray1D, [0.0])

--- a/ni_measurementlink_generator/tests/test_assets/example_renders/example.py
+++ b/ni_measurementlink_generator/tests/test_assets/example_renders/example.py
@@ -6,11 +6,11 @@ import sys
 import click
 import ni_measurementlink_service as nims
 
-parent_directory = pathlib.Path(__file__).resolve().parent
+service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
-    service_config_path=parent_directory / "example.serviceconfig",
+    service_config_path=service_directory / "example.serviceconfig",
     version="0.1.0.0",
-    ui_file_paths=[parent_directory / "MeasurementUI.measui"],
+    ui_file_paths=[service_directory / "MeasurementUI.measui"],
 )
 
 

--- a/ni_measurementlink_generator/tests/test_assets/example_renders/example.py
+++ b/ni_measurementlink_generator/tests/test_assets/example_renders/example.py
@@ -6,18 +6,12 @@ import sys
 import click
 import ni_measurementlink_service as nims
 
-measurement_info = nims.MeasurementInfo(
-    display_name="SampleMeasurement",
-    version="1.0.0.0",
-    ui_file_paths=[pathlib.Path(__file__).resolve().parent / "MeasurementUI.measui"],
+parent_directory = pathlib.Path(__file__).resolve().parent
+measurement_service = nims.MeasurementService(
+    service_config_path=parent_directory / "example.serviceconfig",
+    version="0.1.0.0",
+    ui_file_paths=[parent_directory / "MeasurementUI.measui"],
 )
-
-service_info = nims.ServiceInfo(
-    service_class="SampleMeasurement_Python",
-    description_url="https://www.example.com/SampleMeasurement.html",
-)
-
-measurement_service = nims.MeasurementService(measurement_info, service_info)
 
 
 @measurement_service.register_measurement

--- a/ni_measurementlink_generator/tests/test_assets/example_renders/example.py
+++ b/ni_measurementlink_generator/tests/test_assets/example_renders/example.py
@@ -8,7 +8,7 @@ import ni_measurementlink_service as nims
 
 service_directory = pathlib.Path(__file__).resolve().parent
 measurement_service = nims.MeasurementService(
-    service_config_path=service_directory / "example.serviceconfig",
+    service_config_path=service_directory / "SampleMeasurement.serviceconfig",
     version="0.1.0.0",
     ui_file_paths=[service_directory / "MeasurementUI.measui"],
 )

--- a/ni_measurementlink_service/measurement/service.py
+++ b/ni_measurementlink_service/measurement/service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from os import path
+from pathlib import Path
 from threading import Lock
 from typing import Any, Callable, Dict, TypeVar, List
 

--- a/ni_measurementlink_service/measurement/service.py
+++ b/ni_measurementlink_service/measurement/service.py
@@ -136,7 +136,7 @@ class MeasurementService:
         version: str,
         ui_file_paths: List[str],
         service_class: str = None,
-        ) -> None:
+    ) -> None:
         """Initialize the Measurement Service object.
 
         Uses the specified .serviceconfig file, version, and UI file paths
@@ -151,7 +151,7 @@ class MeasurementService:
             ui_file_paths (List[str]): List of paths to supported UIs.
 
             service_class (str): The service class from the .serviceconfig to use.
-            Default value is None, which will use the first service in the 
+            Default value is None, which will use the first service in the
             .serviceconfig file.
 
         """
@@ -161,11 +161,11 @@ class MeasurementService:
         with open(service_config_path) as service_config_file:
             service_config = json.load(service_config_file)
 
-        try: 
+        try:
             service = next(
-                s for s in service_config["services"] 
-                if service_class is None 
-                or s["serviceClass"] == service_class
+                s
+                for s in service_config["services"]
+                if service_class is None or s["serviceClass"] == service_class
             )
             self.measurement_info = MeasurementInfo(
                 display_name=service["displayName"],
@@ -178,7 +178,9 @@ class MeasurementService:
                 description_url=service["descriptionUrl"],
             )
         except StopIteration:
-            raise RuntimeError(f"Service class '{service_class}' not found in '{service_config_file}'")
+            raise RuntimeError(
+                f"Service class '{service_class}' not found in '{service_config_file}'"
+            )
 
         self.configuration_parameter_list: list = []
         self.output_parameter_list: list = []

--- a/ni_measurementlink_service/measurement/service.py
+++ b/ni_measurementlink_service/measurement/service.py
@@ -135,7 +135,7 @@ class MeasurementService:
         service_config_path: str,
         version: str,
         ui_file_paths: List[str],
-        service_class: str = None
+        service_class: str = None,
         ) -> None:
         """Initialize the Measurement Service object.
 
@@ -156,33 +156,29 @@ class MeasurementService:
 
         """
         if not path.exists(service_config_path):
-            raise Exception(f"File does not exist. {service_config_path}")
+            raise RuntimeError(f"File does not exist. {service_config_path}")
 
         with open(service_config_path) as service_config_file:
             service_config = json.load(service_config_file)
 
-        service_found = False
-        for service in service_config["services"]:
-            if (
-                service_class is None
-                or service["serviceClass"] == service
-            ):
-                service_found = True
-                self.measurement_info = MeasurementInfo(
-                    display_name=service["displayName"],
-                    version=version,
-                    ui_file_paths=ui_file_paths,
-                )
+        try: 
+            service = next(
+                s for s in service_config["services"] 
+                if service_class is None 
+                or s["serviceClass"] == service_class
+            )
+            self.measurement_info = MeasurementInfo(
+                display_name=service["displayName"],
+                version=version,
+                ui_file_paths=ui_file_paths,
+            )
 
-                self.service_info = ServiceInfo(
-                    service_class=service["serviceClass"],
-                    description_url=service["descriptionUrl"],
-                )
-
-                break
-
-        if not service_found:
-            raise Exception(f"Service class '{service_class}' not found in '{service_config_file}'")
+            self.service_info = ServiceInfo(
+                service_class=service["serviceClass"],
+                description_url=service["descriptionUrl"],
+            )
+        except StopIteration:
+            raise RuntimeError(f"Service class '{service_class}' not found in '{service_config_file}'")
 
         self.configuration_parameter_list: list = []
         self.output_parameter_list: list = []

--- a/ni_measurementlink_service/measurement/service.py
+++ b/ni_measurementlink_service/measurement/service.py
@@ -162,19 +162,16 @@ class MeasurementService:
         with open(service_config_path) as service_config_file:
             service_config = json.load(service_config_file)
 
-        services = list(
-            filter(
-                lambda s: service_class is None or s["serviceClass"] == service_class,
-                service_config["services"],
-            ),
-        )
-
-        if not services:
+        if service_class is None:
+            service = next(iter(service_config["services"]), None)
+        else:
+            service = next(
+                (s for s in service_config["services"] if s["serviceClass"] == service_class), None
+            )
+        if not service:
             raise RuntimeError(
                 f"Service class '{service_class}' not found in '{service_config_file}'"
             )
-
-        service = services[0]
 
         self.measurement_info = MeasurementInfo(
             display_name=service["displayName"],

--- a/ni_measurementlink_service/measurement/service.py
+++ b/ni_measurementlink_service/measurement/service.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import json
+from os import path
 from threading import Lock
 from typing import Any, Callable, Dict, TypeVar, List
-from os import path
 
 import grpc
 
@@ -136,7 +136,8 @@ class MeasurementService:
         version: str, 
         ui_file_paths: List[str]
         ) -> None:
-        """Initialize the Measurement Service object with the .serviceconfig file, version, and UI file paths.
+        """Initialize the Measurement Service object with the 
+        .serviceconfig file, version, and UI file paths.
 
         Args:
         ----

--- a/ni_measurementlink_service/measurement/service.py
+++ b/ni_measurementlink_service/measurement/service.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import json
 from threading import Lock
 from typing import Any, Callable, Dict, TypeVar, List
-import json
 from os import path
 
 import grpc
@@ -130,7 +130,12 @@ class MeasurementService:
 
     """
 
-    def __init__( self, service_config_path: str, version: str, ui_file_paths: List[str]) -> None:
+    def __init__( 
+        self, 
+        service_config_path: str, 
+        version: str, 
+        ui_file_paths: List[str]
+        ) -> None:
         """Initialize the Measurement Service object with the .serviceconfig file, version, and UI file paths.
 
         Args:
@@ -345,4 +350,3 @@ class MeasurementService:
         )
 
         return self.channel_pool.get_channel(target=service_location.insecure_address)
-        

--- a/ni_measurementlink_service/measurement/service.py
+++ b/ni_measurementlink_service/measurement/service.py
@@ -162,26 +162,30 @@ class MeasurementService:
         with open(service_config_path) as service_config_file:
             service_config = json.load(service_config_file)
 
-        try:
-            service = next(
-                s
-                for s in service_config["services"]
-                if service_class is None or s["serviceClass"] == service_class
-            )
-            self.measurement_info = MeasurementInfo(
-                display_name=service["displayName"],
-                version=version,
-                ui_file_paths=ui_file_paths,
-            )
+        services = list(
+            filter(
+                lambda s: service_class is None or s["serviceClass"] == service_class,
+                service_config["services"],
+            ),
+        )
 
-            self.service_info = ServiceInfo(
-                service_class=service["serviceClass"],
-                description_url=service["descriptionUrl"],
-            )
-        except StopIteration:
+        if not services:
             raise RuntimeError(
                 f"Service class '{service_class}' not found in '{service_config_file}'"
             )
+
+        service = services[0]
+
+        self.measurement_info = MeasurementInfo(
+            display_name=service["displayName"],
+            version=version,
+            ui_file_paths=ui_file_paths,
+        )
+
+        self.service_info = ServiceInfo(
+            service_class=service["serviceClass"],
+            description_url=service["descriptionUrl"],
+        )
 
         self.configuration_parameter_list: list = []
         self.output_parameter_list: list = []

--- a/ni_measurementlink_service/measurement/service.py
+++ b/ni_measurementlink_service/measurement/service.py
@@ -133,7 +133,7 @@ class MeasurementService:
 
     def __init__(
         self,
-        service_config_path: str,
+        service_config_path: Path,
         version: str,
         ui_file_paths: List[Path],
         service_class: str = None,
@@ -145,7 +145,7 @@ class MeasurementService:
 
         Args:
         ----
-            service_config_path (str): Path to the .serviceconfig file.
+            service_config_path (Path): Path to the .serviceconfig file.
 
             version (str): Version of the measurement service.
 

--- a/ni_measurementlink_service/measurement/service.py
+++ b/ni_measurementlink_service/measurement/service.py
@@ -134,7 +134,7 @@ class MeasurementService:
         self,
         service_config_path: str,
         version: str,
-        ui_file_paths: List[str],
+        ui_file_paths: List[Path],
         service_class: str = None,
     ) -> None:
         """Initialize the Measurement Service object.
@@ -148,7 +148,7 @@ class MeasurementService:
 
             version (str): Version of the measurement service.
 
-            ui_file_paths (List[str]): List of paths to supported UIs.
+            ui_file_paths (List[Path]): List of paths to supported UIs.
 
             service_class (str): The service class from the .serviceconfig to use.
             Default value is None, which will use the first service in the

--- a/tests/assets/example.serviceconfig
+++ b/tests/assets/example.serviceconfig
@@ -1,0 +1,11 @@
+{
+  "services": [
+    {
+      "displayName": "SampleMeasurement",
+      "serviceClass": "SampleMeasurement_Python",
+      "descriptionUrl": "https://www.example.com/SampleMeasurement.html",
+      "providedInterfaces": [ "ni.measurementlink.measurement.v1.MeasurementService" ],
+      "path": "start.bat"
+    }
+  ]
+}

--- a/tests/integration/test_service_manager.py
+++ b/tests/integration/test_service_manager.py
@@ -20,8 +20,8 @@ from tests.utilities.fake_discovery_service import FakeDiscoveryServiceStub
 def test___grpc_service___start_service___service_hosted(grpc_service: GrpcService):
     """Test to validate if measurement service is started."""
     port_number = grpc_service.start(
-        measurement.measurement_info,
-        measurement.service_info,
+        measurement.sample_measurement_service.measurement_info,
+        measurement.sample_measurement_service.service_info,
         measurement.sample_measurement_service.configuration_parameter_list,
         measurement.sample_measurement_service.output_parameter_list,
         measurement.sample_measurement_service.measure_function,
@@ -35,8 +35,8 @@ def test___grpc_service_without_discovery_service___start_service___service_host
 ):
     """Test to validate if measurement service start when the discovery service not available."""
     port_number = grpc_service.start(
-        measurement.measurement_info,
-        measurement.service_info,
+        measurement.sample_measurement_service.measurement_info,
+        measurement.sample_measurement_service.service_info,
         measurement.sample_measurement_service.configuration_parameter_list,
         measurement.sample_measurement_service.output_parameter_list,
         measurement.sample_measurement_service.measure_function,
@@ -48,8 +48,8 @@ def test___grpc_service_without_discovery_service___start_service___service_host
 def test___grpc_service_started___stop_service___service_stopped(grpc_service: GrpcService):
     """Test to validate if measurement service is stopped."""
     port_number = grpc_service.start(
-        measurement.measurement_info,
-        measurement.service_info,
+        measurement.sample_measurement_service.measurement_info,
+        measurement.sample_measurement_service.service_info,
         measurement.sample_measurement_service.configuration_parameter_list,
         measurement.sample_measurement_service.output_parameter_list,
         measurement.sample_measurement_service.measure_function,

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -1,11 +1,10 @@
 """Tests to validated user facing decorators in service.py."""
 import pathlib
+
 import pytest
 
 from ni_measurementlink_service.measurement.info import (
     DataType,
-    MeasurementInfo,
-    ServiceInfo,
     TypeSpecialization,
 )
 from ni_measurementlink_service.measurement.service import MeasurementService

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -240,9 +240,9 @@ def _fake_measurement_function():
 @pytest.fixture
 def measurement_service() -> MeasurementService:
     """Create a MeasurementService."""
-    assets_directory = pathlib.Path(__file__).resolve().parent.parent
+    assets_directory = pathlib.Path(__file__).resolve().parent.parent / "assets"
     return MeasurementService(
-        service_config_path=assets_directory / "assets" / "example.serviceconfig",
+        service_config_path=assets_directory / "example.serviceconfig",
         version="1.0.0.0",
         ui_file_paths=[],
     )

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -1,4 +1,5 @@
 """Tests to validated user facing decorators in service.py."""
+import pathlib
 import pytest
 
 from ni_measurementlink_service.measurement.info import (
@@ -8,14 +9,6 @@ from ni_measurementlink_service.measurement.info import (
     TypeSpecialization,
 )
 from ni_measurementlink_service.measurement.service import MeasurementService
-
-
-_TEST_SERVICE_INFO = ServiceInfo("TestServiceClass", "TestUrl")
-_TEST_MEASUREMENT_INFO = MeasurementInfo(
-    display_name="TestMeasurement",
-    version="1.0.0.0",
-    ui_file_paths=[],
-)
 
 
 def test___measurement_service___register_measurement_method___method_registered(
@@ -248,4 +241,9 @@ def _fake_measurement_function():
 @pytest.fixture
 def measurement_service() -> MeasurementService:
     """Create a MeasurementService."""
-    return MeasurementService(_TEST_MEASUREMENT_INFO, _TEST_SERVICE_INFO)
+    assets_directory = pathlib.Path(__file__).resolve().parent.parent
+    return MeasurementService(
+        service_config_path=assets_directory / "assets" / "example.serviceconfig",
+        version="1.0.0.0",
+        ui_file_paths=[],
+    )


### PR DESCRIPTION
Signed-off-by: Chris Delpire <chris.delpire@ni.com>

- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Rather than duplicating the service info, measurements should just parse their .serviceconfig file so that information can be single sourced.

Current this PR updates the `MeasurementService` `__init__` method to take in the .serviceconfig file path, version, and UI path. I have only updated 1 example so that we can discuss if this is the correct approach or not.

#202 

### Why should this Pull Request be merged?

Once we agree on an implementation, this should be merge to prevent duplication of information between the .serviceconfig and measurement.py files.

### What testing has been done?

Ran the measurement and successfully connected to it via MeasurementLink UI Editor.