### PR TITLE
Adding autoapi/index to index.rst so api shows up in sidebar.

### DIFF
--- a/_docs_source/conf.py
+++ b/_docs_source/conf.py
@@ -62,7 +62,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 #
 html_theme = "sphinx_rtd_theme"
 html_theme_options = {
-    'navigation_depth': -1,
+    "navigation_depth": -1,
 }
 
 # Napoleon settings

--- a/_docs_source/conf.py
+++ b/_docs_source/conf.py
@@ -62,5 +62,9 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 #
 html_theme = "sphinx_rtd_theme"
 
+html_theme_options = {
+    'navigation_depth': -1,
+}
+
 # Napoleon settings
 napoleon_numpy_docstring = False

--- a/_docs_source/conf.py
+++ b/_docs_source/conf.py
@@ -61,7 +61,6 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # a list of builtin themes.
 #
 html_theme = "sphinx_rtd_theme"
-
 html_theme_options = {
     'navigation_depth': -1,
 }

--- a/_docs_source/index.rst
+++ b/_docs_source/index.rst
@@ -1,7 +1,9 @@
-NI Measurement Service
+NI MeasurementLink
 ----------------------
 .. toctree::
    :maxdepth: 3
+
+   autoapi/index
 
 Indices and tables
 ------------------


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds `autoapi/index` to our index.rst. This will cause pages from autoapi to appear in the sidebar. Additionally, I set the `navigation_depth` of the `html_theme_options` to -1 in the conf.py to allow everything to appear in the sidebar.

### Why should this Pull Request be merged?

See issue #231

### What testing has been done?

Built the documentation locally. Once you click API Reference you will see the page tree in the sidebar.
![image](https://user-images.githubusercontent.com/71399316/224834960-92a3343c-b7d0-40d5-87d2-4328f10daf68.png)
