### PR TITLE
generator: Improve Mako usage, error handling, and type annotations

### DIFF
--- a/ni_measurementlink_generator/ni_measurementlink_generator/template.py
+++ b/ni_measurementlink_generator/ni_measurementlink_generator/template.py
@@ -7,18 +7,16 @@ from mako import exceptions
 from mako.template import Template
 
 
-def _render_template(template_name: str, **template_args) -> str:
+def _render_template(template_name: str, **template_args) -> bytes:
     file_path = str(pathlib.Path(__file__).parent / "templates" / template_name)
 
-    with open(file_path, "r") as file:
-        file_contents = file.read()
-    template = Template(file_contents)
+    template = Template(filename=file_path, input_encoding="utf-8", output_encoding="utf-8")
     try:
         return template.render(**template_args)
     except:  # noqa: E722
         print(exceptions.text_error_template().render())
 
-    return ""
+    return b""
 
 
 def _create_file(template_name: str, file_name: str, directory_out, **template_args) -> str:
@@ -26,7 +24,7 @@ def _create_file(template_name: str, file_name: str, directory_out, **template_a
 
     output = _render_template(template_name, **template_args)
 
-    with output_file.open("w") as fout:
+    with output_file.open("wb") as fout:
         fout.write(output)
 
     return ""

--- a/ni_measurementlink_generator/ni_measurementlink_generator/template.py
+++ b/ni_measurementlink_generator/ni_measurementlink_generator/template.py
@@ -2,12 +2,11 @@
 import logging
 import pathlib
 import re
-from typing import Optional, Union
+from typing import Optional
 
 import click
 from mako import exceptions
 from mako.template import Template
-
 
 _logger = logging.getLogger(__name__)
 
@@ -20,7 +19,9 @@ def _render_template(template_name: str, **template_args) -> bytes:
         return template.render(**template_args)
     except Exception as e:
         _logger.error(exceptions.text_error_template().render())
-        raise click.ClickException(f"An error occurred while rendering template \"{template_name}\".") from e
+        raise click.ClickException(
+            f'An error occurred while rendering template "{template_name}".'
+        ) from e
 
 
 def _create_file(template_name: str, file_name: str, directory_out: pathlib.Path, **template_args):
@@ -39,7 +40,9 @@ def _check_version(ctx: click.Context, param: click.Parameter, version: str) -> 
     raise click.BadParameter(f"Invalid version '{version}'.")
 
 
-def _check_ui_file(ctx: click.Context, param: click.Parameter, ui_file: Optional[str]) -> Optional[str]:
+def _check_ui_file(
+    ctx: click.Context, param: click.Parameter, ui_file: Optional[str]
+) -> Optional[str]:
     if ui_file is not None:
         _ = _get_ui_type(ui_file)
     return ui_file

--- a/ni_measurementlink_generator/pyproject.toml
+++ b/ni_measurementlink_generator/pyproject.toml
@@ -34,3 +34,6 @@ ni-measurementlink-generator = "ni_measurementlink_generator.template:create_mea
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.black]
+line-length = 100


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

ni_measurementlink_generator:
- Mako usage:
  - Let Mako read the template file. 
  - Specify the input/output encodings. 
    - This causes Mako to render the template as `bytes` rather than `str`. Using `bytes` avoids incorrect newline conversion that would result in `\r\r\n` line endings on Windows.
    - This preserves the bug fix from https://github.com/ni/measurementlink-python/pull/240
- Error handling:
  - Report Mako template errors as errors rather than printing to stdout and returning success. Use the `logging` module to trace the Mako stack trace (with the correct Mako line numbers), then use `click.ClickException` to return a user-visible error.
  - Report invalid parameters using `click.BadParameter`, avoiding a stack trace.
  - Reformat option descriptions to use single quotes for strings to match `click`'s formatting.
- Type annotations:
  - Add more type annotations.
- Configure Black to use the same line length as in the main project. 

### Why should this Pull Request be merged?

- Apply knowledge learned from using Mako in other NI projects.
- Report errors more clearly.
- Report Mako errors to the shell with the appropriate exit code.
- Improve code maintainability.

### What testing has been done?

Manually tested errors.
Ran `poetry run pytest`.