### PR TITLE
Update static registration readme and script

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -48,8 +48,9 @@ The example measurements are *Poetry-based* projects. Follow the steps below to 
 
 To statically register an example measurement service with the MeasurementLink discovery service, do the following:
 
-1. Copy the example measurement's directory (do not copy the `.venv` subdirectory - it must be re-created in the new location), `.serviceconfig` file, and startup batch file to a subdirectory of `C:\ProgramData\National Instruments\MeasurementLink\Services`.
-2. Open a command prompt to the new example directory under `C:\ProgramData` and run `poetry install`.
+1. Copy the example measurement's directory (including the `.serviceconfig` file and startup batch file) to a subdirectory of `C:\ProgramData\National Instruments\MeasurementLink\Services`.
+2. NOTE: Do not copy the `.venv` subdirectory &mdash; the virtual environment must be re-created in the new location.
+3. Create a virtual environment in the new location. Open a command prompt to the new example directory under `C:\ProgramData` and run `poetry install`.
 
     ``` cmd
     cd <path_of_example_measurement>

--- a/examples/README.md
+++ b/examples/README.md
@@ -49,8 +49,9 @@ The example measurements are *Poetry-based* projects. Follow the steps below to 
 To statically register an example measurement service with the MeasurementLink discovery service, do the following:
 
 1. Copy the example measurement's directory (including the `.serviceconfig` file and startup batch file) to a subdirectory of `C:\ProgramData\National Instruments\MeasurementLink\Services`.
-2. NOTE: Do not copy the `.venv` subdirectory &mdash; the virtual environment must be re-created in the new location.
-3. Create a virtual environment in the new location. Open a command prompt to the new example directory under `C:\ProgramData` and run `poetry install`.
+> **Note**
+> Do not copy the `.venv` subdirectory&mdash;the virtual environment must be re-created in the new location.
+2. Create a virtual environment in the new location by opening a command prompt to the new example directory under `C:\ProgramData` and running `poetry install`.
 
     ``` cmd
     cd <path_of_example_measurement>

--- a/scripts/install_examples.py
+++ b/scripts/install_examples.py
@@ -30,7 +30,7 @@ def main():
             shutil.rmtree(install_path)
 
         print(f"Installing example into {install_path}")
-        shutil.copytree(example_path, install_path)
+        shutil.copytree(example_path, install_path, ignore=shutil.ignore_patterns('.venv'))
 
         poetry_lock = install_path / "poetry.lock"
         if poetry_lock.exists():

--- a/scripts/install_examples.py
+++ b/scripts/install_examples.py
@@ -30,7 +30,7 @@ def main():
             shutil.rmtree(install_path)
 
         print(f"Installing example into {install_path}")
-        shutil.copytree(example_path, install_path, ignore=shutil.ignore_patterns('.venv'))
+        shutil.copytree(example_path, install_path, ignore=shutil.ignore_patterns(".venv"))
 
         poetry_lock = install_path / "poetry.lock"
         if poetry_lock.exists():


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update instructions and script which installs examples. This is a follow-up to https://github.com/ni/measurementlink-python/commit/007f087a018e3614f0370a05f9abc58d240d320a which was mistakenly submitted directly to main.

The .venv should not be copied when copying an example or measurement to statically register it. The venv must be re-created in place to be fully valid.

### Why should this Pull Request be merged?

Fixes #235 

### What testing has been done?

Tested the script locally and ensured that the .venv created has no references to the original directory from the repo.