### PR TITLE
Update pinmaps in nidcpower_source_dc_voltage example to have one pin/channel

### DIFF
--- a/examples/nidcpower_source_dc_voltage/NIDCPowerSourceDCVoltage.pinmap
+++ b/examples/nidcpower_source_dc_voltage/NIDCPowerSourceDCVoltage.pinmap
@@ -7,7 +7,6 @@
 	</Instruments>
 	<Pins>
 		<DUTPin name="Pin1" />
-		<DUTPin name="Pin2" />
 	</Pins>
 	<PinGroups></PinGroups>
 	<Sites>
@@ -15,6 +14,5 @@
 	</Sites>
 	<Connections>
 		<Connection pin="Pin1" siteNumber="0" instrument="DCPower1" channel="0" />
-		<Connection pin="Pin2" siteNumber="0" instrument="DCPower1" channel="1" />
 	</Connections>
 </PinMap>

--- a/examples/nidcpower_source_dc_voltage/NIDCPowerSourceDCVoltageMultiSite.pinmap
+++ b/examples/nidcpower_source_dc_voltage/NIDCPowerSourceDCVoltageMultiSite.pinmap
@@ -7,6 +7,7 @@
 	</Instruments>
 	<Pins>
 		<DUTPin name="Pin1" />
+		<DUTPin name="Pin2" />
 	</Pins>
 	<PinGroups></PinGroups>
 	<Sites>
@@ -14,6 +15,9 @@
 		<Site siteNumber="1" />
 	</Sites>
 	<Connections>
-		<Connection pin="Pin1" siteNumber="0,1" instrument="DCPower1" channel="0" />
+		<Connection pin="Pin1" siteNumber="0" instrument="DCPower1" channel="0" />
+		<Connection pin="Pin1" siteNumber="1" instrument="DCPower1" channel="2" />
+		<Connection pin="Pin2" siteNumber="0" instrument="DCPower1" channel="1" />
+		<Connection pin="Pin2" siteNumber="1" instrument="DCPower1" channel="3" />
 	</Connections>
 </PinMap>

--- a/examples/nidcpower_source_dc_voltage/NIDCPowerSourceDCVoltageMultiSite.pinmap
+++ b/examples/nidcpower_source_dc_voltage/NIDCPowerSourceDCVoltageMultiSite.pinmap
@@ -7,7 +7,6 @@
 	</Instruments>
 	<Pins>
 		<DUTPin name="Pin1" />
-		<DUTPin name="Pin2" />
 	</Pins>
 	<PinGroups></PinGroups>
 	<Sites>
@@ -15,9 +14,6 @@
 		<Site siteNumber="1" />
 	</Sites>
 	<Connections>
-		<Connection pin="Pin1" siteNumber="0" instrument="DCPower1" channel="0" />
-		<Connection pin="Pin1" siteNumber="1" instrument="DCPower1" channel="2" />
-		<Connection pin="Pin2" siteNumber="0" instrument="DCPower1" channel="1" />
-		<Connection pin="Pin2" siteNumber="1" instrument="DCPower1" channel="3" />
+		<Connection pin="Pin1" siteNumber="0,1" instrument="DCPower1" channel="0" />
 	</Connections>
 </PinMap>

--- a/examples/nidcpower_source_dc_voltage/README.md
+++ b/examples/nidcpower_source_dc_voltage/README.md
@@ -30,3 +30,7 @@ This example requires an NI SMU that is supported by NI-DCPower (e.g. PXIe-4141)
 To simulate an NI SMU in software: open `NI MAX`, right-click `Devices and Interfaces`,
 select `Create New...`, and select `Simulated NI-DAQmx Device or Modular Instrument`.
 SMUs are in the `Power Supplies` category.
+
+### Note
+
+- In order to run the measurement with `NIDCPowerSourceDCVoltageMultiSite.pinmap`, it is required to have an NI SMU with 4 or more channels.


### PR DESCRIPTION
### What does this Pull Request accomplish?

Updates pinmaps in `nidcpower_source_dc_voltage` example to have one pin/channel.

### Why should this Pull Request be merged?

Fixes [Bug 2275162](https://ni.visualstudio.com/DevCentral/_workitems/edit/2275162): DCPower Example does not work with single channel SMUs (GitHub Issue #215)

### What testing has been done?

Manually tested.