### PR TITLE
Make examples specifically depend on 1.0.0 to avoid future breakages

### DIFF
--- a/examples/nidaqmx_analog_input/pyproject.toml
+++ b/examples/nidaqmx_analog_input/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidaqmx = ">=0.6.3"
-ni-measurementlink-service = "*"
+ni-measurementlink-service = "1.0.0"
 click = ">=7.1.2"
 
 [tool.poetry.dev-dependencies]

--- a/examples/nidaqmx_analog_input/pyproject.toml
+++ b/examples/nidaqmx_analog_input/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidaqmx = ">=0.6.3"
-ni-measurementlink-service = "1.0.0"
+ni-measurementlink-service = "^1.0.0"
 click = ">=7.1.2"
 
 [tool.poetry.dev-dependencies]

--- a/examples/nidcpower_source_dc_voltage/pyproject.toml
+++ b/examples/nidcpower_source_dc_voltage/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidcpower = ">=1.4.3"
-ni-measurementlink-service = "*"
+ni-measurementlink-service = "1.0.0"
 click = ">=7.1.2"
 grpcio = "*"
 

--- a/examples/nidcpower_source_dc_voltage/pyproject.toml
+++ b/examples/nidcpower_source_dc_voltage/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidcpower = ">=1.4.3"
-ni-measurementlink-service = "1.0.0"
+ni-measurementlink-service = "^1.0.0"
 click = ">=7.1.2"
 grpcio = "*"
 

--- a/examples/nidmm_measurement/pyproject.toml
+++ b/examples/nidmm_measurement/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidmm = ">=1.4.3"
-ni-measurementlink-service = "*"
+ni-measurementlink-service = "1.0.0"
 click = ">=7.1.2"
 grpcio = "*"
 

--- a/examples/nidmm_measurement/pyproject.toml
+++ b/examples/nidmm_measurement/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidmm = ">=1.4.3"
-ni-measurementlink-service = "1.0.0"
+ni-measurementlink-service = "^1.0.0"
 click = ">=7.1.2"
 grpcio = "*"
 

--- a/examples/nifgen_standard_function/pyproject.toml
+++ b/examples/nifgen_standard_function/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nifgen = ">=1.4.3"
-ni-measurementlink-service = "1.0.0"
+ni-measurementlink-service = "^1.0.0"
 click = ">=7.1.2"
 grpcio = "*"
 

--- a/examples/nifgen_standard_function/pyproject.toml
+++ b/examples/nifgen_standard_function/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nifgen = ">=1.4.3"
-ni-measurementlink-service = "*"
+ni-measurementlink-service = "1.0.0"
 click = ">=7.1.2"
 grpcio = "*"
 

--- a/examples/niscope_acquire_waveform/pyproject.toml
+++ b/examples/niscope_acquire_waveform/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 niscope = ">=1.4.3"
-ni-measurementlink-service = "1.0.0"
+ni-measurementlink-service = "^1.0.0"
 click = ">=7.1.2"
 grpcio = "*"
 

--- a/examples/niscope_acquire_waveform/pyproject.toml
+++ b/examples/niscope_acquire_waveform/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 niscope = ">=1.4.3"
-ni-measurementlink-service = "*"
+ni-measurementlink-service = "1.0.0"
 click = ">=7.1.2"
 grpcio = "*"
 

--- a/examples/niswitch_control_relays/pyproject.toml
+++ b/examples/niswitch_control_relays/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 niswitch = ">=1.4.3"
-ni-measurementlink-service = "1.0.0"
+ni-measurementlink-service = "^1.0.0"
 click = ">=7.1.2"
 grpcio = "*"
 

--- a/examples/niswitch_control_relays/pyproject.toml
+++ b/examples/niswitch_control_relays/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 niswitch = ">=1.4.3"
-ni-measurementlink-service = "*"
+ni-measurementlink-service = "1.0.0"
 click = ">=7.1.2"
 grpcio = "*"
 

--- a/examples/nivisa_dmm_measurement/pyproject.toml
+++ b/examples/nivisa_dmm_measurement/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-ni-measurementlink-service = "1.0.0"
+ni-measurementlink-service = "^1.0.0"
 PyVISA = "^1.13.0"
 PyVISA-sim = "^0.5.1"
 click = ">=7.1.2"

--- a/examples/nivisa_dmm_measurement/pyproject.toml
+++ b/examples/nivisa_dmm_measurement/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-ni-measurementlink-service = "*"
+ni-measurementlink-service = "1.0.0"
 PyVISA = "^1.13.0"
 PyVISA-sim = "^0.5.1"
 click = ">=7.1.2"

--- a/examples/sample_measurement/pyproject.toml
+++ b/examples/sample_measurement/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-ni-measurementlink-service = "1.0.0"
+ni-measurementlink-service = "^1.0.0"
 click = ">=7.1.2"
 
 [tool.poetry.dev-dependencies]

--- a/examples/sample_measurement/pyproject.toml
+++ b/examples/sample_measurement/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-ni-measurementlink-service = "*"
+ni-measurementlink-service = "1.0.0"
 click = ">=7.1.2"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Make the examples depend on a specific version of ni-measurement-service, 1.0.0 as of now instead of "*" which would always take the latest.
fixes #209 

### Why should this Pull Request be merged?

We know the examples won't break as we add new potentially breaking code to the repo.

### What testing has been done?

None.