### PR TITLE
Updated the TestStand sequence of measurement examples to make it simpler (DMM, FGEN, SCOPE, SWITCH, VISA DMM)

### DIFF
--- a/examples/nidcpower_source_dc_voltage/README.md
+++ b/examples/nidcpower_source_dc_voltage/README.md
@@ -16,6 +16,7 @@ This is a MeasurementLink example that sources and measures a DC voltage with an
   `ui_file_paths` array in `measurement.py`
 - Includes a TestStand sequence showing how to configure the pin map, register
   instrument sessions with the session management service, and run a measurement
+  - For the sake of simplicity, the TestStand sequence handles pin map and session registration and unregistration in the `Setup` and `Cleanup` sections of the main sequence. For **Test UUTs** and batch process model use cases, these steps should be moved to the `ProcessSetup` and `ProcessCleanup` callbacks.
 - Uses the NI gRPC Device Server to allow sharing instrument sessions with other
   measurement services when running measurements from TestStand
 

--- a/examples/nidcpower_source_dc_voltage/README.md
+++ b/examples/nidcpower_source_dc_voltage/README.md
@@ -16,7 +16,10 @@ This is a MeasurementLink example that sources and measures a DC voltage with an
   `ui_file_paths` array in `measurement.py`
 - Includes a TestStand sequence showing how to configure the pin map, register
   instrument sessions with the session management service, and run a measurement
-  - For the sake of simplicity, the TestStand sequence handles pin map and session registration and unregistration in the `Setup` and `Cleanup` sections of the main sequence. For **Test UUTs** and batch process model use cases, these steps should be moved to the `ProcessSetup` and `ProcessCleanup` callbacks.
+  - For the sake of simplicity, the TestStand sequence handles pin map and session 
+    registration and unregistration in the `Setup` and `Cleanup` sections of the main 
+    sequence. For **Test UUTs** and batch process model use cases, these steps should 
+    be moved to the `ProcessSetup` and `ProcessCleanup` callbacks.
 - Uses the NI gRPC Device Server to allow sharing instrument sessions with other
   measurement services when running measurements from TestStand
 

--- a/examples/nidmm_measurement/NIDmmMeasurement.seq
+++ b/examples/nidmm_measurement/NIDmmMeasurement.seq
@@ -1670,6 +1670,647 @@
 		</typedef>
 		<protected>E@=3DJC4100hYLECF=_K@0@mKCYo_1KN:&lt;Ta239hF9[gHbEVFDfRINZfQ01CkaUMk5=k`[c;[42MMF9aiNliecVfMFCLXi_`f2H7c\G\X50M=Z4S4aT2QI&gt;A^D:d1\PCI`L11RlV5bM5AIZTc9STI5Mkg&lt;bHlle[O=CL_KEgb?8RiVHS7QmPY@S4X^7I58A@kPaKcPWCOC1;DBf61lViY=]`28BC\B_mEf20ZJS@W@GDDRffLe\Ci;aKbN&gt;i5P_4ScVVBTjIIfn0j8l&lt;e6IcMbZHgCI;n8CRlR7&lt;YcK0@cY[8aDHj=GGkNK;C?KC?b=]mMejoc1gGol1&gt;hL6lf5fZ92?Ia@l1;QL024f^NSm2MhNlcFg_YR[l5kclo:einXehbR&gt;98[4?GC:CX[3hm\UMob2aIMT0eJmgI@\;njRK9]fIl_8f=d]n4bQcRXDEl&lt;o=@Yiik\3Md@?k1=0Joj&gt;?Je`&lt;RUd&lt;JYmeOnOgB3G@Ub\FoGFgIQmQli8nGH=QjKD9i`2nf41XEKj;oDB8iZU`@XP^KWoAKEbOf:ViVAl=_I37KJSec7Ea\nJ5]NZj\OnJF;ASQemRIDbbdglb\U&gt;H[O^bDHO?XMLaOoeVCf=a^CC`d8^TX2B</protected>
 		<protected>E@=3@J\4110h]L]Mg[cK3fBoj\Kifo1C[KY_3VgFm3_6n&gt;DfdTDgjaSF_LdVUJaY::FII@T:GB9LaYOo80OP^053LBBVb1G?:50k4;P1c\^`03ffoj9S72=AOm;a2oh?Na\lC7TUOXcNfaSdfIbVCC_ao20aN9bmo_&lt;R_S=&gt;KV;lhbmh89SY[:2UflXcmGIlnngoE]\\ad_6_gW8X9GAXJSPJYin&gt;C71=c74a79JN&lt;`GPK]_\&gt;2`h9IOC]VA5BU4AMW1Qc`j?lJ\aR4__&gt;R4SI_`[_mmnM33ONg`3P[g4N5aSF;ce]^eVffg6&gt;cIRLhI]7CjE^W[jW`kZkGEWHk1=RR;gTe:O[H;k[bAd7UCaTVXgjlho3Af&gt;?oIJdjMo&gt;3=o;aTo\ZZnG9_cgcO7mjV^k&gt;\:gkoOkSn1jkfm@MgLnb&lt;Amg;\Nmj8klk3llhhnW&gt;nn^GCW_fW_&gt;ji]:Va&gt;TNnNQdK5LolNX?M@\6jN2ddlIHh=MT1E^[o4Q7I54R=RlVg[S\KmOe9GM:Qeh9OnUhWTeC^ZM7SAGP1V=LZ4[i\cOmoH[RS6YBL2L\PAg][JQ&lt;Eo?8;D9Mk3M]&gt;N^6&gt;HgJ]KP^a&gt;cfBkkmZ33RdU`]jB_NIOShWL4oDlbn3lNOCL??R7GCmKaTDhekoi_En`9oJKe&lt;e1`lBjmjXJ&lt;^4_^_^&gt;?7O?nEE_WTY:VYEc]3^eJm^cdC7;LcK_]Ei&gt;b&lt;^`9HR6YcO&gt;l@Amg&gt;PLXQbSb^=?FXRUZd&lt;[n&lt;SGjgCQ`mhTl;7NUbgaRQBkXNY4iX5iAJX6C`gdG[d3d&gt;`Uj3DPMF7h71WBBLLR&gt;Tk9dZlFCYSi__fNBBT`C;A&gt;jeP2CdONN52i5^eBEIEI=8EMHBBe^G^1ohD6&gt;LRiJgM\IPYE8Wn`T9W@jf8iEfN:@L3&lt;Ha_l0CCE&lt;HOJjXBRll_NLReo_^K7CQWihL&lt;B1::YXdSaG&lt;XFnCP94dQXb;^6V07F&gt;TkPem&gt;4QI;?9JkF`g80:`G?AULFSY^XW;4XL^_D=GZV9VVODS^[=]dL]b=N;O[ib6]2aLATM7\AcX=JH&lt;\1j8_?I9_VUO]5;PKjdi^o&gt;Kn=FbmhAmF3EXh?dAPF?cWPU;NHFT9YBblF15fj0n]RK9&gt;d;@lD9HXLGTZOAa;gEd6:MElAPOkOoMom`hnaYko^ne_;PeC\`kMYOoCalP3DR_^NADNSV6R1Nk4f?=Lo;VQ&gt;7&gt;fR@=2j8C:;D@3fk&gt;^=YHE^PQ1fU&gt;TFoNH&gt;GnfRGNMNW`[okK`S56RJfM4Zmo^6E9ZYc&gt;FNEO3PO=T9eK0:bgljYdR7WooKS9eTjd@bcImNVZ8UXa:AC_F_WCj]4\6ST&lt;:ie_AbZFIL7UmlIne:BcTQ5T2U]O2goYWXRN5F8oeQT^`HXPD=2LV[h;ibbNNj1kU]lXlnX4ACO5aRA@TfHY77@P?L=_N@4^cJG;Wi2@3M5OQ:^@&gt;2K9_9W:4Vn1LGaRN@WL9AFFVg1oYHdi`54XIa5G[\i&gt;iPT4506XA7h2^c_T`3d[ARdFICaAS2RM:1KgT7B&gt;MhXVaI&lt;kA^@CX2aS^I:B&gt;=W&lt;U?l&lt;DWU&lt;Jd7^cKe2R]EdIBcBQZni_K1JPCEhV&gt;VH]FBZ&lt;5413k[U]MAFA`Ohma2g2NoU0@E;FI93Yi;RjnlScC;`glEaH^X@K[NY9Y1EUZc6V6\3?FKC0APU0^[aP:_GMI=eeWnJ&lt;6e2]@;AXaAE&lt;S[lhAb`XFjPP@dTXNYS=&lt;568je\`W3?@gn9HDaM84^&gt;SDl0&lt;Ba6YNKCeYZ\CUU?WGnR4=m^aN[KTlFG\?VZ[MC:3HfflAagl\jZUG@ScZW:2K\FU9TQa&lt;h;?iYb&lt;RJI66IEg&lt;WHgdkU:\KFIZG\BDU=9W&gt;:\:W7nM3NIjXT;2YV[@dDaY3bhOQY^af&lt;UVo:ZV^^@0d_M5ObRQ2PIHZ9bbbGm;4Z\KEfEYI=M];D@9j1kZ@2@FIkf9:\CYe5KnKANXH7R@eMc2M;Pl]PZG]@4h2Q7OY:=QFh@\Y6]E6X1bL6mjS76a`JS=H=XQReG6Djb7[c&lt;h@S5UCX4`ABLQ4:ZZ7=JF9JejC5\[T:meE5_[:`Qm=DfI0EDQLRH6o]LAPRXlbTgXSbnW7ZTN?N]lH02JKm;Z4hn&lt;A[89:C8lM5hC]Ab^\\WNK7JGS]XainLm:PWFF3EmC15\]YC\D;I6a&lt;NiIhd2GMIG`A9\[]T00fP:UXIXSHk2jI&gt;XFG&gt;I521bbKDA`Xb]h&gt;oAl&gt;IolbRB7j=i9_H89&lt;FR=U572U\LjNhnkeeemHDJJ\GHX\;J51M&lt;?QV2DneREAR3in6&lt;M75M_Re=Ci3gEOQ2VO`4P8_hfhSO\dZ7m]n\hlV6gSlSC@PoZSe8WUaY3d0_;Z=9H:I6Gf2PVG`mf8CC87@DBlT62^h6QFFhZF64BJ46@Dh&lt;T1=C]0_9J?073S@61ADIUT31&lt;mVE&lt;W?R@RBUJP`@;50X2Bh618KM^bf033T033D?NM@P`?0\dBA3A8AXF0]@KnP[5&lt;EDfUICcBF^EZT=:cWKBKYTDKXD=&lt;A:mkNB7LFDHC9b7nG57NFZ1]Ubo]8]0MN]YWJJ&gt;eS42I?===3_n_?J=384=Go8e^0mdmBiTjRaf;F@8M4_gCZSGQ3cUUnF6J_R9WJV0PNaTJDk&lt;RiWS6=&gt;Rf9EmM:WgL4LHg5oH[aMbbOlnI6b`9KZ^Z]oAdeH\@YgaV8ChHTKjEVA]a^YN&lt;;71CAbR\&lt;jAYI\\Y&lt;R\`1AOol`j1&gt;53?d8MV_@kAN_W4nIdKc0gRYHEo`]U?HWN?0&lt;?l2h:ZC\&gt;^D]Ug4FNZl123fNoZ7fLRB[_HR6O&gt;BaoomWl_8YS0Q\8;RB]@j=GIIe]J&lt;AT[;1I&lt;5ZJ\?Va5g?&gt;7hXgcbU4V=lT&gt;nV[28JKeQJ5QX4^WD3MfTBIBPKU57e&gt;[FRd&gt;_EeSHJhDa4hM9S9TUlOR=KWn]eAJ]W5VROh9ak`n5&lt;LV6L9d&lt;0`?fk]J8FW52OlL2i&lt;L1kO=mGBf9e:\`^[_J:F&gt;7o0_9mGc_`=KP@SW_^NU525JcQcEGhR8Da3gf4mJ?R6a2lLPKjL:TlfL8iHOKf:Mjeb\&gt;Xb3&gt;0kM@iNkaifYHDFNIKP\e^;bhg@V&lt;g0Za7F]R=JKPMgdg&gt;nYaMSb8MAV0o05XKjM5&lt;5^V=albT\&lt;868hhl^jHPRa0KcT4i[31chfOeGW&gt;;``&gt;&gt;I;B:YafYW&gt;jW_7D1&gt;9_X14U9VXJ5E_PA2ZPb&gt;n6eBLcN]SU4eSd&lt;IDGD4D5WHMlFCU0DeARScb:h\?EC1&gt;IBWead&gt;7F&gt;FeBea\oCS]jf@kE47ZHcB?TlP6_K[QC2@_N&gt;ilNn0VdgZE&gt;Z98hXCHa4bNUM16M74Q;DhldmcZ&gt;V?_TG1J?NI:F8&lt;aomhdPX5^AEe6BRYle4clf_gSb6D9LaD2h]ij8SAH@[`J@cb2G7ee@iZWl2A&gt;`Ga95FDhJo7Xo&gt;Zd3[jL&lt;DQ4OILX9a;0T\SUDWY:Bh&gt;WGNb:dHQ[S`[8:1L:F@&gt;H[49RQ6_3QV&lt;UT0oIITF^H_\X=:&lt;42`N``YjM75HWEd]5O`&lt;EX89FTP`^oN:QHgED5k:\CaYbA2GbD1;X5:N;?SoLhVhR`R_9lg3hU4n:I`2Gn:IjDHED]5i=2fcTklTK1H6k4HjK;HBM&gt;;c]9;i[MFD?WaY1O]oS293kLd9S3N6He?:_QKEcBGLOc:jB6H@fR]h]HGB5;:&lt;RE&lt;`3K4Ibi29dR;nU&lt;&lt;TKBRnTdK[ZTT6oiOVVXKgaP6&lt;lMTO_JC\0&lt;RY5NkR352&lt;FbcCB&lt;_3?0XjQ`BJP;OJR::8eHFb3&lt;;M\9FOC8T:MkD:Z;C=eb^0:AMSbSY_^Lc=SGbD5WDh@6j]PCDc@;\X1Nb\[`Z0W_Th5&lt;HD4CafYghb`T95Ko571]SZJDHF2eE&lt;7jViL_\8TQ@dFRo]`G[h3&gt;862l:2F[UU6dVbFjU?NI&gt;OHOk&gt;JNcFNU[mXi]iJ[neWQ\mWa]i[e?IkO^Mf]LHTP[G3?43M8g^Wh``lW3kBT7ADM6b_IUCIPO=C8g5@?9R3&lt;hilXNY7_&lt;THNN&lt;KMLm;eGM6_A6AUDB\c5Q;S2POniP9[mdEeIDnO7;T7Nia2nFN\L2XZIP?ZJKW\2cK0U5fb[dLn?[C&gt;YAMXfVFic02OQA\6LHEk0oBd0f;`kR1hImAUl:@I;^:oFJUF?mDgPlLokm]OIgenn9;n5[Oh3g7@W7OWBCk9X1mYDPF9AQ4LOGeM_D_WR?I7QRlVEmN_0QlA9^lO[HjnfngGjkHokO\A35=_4hVU^jKm;\?Y9^B=RkTG1I&lt;6nI`AQ_kJ;of[GmIi[g0]1\UG_FKUnX]ZcGmoI;NUdDFOolHn;NbMLkT`1GEo;j63N_8b_O`PQ[KRjb&lt;NDHW4;\lT[Ila;nMd`56_c\C25fJLUS;9fn@6[[SMIBBMFK\8d;ZIRSI;fJ5_cojWSIfcY2kNd1jkS0f9A3BNfk8W1m4H0gRbfA3J6Q726nmNm4PQYcWZ___NEf_FmmmOm40IZ1mf4PmS?H8k&gt;=J3g&lt;\1K6j;CNTGZ8kY61mk30RLUO`T`_H`Hg&lt;`\K67=HJ3g&lt;\3K6iGRVO9``_1H`L`\K6`f=371ikY61mf30S&lt;W]K86enT`_H`Hg&lt;=fbaLQO`c@&lt;hK;Rmmf&gt;KT=]4\mm;NkW]^mcFgV[_]l=8aHk_j]MgIEYV5XJkiW]l^^CKnYn2OgNJ0g&lt;fR\mWo;?JNcFN^cfL_eWZ[Eff[LeWebL[d?YfWFm3O0neW6m3NP3nGQ@G_M?lS61c3KG?`NUXHYTJ?j1SoC7V&gt;RGj_]d[blRO_M^Qg&gt;f_[0oQJWgg`CkhXXJ\hG;1Ujg`4MNjIg_6l3GG;oohYSNBallm3eZnFmebBeaLSDIS17WJfDBN9nUo^n2oC_;Q\;4O3WWk7mAZI17;2]ChHfZeJ;I\fY;^dB\J;NW@cEDj]HE]B8GSiKJgN9M6f4UIKhV02kFjYnXXBH9lF?3gDC&lt;EC`d=4l&lt;aIYa?]YS&lt;9Zl8]AkXcPg:6L69WWX^8R2;YXfC&lt;Xg6AQg@oOoChH=41ln]AG?J3U0Wn&gt;8[8cdWGUnL2Z&gt;Ll4HaNcI&lt;f]SiWCVXSMeP?^a7:Tf&lt;`L3cKdmDl7?Uj&gt;FnPG5NSQBkHE`Yj&gt;ZNQ^;UbDk0kCT]3]YV&lt;50o&lt;2&lt;aTY7THb5hg;3^hl@GYRZE@mbL?5gdHJNW5`6W8[eho^38?;R459L4WN1Jg[egNX[3[_&gt;lAAY&gt;L9Z_H5YN]9:KZMj\cPGZco]??=ig[hH7YShgPS8:44leI:@9R?fLHKlH6UZ]nlAXHFAFUn7AdT=;FK^oZgocoK[2W_=Aj]T;2mBd8`7h`B0K&gt;IP&lt;04@S6]dA9N`8Q8YBk19T@8RFF4T29OB1V7TX7QM01@hI@3`QJ=4@H\nBkS2d5P1BDgN8?4B230Y8lb8ONC@?IPH0A@OMPD?HZ@1`&gt;mj`5N5c60PN06hNI1c8`@k6b0M9IN3`QM68;M1l5Bl&gt;6cX&gt;XD78V@S2j5Ad;C&lt;0cA7OX0nM8&lt;iaN3K0@0Kil664BNSOe:0@R=6NA66f9@PX0d0dHb:LL\6@1aSJl[5h6I38X&lt;0`;0&lt;Al748MXb84H=@Y&lt;lI\5@GNMD;RJd?DeY0Ac1J230g&gt;d1e00LP8d;&gt;V@59CQA1BG&lt;@2[2A45hE8CX:H0A=a\KRAC&lt;Q0YPRb5D&lt;IR63P1QX&lt;JXCS9a3FQ&gt;daQVRjO4I;1da1URZ;LZ444@R2PX2XAXA9Te@FngkoKI_ea&gt;NZN^m\`1H5CMhX9Bn1?ZYS0WAbR2RD8F3W@XajF1=AXS6&lt;TS4i09PN?`gPUG9G3J26`2GbAW]jGY5&lt;AGn^iZAjM_;W5&lt;g^kKMC]B[X13GZm3mmNffKMhb:cJ]DAT&gt;a?_4H8jZX2PIja6[DFTFC:]l]=1AN=PD`VJ&gt;HX2k?Pj7:bQ`W[XWe0\38&lt;V=I\:]2HOl74S6e0a;ZmCFf:3FnRcED67[hUWZPU7ZZKLUVD\PFX_FVE23Q7WUaWV=U&gt;&lt;ZRLQB8LDd0hS94OC1D?6J9N:\\`US2k:iaJY8jY]eTVWO0KLeICMh3dn\dH86aYA7eY]eZZ3=d6WJLE7IPEWIe=_c4FYLEhdA\b5XoJQE;n[HFdKI7C3oK`RFK6l`B8RhhCXhP8XnP3841548PB6P6B[DKHS41JU&lt;Qne:U\ARQ=B[VDHSOT307XA07Qhn2d8RBoajKU&gt;9P@S2lYle3RId0IIf072nP8&gt;;NUah=0ilGD:G5\RN_\=;5jTD@iTfQNGIfmQJ2oJl[SBFC]DLncWBE4mFZe6d_Ob&gt;3YC4APEA@D_mOFNI8ALek79bT&gt;:a8]EjYToY&lt;]8C`FV4Z``X`1aB@L&lt;?V9ARCQ4c:K71jA4o8X@_N2@;?hf9D0M0]D;:A]?]T5@Y1`&gt;Vi=L5H`I25YCYJTF@F?fd@VbI9Pf6?dDZY8JdAcR`QM5&gt;MT&lt;aOnO7&lt;DiRiB;\k?RRIHVCkC&lt;FWi=5fXF\he2n@Q&gt;2TEkZIo6kBK3\C@]3\oE]=7UY8knVi7O5=^_a6d;G^?DaLI=YY]ARAc7NRDMhAYZlK90=KQlem6G@;;lecBDFecfKNA=H&gt;mJl3I59=NFgn`nf[B1:05f5E[`fiTPQ4EDe1H=4ZRWkf3TWlOP&gt;Ela5hZDn]cQJC=UBXIIJdWiR@KZe]DHRbmfI;]VYoi&gt;o?3K1h=6</protected>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='21'>
+			<Action classname='StepType' isroottypedef='true' typecategory='1' timestamp='1618215606' typeversion='21.0.0.2' typelastmodversion='21.0.0.0' typeminprodversion='21.0.0.0' typeflags='33554446'>
+				<subprops>
+					<Substeps typename='StepTypeSubstepsArray' xsi:type='StepTypeSubstepsArray' classname='Objs' flagsforinstances='524312' instanceoverrideflags='655384'>
+						<value lbound='[0]' ubound='[]'/>
+					</Substeps>
+					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
+						<value>ResStr("NI_STEPTYPES", "ACTION_DESCRIPTION_NAME") + (("%ModuleDescription" == "") ? "" : ",  %ModuleDescription")</value>
+					</DescriptionFormat>
+					<DefaultNameFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
+						<value>ResStr("NI_STEPTYPES", "ACTION_DEF_STEP_NAME")</value>
+					</DefaultNameFormat>
+					<Menu typename='StepTypeMenu' xsi:type='StepTypeMenu' classname='Obj' flagsforinstances='524312' instanceoverrideflags='524312'>
+						<subprops>
+							<CanBeSubstepType classname='Bool'>
+								<value>false</value>
+							</CanBeSubstepType>
+							<CanOnlyBeSubstepType classname='Bool'>
+								<value>false</value>
+							</CanOnlyBeSubstepType>
+							<Category classname='Str'>
+								<value>""</value>
+							</Category>
+							<ItemName classname='ExprValue'>
+								<value>ResStr("NI_STEPTYPES", "ACTION_MENU_ITEM_NAME")</value>
+							</ItemName>
+							<SingularItemName classname='Str'>
+								<value>""</value>
+							</SingularItemName>
+							<SeparatorBeforeCategory classname='Bool'>
+								<value>false</value>
+							</SeparatorBeforeCategory>
+							<SeparatorBeforeItemName classname='Bool'>
+								<value>false</value>
+							</SeparatorBeforeItemName>
+							<Group classname='Str'>
+								<value>Action</value>
+							</Group>
+						</subprops>
+					</Menu>
+					<AdditionalResultsHints classname='Objs' valueflags='4194328' structureflags='524288'>
+						<value lbound='[0]' ubound='[]'>
+							<elemproto>
+								<_NAME_IN_ATTRIBUTE_ typename='NI_CustomResult' xsi:type='NI_CustomResult' name='' classname='CustomResult'>
+									<subprops>
+										<Name classname='ExprValue'>
+											<value/>
+										</Name>
+										<ValueToLog classname='ExprValue'>
+											<value/>
+										</ValueToLog>
+										<Condition classname='ExprValue'>
+											<value/>
+										</Condition>
+										<Flags classname='Num'>
+											<value>8192</value>
+										</Flags>
+										<CheckedState classname='Num'>
+											<value>2</value>
+										</CheckedState>
+										<Type classname='PropertyObjectType'>
+											<subprops>
+												<ValueType classname='Num'>
+													<value>3</value>
+												</ValueType>
+												<IsObject classname='Bool'>
+													<value>true</value>
+												</IsObject>
+												<TypeName classname='Str'>
+													<value/>
+												</TypeName>
+												<ElementType classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</ElementType>
+												<ArrayDimensions classname='ArrayDimensions'>
+													<subprops>
+														<LowerBounds classname='Nums'>
+															<value lbound='[0]' ubound='[]'/>
+														</LowerBounds>
+														<UpperBounds classname='Nums'>
+															<value lbound='[0]' ubound='[]'/>
+														</UpperBounds>
+													</subprops>
+												</ArrayDimensions>
+												<Representation classname='Num'>
+													<value>1</value>
+												</Representation>
+												<ClassName classname='Str'>
+													<value/>
+												</ClassName>
+											</subprops>
+										</Type>
+										<Elements classname='Objs'>
+											<value lbound='[0]' ubound='[]'/>
+										</Elements>
+										<IsAnyType classname='Bool'>
+											<value>true</value>
+										</IsAnyType>
+									</subprops>
+								</_NAME_IN_ATTRIBUTE_>
+							</elemproto>
+						</value>
+					</AdditionalResultsHints>
+					<TS typename='TEInf' xsi:type='TEInf' classname='Obj' flagsforinstances='262168' instanceoverrideflags='4456472'>
+						<subprops>
+							<Id classname='Str'>
+								<value/>
+							</Id>
+							<Icon classname='Str'>
+								<value/>
+							</Icon>
+							<SData classname='Obj' flagsforinstances='2097152' instanceoverrideflags='7143448' structureflags='2097152'/>
+							<PreCond classname='ExprValue'>
+								<value/>
+							</PreCond>
+							<LoadOpt classname='Str'>
+								<value>PreloadWhenExecuted</value>
+							</LoadOpt>
+							<UnloadOpt classname='Str'>
+								<value>UnloadWithFile</value>
+							</UnloadOpt>
+							<Mode classname='Str'>
+								<value>Normal</value>
+							</Mode>
+							<WindowActivation classname='Str'>
+								<value>None</value>
+							</WindowActivation>
+							<ResultOption classname='Num'>
+								<value>1</value>
+							</ResultOption>
+							<StepFCSeqF classname='Bool'>
+								<value>true</value>
+							</StepFCSeqF>
+							<IgnoreRTE classname='Bool'>
+								<value>false</value>
+							</IgnoreRTE>
+							<UseMutex classname='Bool'>
+								<value>false</value>
+							</UseMutex>
+							<MutexNameOrRef classname='ExprValue'>
+								<value/>
+							</MutexNameOrRef>
+							<BatchSyncOpt classname='Num'>
+								<value>0</value>
+							</BatchSyncOpt>
+							<SwitchEnabled classname='Bool'>
+								<value>false</value>
+							</SwitchEnabled>
+							<VirtualDeviceName classname='ExprValue'>
+								<value/>
+							</VirtualDeviceName>
+							<SwitchOperation classname='Num'>
+								<value>1</value>
+							</SwitchOperation>
+							<RouteGroupConnect classname='ExprValue'>
+								<value/>
+							</RouteGroupConnect>
+							<RouteGroupDisconnect classname='ExprValue'>
+								<value/>
+							</RouteGroupDisconnect>
+							<MulticonnectMode classname='Num'>
+								<value>1</value>
+							</MulticonnectMode>
+							<OperationOrder classname='Num'>
+								<value>2</value>
+							</OperationOrder>
+							<ConnectionLifetime classname='Num'>
+								<value>0</value>
+							</ConnectionLifetime>
+							<WaitForDebounce classname='Bool'>
+								<value>true</value>
+							</WaitForDebounce>
+							<PassAct classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
+								<value>Next</value>
+							</PassAct>
+							<FailAct classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
+								<value>Next</value>
+							</FailAct>
+							<PassActTarget classname='ExprValue' flagsforinstances='1' instanceoverrideflags='5046297'>
+								<value/>
+							</PassActTarget>
+							<FailActTarget classname='ExprValue' flagsforinstances='1' instanceoverrideflags='5046297'>
+								<value/>
+							</FailActTarget>
+							<CustExpr classname='ExprValue'>
+								<value/>
+							</CustExpr>
+							<CustTrueAct classname='Str'>
+								<value>Next</value>
+							</CustTrueAct>
+							<CustFalseAct classname='Str'>
+								<value>Next</value>
+							</CustFalseAct>
+							<CustTrueActTarget classname='ExprValue'>
+								<value/>
+							</CustTrueActTarget>
+							<CustFalseActTarget classname='ExprValue'>
+								<value/>
+							</CustFalseActTarget>
+							<LoopType classname='Str'>
+								<value>NoLooping</value>
+							</LoopType>
+							<LoopWhile classname='ExprValue'>
+								<value/>
+							</LoopWhile>
+							<LoopStatus classname='ExprValue'>
+								<value/>
+							</LoopStatus>
+							<LoopIncrement classname='ExprValue'>
+								<value>RunState.LoopIndex += 1</value>
+							</LoopIncrement>
+							<LoopInitialize classname='ExprValue'>
+								<value>RunState.LoopIndex = 0</value>
+							</LoopInitialize>
+							<LoopOpt classname='Num'>
+								<value>0</value>
+							</LoopOpt>
+							<PreExpr classname='ExprValue'>
+								<value/>
+							</PreExpr>
+							<PostExpr classname='ExprValue'>
+								<value/>
+							</PostExpr>
+							<StatusExpr classname='ExprValue'>
+								<value/>
+							</StatusExpr>
+							<CanSpecifyModule classname='Bool'>
+								<value>true</value>
+							</CanSpecifyModule>
+							<CanEditCode classname='Bool'>
+								<value>true</value>
+							</CanEditCode>
+							<CanEditModulePrototype classname='Bool'>
+								<value>true</value>
+							</CanEditModulePrototype>
+							<CanEditParameterAdditionalResults classname='Bool'>
+								<value>true</value>
+							</CanEditParameterAdditionalResults>
+							<PrecondIntExe classname='Num'>
+								<value>0</value>
+							</PrecondIntExe>
+							<Requirements classname='Obj' flagsforinstances='1' valueflags='1' structureflags='2097152'>
+								<subprops>
+									<Links classname='Strs' flagsforinstances='71303168' instanceoverrideflags='72286233' valueflags='71303168'>
+										<value lbound='[0]' ubound='[]'/>
+									</Links>
+								</subprops>
+							</Requirements>
+							<CustomResults classname='Objs'>
+								<value lbound='[0]' ubound='[]'>
+									<elemproto>
+										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+											<subprops>
+												<Name classname='ExprValue'>
+													<value/>
+												</Name>
+												<ValueToLog classname='ExprValue'>
+													<value/>
+												</ValueToLog>
+												<Condition classname='ExprValue'>
+													<value/>
+												</Condition>
+												<Flags classname='Num'>
+													<value>8192</value>
+												</Flags>
+												<CheckedState classname='Num'>
+													<value>2</value>
+												</CheckedState>
+												<Type classname='PropertyObjectType'>
+													<subprops>
+														<ValueType classname='Num'>
+															<value>3</value>
+														</ValueType>
+														<IsObject classname='Bool'>
+															<value>true</value>
+														</IsObject>
+														<TypeName classname='Str'>
+															<value/>
+														</TypeName>
+														<ElementType classname='Objs'>
+															<value lbound='[0]' ubound='[]'/>
+														</ElementType>
+														<ArrayDimensions classname='ArrayDimensions'>
+															<subprops>
+																<LowerBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</LowerBounds>
+																<UpperBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</UpperBounds>
+															</subprops>
+														</ArrayDimensions>
+														<Representation classname='Num'>
+															<value>1</value>
+														</Representation>
+														<ClassName classname='Str'>
+															<value/>
+														</ClassName>
+													</subprops>
+												</Type>
+												<Elements classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</Elements>
+												<IsAnyType classname='Bool'>
+													<value>true</value>
+												</IsAnyType>
+											</subprops>
+										</_NAME_IN_ATTRIBUTE_>
+									</elemproto>
+								</value>
+							</CustomResults>
+							<AdditionalResultsHints classname='Objs'>
+								<value lbound='[0]' ubound='[]'>
+									<elemproto>
+										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+											<subprops>
+												<Name classname='ExprValue'>
+													<value/>
+												</Name>
+												<ValueToLog classname='ExprValue'>
+													<value/>
+												</ValueToLog>
+												<Condition classname='ExprValue'>
+													<value/>
+												</Condition>
+												<Flags classname='Num'>
+													<value>8192</value>
+												</Flags>
+												<CheckedState classname='Num'>
+													<value>2</value>
+												</CheckedState>
+												<Type classname='PropertyObjectType'>
+													<subprops>
+														<ValueType classname='Num'>
+															<value>3</value>
+														</ValueType>
+														<IsObject classname='Bool'>
+															<value>true</value>
+														</IsObject>
+														<TypeName classname='Str'>
+															<value/>
+														</TypeName>
+														<ElementType classname='Objs'>
+															<value lbound='[0]' ubound='[]'/>
+														</ElementType>
+														<ArrayDimensions classname='ArrayDimensions'>
+															<subprops>
+																<LowerBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</LowerBounds>
+																<UpperBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</UpperBounds>
+															</subprops>
+														</ArrayDimensions>
+														<Representation classname='Num'>
+															<value>1</value>
+														</Representation>
+														<ClassName classname='Str'>
+															<value/>
+														</ClassName>
+													</subprops>
+												</Type>
+												<Elements classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</Elements>
+												<IsAnyType classname='Bool'>
+													<value>true</value>
+												</IsAnyType>
+											</subprops>
+										</_NAME_IN_ATTRIBUTE_>
+									</elemproto>
+								</value>
+							</AdditionalResultsHints>
+						</subprops>
+					</TS>
+					<NI_Data typename='StepTypeNIData' xsi:type='StepTypeNIData' classname='Obj'>
+						<subprops>
+							<EditPanels classname='Strs'>
+								<value lbound='[0]' ubound='[]'/>
+							</EditPanels>
+						</subprops>
+					</NI_Data>
+					<Result classname='Obj' flagsforinstances='4194304' valueflags='4194304'>
+						<subprops>
+							<Error typename='Error' xsi:type='Error' classname='Obj' flagsforinstances='4194304' instanceoverrideflags='4194304' valueflags='4194304'>
+								<subprops>
+									<Code classname='Num'>
+										<value>0</value>
+									</Code>
+									<Msg classname='Str'>
+										<value/>
+									</Msg>
+									<Occurred classname='Bool'>
+										<value>false</value>
+									</Occurred>
+								</subprops>
+							</Error>
+							<Status classname='Str' flagsforinstances='4194304' valueflags='4194304'>
+								<value/>
+							</Status>
+							<ReportText classname='Str' flagsforinstances='4194304' valueflags='4194304'>
+								<value/>
+							</ReportText>
+							<Common typename='CommonResults' xsi:type='CommonResults' classname='Obj' instanceoverrideflags='4194304'/>
+						</subprops>
+					</Result>
+					<CodeTemplates classname='Str' valueflags='4194328' structureflags='524288'>
+						<value>DefaultLabVIEW|DefaultLabVIEWNXG|DefaultCVI|DefaultVB.NET|DefaultCSharp.NET|DefaultC++.NET|DefaultVC++_Template|DefaultHTB72_Template|DefaultHTB80_Template|Default_Template</value>
+					</CodeTemplates>
+					<BlockStartTypes classname='Str' valueflags='4194328' structureflags='524288'>
+						<value/>
+					</BlockStartTypes>
+					<BlockEndTypes classname='Str' valueflags='4194328' structureflags='524288'>
+						<value/>
+					</BlockEndTypes>
+					<AppliesToBlockStructure classname='Bool' valueflags='4194328' structureflags='524288'>
+						<value>false</value>
+					</AppliesToBlockStructure>
+					<CanEncapsulate classname='Bool' valueflags='4194328' structureflags='524288'>
+						<value>false</value>
+					</CanEncapsulate>
+					<Category classname='Str' valueflags='24' structureflags='524288'>
+						<value>Action</value>
+					</Category>
+				</subprops>
+			</Action>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='29'>
+			<NI_PythonParameterResult classname='PythonParameterResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+				<subprops>
+					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</Condition>
+					<Flags classname='Num'>
+						<value>8192</value>
+						<numericfmt>%#x</numericfmt>
+					</Flags>
+					<CheckedState classname='Num'>
+						<value>1</value>
+					</CheckedState>
+				</subprops>
+			</NI_PythonParameterResult>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='28'>
+			<NI_PythonParameter classname='CPythonParameter' isroottypedef='true' typecategory='3' timestamp='1650060872' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+				<subprops>
+					<Name classname='Str'>
+						<value>_notNamed</value>
+					</Name>
+					<Type classname='Num'>
+						<value>7</value>
+					</Type>
+					<ArgumentValue typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</ArgumentValue>
+					<ArgumentDisplayValue typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</ArgumentDisplayValue>
+					<AdditionalResults classname='Obj'>
+						<subprops>
+							<Input typename='NI_PythonParameterResult' xsi:type='NI_PythonParameterResult' classname='PythonParameterResult'>
+								<subprops>
+									<Condition classname='ExprValue'>
+										<value/>
+									</Condition>
+									<Flags classname='Num'>
+										<value>8192</value>
+									</Flags>
+									<CheckedState classname='Num'>
+										<value>1</value>
+									</CheckedState>
+								</subprops>
+							</Input>
+							<Output typename='NI_PythonParameterResult' xsi:type='NI_PythonParameterResult' classname='PythonParameterResult'>
+								<subprops>
+									<Condition classname='ExprValue'>
+										<value/>
+									</Condition>
+									<Flags classname='Num'>
+										<value>8192</value>
+									</Flags>
+									<CheckedState classname='Num'>
+										<value>1</value>
+									</CheckedState>
+								</subprops>
+							</Output>
+						</subprops>
+					</AdditionalResults>
+				</subprops>
+			</NI_PythonParameter>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='27'>
+			<PythonStepAdditions classname='CPythonModule' isroottypedef='true' typecategory='3' timestamp='1650060872' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+				<subprops>
+					<PythonCall classname='CPythonCall'>
+						<subprops>
+							<UseAdapterSettingsForInterpreterSession classname='Bool'>
+								<value>true</value>
+							</UseAdapterSettingsForInterpreterSession>
+							<InterpreterSessionScope classname='Num'>
+								<value>3</value>
+							</InterpreterSessionScope>
+							<PythonVersion classname='Str'>
+								<value/>
+							</PythonVersion>
+							<PythonVirtualEnvironmentPath classname='Str'>
+								<value/>
+							</PythonVirtualEnvironmentPath>
+							<InterpreterLocation typename='Expression' xsi:type='Expression' classname='ExprValue'>
+								<value/>
+							</InterpreterLocation>
+							<CreateIfInterpreterDoesNotExist classname='Bool'>
+								<value>true</value>
+							</CreateIfInterpreterDoesNotExist>
+							<ModulePath typename='Path' xsi:type='Path' classname='PathValue'>
+								<value/>
+							</ModulePath>
+							<OperationType classname='Num'>
+								<value>1</value>
+							</OperationType>
+							<OperationScope classname='Num'>
+								<value>0</value>
+							</OperationScope>
+							<ClassName classname='Str'>
+								<value/>
+							</ClassName>
+							<ClassInstanceLocation typename='Expression' xsi:type='Expression' classname='ExprValue'>
+								<value/>
+							</ClassInstanceLocation>
+							<FunctionOrAttributeName classname='Str'>
+								<value/>
+							</FunctionOrAttributeName>
+							<Parameters classname='Objs'>
+								<value lbound='[0]' ubound='[0]'>
+									<elemproto>
+										<_NAME_IN_ATTRIBUTE_ typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name='' classname='CPythonParameter' structureflags='131072'>
+											<subprops>
+												<Name classname='Str'>
+													<value>_notNamed</value>
+												</Name>
+												<Type classname='Num'>
+													<value>7</value>
+												</Type>
+												<ArgumentValue classname='ExprValue'>
+													<value/>
+												</ArgumentValue>
+												<ArgumentDisplayValue classname='ExprValue'>
+													<value/>
+												</ArgumentDisplayValue>
+												<AdditionalResults classname='Obj'>
+													<subprops>
+														<Input classname='PythonParameterResult'>
+															<subprops>
+																<Condition classname='ExprValue'>
+																	<value/>
+																</Condition>
+																<Flags classname='Num'>
+																	<value>8192</value>
+																</Flags>
+																<CheckedState classname='Num'>
+																	<value>1</value>
+																</CheckedState>
+															</subprops>
+														</Input>
+														<Output classname='PythonParameterResult'>
+															<subprops>
+																<Condition classname='ExprValue'>
+																	<value/>
+																</Condition>
+																<Flags classname='Num'>
+																	<value>8192</value>
+																</Flags>
+																<CheckedState classname='Num'>
+																	<value>1</value>
+																</CheckedState>
+															</subprops>
+														</Output>
+													</subprops>
+												</AdditionalResults>
+											</subprops>
+										</_NAME_IN_ATTRIBUTE_>
+									</elemproto>
+									<value>
+										<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
+											<subprops>
+												<Name classname='Str'>
+													<value>Return Value</value>
+												</Name>
+												<Type classname='Num'>
+													<value>7</value>
+												</Type>
+												<ArgumentValue classname='ExprValue'>
+													<value/>
+												</ArgumentValue>
+												<ArgumentDisplayValue classname='ExprValue'>
+													<value/>
+												</ArgumentDisplayValue>
+												<AdditionalResults classname='Obj'>
+													<subprops>
+														<Input classname='PythonParameterResult'>
+															<subprops>
+																<Condition classname='ExprValue'>
+																	<value/>
+																</Condition>
+																<Flags classname='Num'>
+																	<value>8192</value>
+																</Flags>
+																<CheckedState classname='Num'>
+																	<value>1</value>
+																</CheckedState>
+															</subprops>
+														</Input>
+														<Output classname='PythonParameterResult'>
+															<subprops>
+																<Condition classname='ExprValue'>
+																	<value/>
+																</Condition>
+																<Flags classname='Num'>
+																	<value>8192</value>
+																</Flags>
+																<CheckedState classname='Num'>
+																	<value>1</value>
+																</CheckedState>
+															</subprops>
+														</Output>
+													</subprops>
+												</AdditionalResults>
+											</subprops>
+										</CPythonParameter>
+									</value>
+								</value>
+							</Parameters>
+							<DefaultParamCategoryForArray classname='Num'>
+								<value>5</value>
+							</DefaultParamCategoryForArray>
+						</subprops>
+					</PythonCall>
+				</subprops>
+			</PythonStepAdditions>
+		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='22'>
 			<EditSubstep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
 				<subprops>
@@ -3592,647 +4233,6 @@
 				</subprops>
 			</Statement>
 		</typedef>
-		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='21'>
-			<Action classname='StepType' isroottypedef='true' typecategory='1' timestamp='1618215606' typeversion='21.0.0.2' typelastmodversion='21.0.0.0' typeminprodversion='21.0.0.0' typeflags='33554446'>
-				<subprops>
-					<Substeps typename='StepTypeSubstepsArray' xsi:type='StepTypeSubstepsArray' classname='Objs' flagsforinstances='524312' instanceoverrideflags='655384'>
-						<value lbound='[0]' ubound='[]'/>
-					</Substeps>
-					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
-						<value>ResStr("NI_STEPTYPES", "ACTION_DESCRIPTION_NAME") + (("%ModuleDescription" == "") ? "" : ",  %ModuleDescription")</value>
-					</DescriptionFormat>
-					<DefaultNameFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
-						<value>ResStr("NI_STEPTYPES", "ACTION_DEF_STEP_NAME")</value>
-					</DefaultNameFormat>
-					<Menu typename='StepTypeMenu' xsi:type='StepTypeMenu' classname='Obj' flagsforinstances='524312' instanceoverrideflags='524312'>
-						<subprops>
-							<CanBeSubstepType classname='Bool'>
-								<value>false</value>
-							</CanBeSubstepType>
-							<CanOnlyBeSubstepType classname='Bool'>
-								<value>false</value>
-							</CanOnlyBeSubstepType>
-							<Category classname='Str'>
-								<value>""</value>
-							</Category>
-							<ItemName classname='ExprValue'>
-								<value>ResStr("NI_STEPTYPES", "ACTION_MENU_ITEM_NAME")</value>
-							</ItemName>
-							<SingularItemName classname='Str'>
-								<value>""</value>
-							</SingularItemName>
-							<SeparatorBeforeCategory classname='Bool'>
-								<value>false</value>
-							</SeparatorBeforeCategory>
-							<SeparatorBeforeItemName classname='Bool'>
-								<value>false</value>
-							</SeparatorBeforeItemName>
-							<Group classname='Str'>
-								<value>Action</value>
-							</Group>
-						</subprops>
-					</Menu>
-					<AdditionalResultsHints classname='Objs' valueflags='4194328' structureflags='524288'>
-						<value lbound='[0]' ubound='[]'>
-							<elemproto>
-								<_NAME_IN_ATTRIBUTE_ typename='NI_CustomResult' xsi:type='NI_CustomResult' name='' classname='CustomResult'>
-									<subprops>
-										<Name classname='ExprValue'>
-											<value/>
-										</Name>
-										<ValueToLog classname='ExprValue'>
-											<value/>
-										</ValueToLog>
-										<Condition classname='ExprValue'>
-											<value/>
-										</Condition>
-										<Flags classname='Num'>
-											<value>8192</value>
-										</Flags>
-										<CheckedState classname='Num'>
-											<value>2</value>
-										</CheckedState>
-										<Type classname='PropertyObjectType'>
-											<subprops>
-												<ValueType classname='Num'>
-													<value>3</value>
-												</ValueType>
-												<IsObject classname='Bool'>
-													<value>true</value>
-												</IsObject>
-												<TypeName classname='Str'>
-													<value/>
-												</TypeName>
-												<ElementType classname='Objs'>
-													<value lbound='[0]' ubound='[]'/>
-												</ElementType>
-												<ArrayDimensions classname='ArrayDimensions'>
-													<subprops>
-														<LowerBounds classname='Nums'>
-															<value lbound='[0]' ubound='[]'/>
-														</LowerBounds>
-														<UpperBounds classname='Nums'>
-															<value lbound='[0]' ubound='[]'/>
-														</UpperBounds>
-													</subprops>
-												</ArrayDimensions>
-												<Representation classname='Num'>
-													<value>1</value>
-												</Representation>
-												<ClassName classname='Str'>
-													<value/>
-												</ClassName>
-											</subprops>
-										</Type>
-										<Elements classname='Objs'>
-											<value lbound='[0]' ubound='[]'/>
-										</Elements>
-										<IsAnyType classname='Bool'>
-											<value>true</value>
-										</IsAnyType>
-									</subprops>
-								</_NAME_IN_ATTRIBUTE_>
-							</elemproto>
-						</value>
-					</AdditionalResultsHints>
-					<TS typename='TEInf' xsi:type='TEInf' classname='Obj' flagsforinstances='262168' instanceoverrideflags='4456472'>
-						<subprops>
-							<Id classname='Str'>
-								<value/>
-							</Id>
-							<Icon classname='Str'>
-								<value/>
-							</Icon>
-							<SData classname='Obj' flagsforinstances='2097152' instanceoverrideflags='7143448' structureflags='2097152'/>
-							<PreCond classname='ExprValue'>
-								<value/>
-							</PreCond>
-							<LoadOpt classname='Str'>
-								<value>PreloadWhenExecuted</value>
-							</LoadOpt>
-							<UnloadOpt classname='Str'>
-								<value>UnloadWithFile</value>
-							</UnloadOpt>
-							<Mode classname='Str'>
-								<value>Normal</value>
-							</Mode>
-							<WindowActivation classname='Str'>
-								<value>None</value>
-							</WindowActivation>
-							<ResultOption classname='Num'>
-								<value>1</value>
-							</ResultOption>
-							<StepFCSeqF classname='Bool'>
-								<value>true</value>
-							</StepFCSeqF>
-							<IgnoreRTE classname='Bool'>
-								<value>false</value>
-							</IgnoreRTE>
-							<UseMutex classname='Bool'>
-								<value>false</value>
-							</UseMutex>
-							<MutexNameOrRef classname='ExprValue'>
-								<value/>
-							</MutexNameOrRef>
-							<BatchSyncOpt classname='Num'>
-								<value>0</value>
-							</BatchSyncOpt>
-							<SwitchEnabled classname='Bool'>
-								<value>false</value>
-							</SwitchEnabled>
-							<VirtualDeviceName classname='ExprValue'>
-								<value/>
-							</VirtualDeviceName>
-							<SwitchOperation classname='Num'>
-								<value>1</value>
-							</SwitchOperation>
-							<RouteGroupConnect classname='ExprValue'>
-								<value/>
-							</RouteGroupConnect>
-							<RouteGroupDisconnect classname='ExprValue'>
-								<value/>
-							</RouteGroupDisconnect>
-							<MulticonnectMode classname='Num'>
-								<value>1</value>
-							</MulticonnectMode>
-							<OperationOrder classname='Num'>
-								<value>2</value>
-							</OperationOrder>
-							<ConnectionLifetime classname='Num'>
-								<value>0</value>
-							</ConnectionLifetime>
-							<WaitForDebounce classname='Bool'>
-								<value>true</value>
-							</WaitForDebounce>
-							<PassAct classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
-								<value>Next</value>
-							</PassAct>
-							<FailAct classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
-								<value>Next</value>
-							</FailAct>
-							<PassActTarget classname='ExprValue' flagsforinstances='1' instanceoverrideflags='5046297'>
-								<value/>
-							</PassActTarget>
-							<FailActTarget classname='ExprValue' flagsforinstances='1' instanceoverrideflags='5046297'>
-								<value/>
-							</FailActTarget>
-							<CustExpr classname='ExprValue'>
-								<value/>
-							</CustExpr>
-							<CustTrueAct classname='Str'>
-								<value>Next</value>
-							</CustTrueAct>
-							<CustFalseAct classname='Str'>
-								<value>Next</value>
-							</CustFalseAct>
-							<CustTrueActTarget classname='ExprValue'>
-								<value/>
-							</CustTrueActTarget>
-							<CustFalseActTarget classname='ExprValue'>
-								<value/>
-							</CustFalseActTarget>
-							<LoopType classname='Str'>
-								<value>NoLooping</value>
-							</LoopType>
-							<LoopWhile classname='ExprValue'>
-								<value/>
-							</LoopWhile>
-							<LoopStatus classname='ExprValue'>
-								<value/>
-							</LoopStatus>
-							<LoopIncrement classname='ExprValue'>
-								<value>RunState.LoopIndex += 1</value>
-							</LoopIncrement>
-							<LoopInitialize classname='ExprValue'>
-								<value>RunState.LoopIndex = 0</value>
-							</LoopInitialize>
-							<LoopOpt classname='Num'>
-								<value>0</value>
-							</LoopOpt>
-							<PreExpr classname='ExprValue'>
-								<value/>
-							</PreExpr>
-							<PostExpr classname='ExprValue'>
-								<value/>
-							</PostExpr>
-							<StatusExpr classname='ExprValue'>
-								<value/>
-							</StatusExpr>
-							<CanSpecifyModule classname='Bool'>
-								<value>true</value>
-							</CanSpecifyModule>
-							<CanEditCode classname='Bool'>
-								<value>true</value>
-							</CanEditCode>
-							<CanEditModulePrototype classname='Bool'>
-								<value>true</value>
-							</CanEditModulePrototype>
-							<CanEditParameterAdditionalResults classname='Bool'>
-								<value>true</value>
-							</CanEditParameterAdditionalResults>
-							<PrecondIntExe classname='Num'>
-								<value>0</value>
-							</PrecondIntExe>
-							<Requirements classname='Obj' flagsforinstances='1' valueflags='1' structureflags='2097152'>
-								<subprops>
-									<Links classname='Strs' flagsforinstances='71303168' instanceoverrideflags='72286233' valueflags='71303168'>
-										<value lbound='[0]' ubound='[]'/>
-									</Links>
-								</subprops>
-							</Requirements>
-							<CustomResults classname='Objs'>
-								<value lbound='[0]' ubound='[]'>
-									<elemproto>
-										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-											<subprops>
-												<Name classname='ExprValue'>
-													<value/>
-												</Name>
-												<ValueToLog classname='ExprValue'>
-													<value/>
-												</ValueToLog>
-												<Condition classname='ExprValue'>
-													<value/>
-												</Condition>
-												<Flags classname='Num'>
-													<value>8192</value>
-												</Flags>
-												<CheckedState classname='Num'>
-													<value>2</value>
-												</CheckedState>
-												<Type classname='PropertyObjectType'>
-													<subprops>
-														<ValueType classname='Num'>
-															<value>3</value>
-														</ValueType>
-														<IsObject classname='Bool'>
-															<value>true</value>
-														</IsObject>
-														<TypeName classname='Str'>
-															<value/>
-														</TypeName>
-														<ElementType classname='Objs'>
-															<value lbound='[0]' ubound='[]'/>
-														</ElementType>
-														<ArrayDimensions classname='ArrayDimensions'>
-															<subprops>
-																<LowerBounds classname='Nums'>
-																	<value lbound='[0]' ubound='[]'/>
-																</LowerBounds>
-																<UpperBounds classname='Nums'>
-																	<value lbound='[0]' ubound='[]'/>
-																</UpperBounds>
-															</subprops>
-														</ArrayDimensions>
-														<Representation classname='Num'>
-															<value>1</value>
-														</Representation>
-														<ClassName classname='Str'>
-															<value/>
-														</ClassName>
-													</subprops>
-												</Type>
-												<Elements classname='Objs'>
-													<value lbound='[0]' ubound='[]'/>
-												</Elements>
-												<IsAnyType classname='Bool'>
-													<value>true</value>
-												</IsAnyType>
-											</subprops>
-										</_NAME_IN_ATTRIBUTE_>
-									</elemproto>
-								</value>
-							</CustomResults>
-							<AdditionalResultsHints classname='Objs'>
-								<value lbound='[0]' ubound='[]'>
-									<elemproto>
-										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-											<subprops>
-												<Name classname='ExprValue'>
-													<value/>
-												</Name>
-												<ValueToLog classname='ExprValue'>
-													<value/>
-												</ValueToLog>
-												<Condition classname='ExprValue'>
-													<value/>
-												</Condition>
-												<Flags classname='Num'>
-													<value>8192</value>
-												</Flags>
-												<CheckedState classname='Num'>
-													<value>2</value>
-												</CheckedState>
-												<Type classname='PropertyObjectType'>
-													<subprops>
-														<ValueType classname='Num'>
-															<value>3</value>
-														</ValueType>
-														<IsObject classname='Bool'>
-															<value>true</value>
-														</IsObject>
-														<TypeName classname='Str'>
-															<value/>
-														</TypeName>
-														<ElementType classname='Objs'>
-															<value lbound='[0]' ubound='[]'/>
-														</ElementType>
-														<ArrayDimensions classname='ArrayDimensions'>
-															<subprops>
-																<LowerBounds classname='Nums'>
-																	<value lbound='[0]' ubound='[]'/>
-																</LowerBounds>
-																<UpperBounds classname='Nums'>
-																	<value lbound='[0]' ubound='[]'/>
-																</UpperBounds>
-															</subprops>
-														</ArrayDimensions>
-														<Representation classname='Num'>
-															<value>1</value>
-														</Representation>
-														<ClassName classname='Str'>
-															<value/>
-														</ClassName>
-													</subprops>
-												</Type>
-												<Elements classname='Objs'>
-													<value lbound='[0]' ubound='[]'/>
-												</Elements>
-												<IsAnyType classname='Bool'>
-													<value>true</value>
-												</IsAnyType>
-											</subprops>
-										</_NAME_IN_ATTRIBUTE_>
-									</elemproto>
-								</value>
-							</AdditionalResultsHints>
-						</subprops>
-					</TS>
-					<NI_Data typename='StepTypeNIData' xsi:type='StepTypeNIData' classname='Obj'>
-						<subprops>
-							<EditPanels classname='Strs'>
-								<value lbound='[0]' ubound='[]'/>
-							</EditPanels>
-						</subprops>
-					</NI_Data>
-					<Result classname='Obj' flagsforinstances='4194304' valueflags='4194304'>
-						<subprops>
-							<Error typename='Error' xsi:type='Error' classname='Obj' flagsforinstances='4194304' instanceoverrideflags='4194304' valueflags='4194304'>
-								<subprops>
-									<Code classname='Num'>
-										<value>0</value>
-									</Code>
-									<Msg classname='Str'>
-										<value/>
-									</Msg>
-									<Occurred classname='Bool'>
-										<value>false</value>
-									</Occurred>
-								</subprops>
-							</Error>
-							<Status classname='Str' flagsforinstances='4194304' valueflags='4194304'>
-								<value/>
-							</Status>
-							<ReportText classname='Str' flagsforinstances='4194304' valueflags='4194304'>
-								<value/>
-							</ReportText>
-							<Common typename='CommonResults' xsi:type='CommonResults' classname='Obj' instanceoverrideflags='4194304'/>
-						</subprops>
-					</Result>
-					<CodeTemplates classname='Str' valueflags='4194328' structureflags='524288'>
-						<value>DefaultLabVIEW|DefaultLabVIEWNXG|DefaultCVI|DefaultVB.NET|DefaultCSharp.NET|DefaultC++.NET|DefaultVC++_Template|DefaultHTB72_Template|DefaultHTB80_Template|Default_Template</value>
-					</CodeTemplates>
-					<BlockStartTypes classname='Str' valueflags='4194328' structureflags='524288'>
-						<value/>
-					</BlockStartTypes>
-					<BlockEndTypes classname='Str' valueflags='4194328' structureflags='524288'>
-						<value/>
-					</BlockEndTypes>
-					<AppliesToBlockStructure classname='Bool' valueflags='4194328' structureflags='524288'>
-						<value>false</value>
-					</AppliesToBlockStructure>
-					<CanEncapsulate classname='Bool' valueflags='4194328' structureflags='524288'>
-						<value>false</value>
-					</CanEncapsulate>
-					<Category classname='Str' valueflags='24' structureflags='524288'>
-						<value>Action</value>
-					</Category>
-				</subprops>
-			</Action>
-		</typedef>
-		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='29'>
-			<NI_PythonParameterResult classname='PythonParameterResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
-				<subprops>
-					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
-						<value/>
-					</Condition>
-					<Flags classname='Num'>
-						<value>8192</value>
-						<numericfmt>%#x</numericfmt>
-					</Flags>
-					<CheckedState classname='Num'>
-						<value>1</value>
-					</CheckedState>
-				</subprops>
-			</NI_PythonParameterResult>
-		</typedef>
-		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='28'>
-			<NI_PythonParameter classname='CPythonParameter' isroottypedef='true' typecategory='3' timestamp='1650060872' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
-				<subprops>
-					<Name classname='Str'>
-						<value>_notNamed</value>
-					</Name>
-					<Type classname='Num'>
-						<value>7</value>
-					</Type>
-					<ArgumentValue typename='Expression' xsi:type='Expression' classname='ExprValue'>
-						<value/>
-					</ArgumentValue>
-					<ArgumentDisplayValue typename='Expression' xsi:type='Expression' classname='ExprValue'>
-						<value/>
-					</ArgumentDisplayValue>
-					<AdditionalResults classname='Obj'>
-						<subprops>
-							<Input typename='NI_PythonParameterResult' xsi:type='NI_PythonParameterResult' classname='PythonParameterResult'>
-								<subprops>
-									<Condition classname='ExprValue'>
-										<value/>
-									</Condition>
-									<Flags classname='Num'>
-										<value>8192</value>
-									</Flags>
-									<CheckedState classname='Num'>
-										<value>1</value>
-									</CheckedState>
-								</subprops>
-							</Input>
-							<Output typename='NI_PythonParameterResult' xsi:type='NI_PythonParameterResult' classname='PythonParameterResult'>
-								<subprops>
-									<Condition classname='ExprValue'>
-										<value/>
-									</Condition>
-									<Flags classname='Num'>
-										<value>8192</value>
-									</Flags>
-									<CheckedState classname='Num'>
-										<value>1</value>
-									</CheckedState>
-								</subprops>
-							</Output>
-						</subprops>
-					</AdditionalResults>
-				</subprops>
-			</NI_PythonParameter>
-		</typedef>
-		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='27'>
-			<PythonStepAdditions classname='CPythonModule' isroottypedef='true' typecategory='3' timestamp='1650060872' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
-				<subprops>
-					<PythonCall classname='CPythonCall'>
-						<subprops>
-							<UseAdapterSettingsForInterpreterSession classname='Bool'>
-								<value>true</value>
-							</UseAdapterSettingsForInterpreterSession>
-							<InterpreterSessionScope classname='Num'>
-								<value>3</value>
-							</InterpreterSessionScope>
-							<PythonVersion classname='Str'>
-								<value/>
-							</PythonVersion>
-							<PythonVirtualEnvironmentPath classname='Str'>
-								<value/>
-							</PythonVirtualEnvironmentPath>
-							<InterpreterLocation typename='Expression' xsi:type='Expression' classname='ExprValue'>
-								<value/>
-							</InterpreterLocation>
-							<CreateIfInterpreterDoesNotExist classname='Bool'>
-								<value>true</value>
-							</CreateIfInterpreterDoesNotExist>
-							<ModulePath typename='Path' xsi:type='Path' classname='PathValue'>
-								<value/>
-							</ModulePath>
-							<OperationType classname='Num'>
-								<value>1</value>
-							</OperationType>
-							<OperationScope classname='Num'>
-								<value>0</value>
-							</OperationScope>
-							<ClassName classname='Str'>
-								<value/>
-							</ClassName>
-							<ClassInstanceLocation typename='Expression' xsi:type='Expression' classname='ExprValue'>
-								<value/>
-							</ClassInstanceLocation>
-							<FunctionOrAttributeName classname='Str'>
-								<value/>
-							</FunctionOrAttributeName>
-							<Parameters classname='Objs'>
-								<value lbound='[0]' ubound='[0]'>
-									<elemproto>
-										<_NAME_IN_ATTRIBUTE_ typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name='' classname='CPythonParameter' structureflags='131072'>
-											<subprops>
-												<Name classname='Str'>
-													<value>_notNamed</value>
-												</Name>
-												<Type classname='Num'>
-													<value>7</value>
-												</Type>
-												<ArgumentValue classname='ExprValue'>
-													<value/>
-												</ArgumentValue>
-												<ArgumentDisplayValue classname='ExprValue'>
-													<value/>
-												</ArgumentDisplayValue>
-												<AdditionalResults classname='Obj'>
-													<subprops>
-														<Input classname='PythonParameterResult'>
-															<subprops>
-																<Condition classname='ExprValue'>
-																	<value/>
-																</Condition>
-																<Flags classname='Num'>
-																	<value>8192</value>
-																</Flags>
-																<CheckedState classname='Num'>
-																	<value>1</value>
-																</CheckedState>
-															</subprops>
-														</Input>
-														<Output classname='PythonParameterResult'>
-															<subprops>
-																<Condition classname='ExprValue'>
-																	<value/>
-																</Condition>
-																<Flags classname='Num'>
-																	<value>8192</value>
-																</Flags>
-																<CheckedState classname='Num'>
-																	<value>1</value>
-																</CheckedState>
-															</subprops>
-														</Output>
-													</subprops>
-												</AdditionalResults>
-											</subprops>
-										</_NAME_IN_ATTRIBUTE_>
-									</elemproto>
-									<value>
-										<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
-											<subprops>
-												<Name classname='Str'>
-													<value>Return Value</value>
-												</Name>
-												<Type classname='Num'>
-													<value>7</value>
-												</Type>
-												<ArgumentValue classname='ExprValue'>
-													<value/>
-												</ArgumentValue>
-												<ArgumentDisplayValue classname='ExprValue'>
-													<value/>
-												</ArgumentDisplayValue>
-												<AdditionalResults classname='Obj'>
-													<subprops>
-														<Input classname='PythonParameterResult'>
-															<subprops>
-																<Condition classname='ExprValue'>
-																	<value/>
-																</Condition>
-																<Flags classname='Num'>
-																	<value>8192</value>
-																</Flags>
-																<CheckedState classname='Num'>
-																	<value>1</value>
-																</CheckedState>
-															</subprops>
-														</Input>
-														<Output classname='PythonParameterResult'>
-															<subprops>
-																<Condition classname='ExprValue'>
-																	<value/>
-																</Condition>
-																<Flags classname='Num'>
-																	<value>8192</value>
-																</Flags>
-																<CheckedState classname='Num'>
-																	<value>1</value>
-																</CheckedState>
-															</subprops>
-														</Output>
-													</subprops>
-												</AdditionalResults>
-											</subprops>
-										</CPythonParameter>
-									</value>
-								</value>
-							</Parameters>
-							<DefaultParamCategoryForArray classname='Num'>
-								<value>5</value>
-							</DefaultParamCategoryForArray>
-						</subprops>
-					</PythonCall>
-				</subprops>
-			</PythonStepAdditions>
-		</typedef>
 	</typelist>
 	<Data classname='SequenceFileData' valueflags='4194304'>
 		<subprops>
@@ -4801,302 +4801,7 @@
 									</value>
 								</Main>
 								<Setup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[3]'>
-										<value>
-											<Step typename='Statement' xsi:type='Statement' name='Get absolute path to pinmap file'>
-												<subprops>
-													<TS classname='Obj'>
-														<subprops>
-															<Id classname='Str'>
-																<value>ID#:CHEZyO1w7RGuNrjdh1OqZD</value>
-															</Id>
-															<Icon classname='Str'>
-																<value>StatementStep.ico</value>
-															</Icon>
-															<PreCond classname='ExprValue'>
-																<value/>
-															</PreCond>
-															<LoadOpt classname='Str'>
-																<value>PreloadWhenExecuted</value>
-															</LoadOpt>
-															<UnloadOpt classname='Str'>
-																<value>UnloadWithFile</value>
-															</UnloadOpt>
-															<Mode classname='Str'>
-																<value>Normal</value>
-															</Mode>
-															<WindowActivation classname='Str'>
-																<value>None</value>
-															</WindowActivation>
-															<ResultOption classname='Num'>
-																<value>1</value>
-															</ResultOption>
-															<StepFCSeqF classname='Bool'>
-																<value>true</value>
-															</StepFCSeqF>
-															<IgnoreRTE classname='Bool'>
-																<value>false</value>
-															</IgnoreRTE>
-															<UseMutex classname='Bool'>
-																<value>false</value>
-															</UseMutex>
-															<MutexNameOrRef classname='ExprValue'>
-																<value/>
-															</MutexNameOrRef>
-															<BatchSyncOpt classname='Num'>
-																<value>0</value>
-															</BatchSyncOpt>
-															<SwitchEnabled classname='Bool'>
-																<value>false</value>
-															</SwitchEnabled>
-															<VirtualDeviceName classname='ExprValue'>
-																<value/>
-															</VirtualDeviceName>
-															<SwitchOperation classname='Num'>
-																<value>1</value>
-															</SwitchOperation>
-															<RouteGroupConnect classname='ExprValue'>
-																<value/>
-															</RouteGroupConnect>
-															<RouteGroupDisconnect classname='ExprValue'>
-																<value/>
-															</RouteGroupDisconnect>
-															<MulticonnectMode classname='Num'>
-																<value>1</value>
-															</MulticonnectMode>
-															<OperationOrder classname='Num'>
-																<value>2</value>
-															</OperationOrder>
-															<ConnectionLifetime classname='Num'>
-																<value>0</value>
-															</ConnectionLifetime>
-															<WaitForDebounce classname='Bool'>
-																<value>true</value>
-															</WaitForDebounce>
-															<PassAct classname='Str'>
-																<value>Next</value>
-															</PassAct>
-															<FailAct classname='Str'>
-																<value>Next</value>
-															</FailAct>
-															<PassActTarget classname='ExprValue'>
-																<value/>
-															</PassActTarget>
-															<FailActTarget classname='ExprValue'>
-																<value/>
-															</FailActTarget>
-															<CustExpr classname='ExprValue'>
-																<value/>
-															</CustExpr>
-															<CustTrueAct classname='Str'>
-																<value>Next</value>
-															</CustTrueAct>
-															<CustFalseAct classname='Str'>
-																<value>Next</value>
-															</CustFalseAct>
-															<CustTrueActTarget classname='ExprValue'>
-																<value/>
-															</CustTrueActTarget>
-															<CustFalseActTarget classname='ExprValue'>
-																<value/>
-															</CustFalseActTarget>
-															<LoopType classname='Str'>
-																<value>NoLooping</value>
-															</LoopType>
-															<LoopWhile classname='ExprValue'>
-																<value/>
-															</LoopWhile>
-															<LoopStatus classname='ExprValue'>
-																<value/>
-															</LoopStatus>
-															<LoopIncrement classname='ExprValue'>
-																<value>RunState.LoopIndex += 1</value>
-															</LoopIncrement>
-															<LoopInitialize classname='ExprValue'>
-																<value>RunState.LoopIndex = 0</value>
-															</LoopInitialize>
-															<LoopOpt classname='Num'>
-																<value>0</value>
-															</LoopOpt>
-															<PreExpr classname='ExprValue'>
-																<value/>
-															</PreExpr>
-															<PostExpr classname='ExprValue'>
-																<value>FindFile(FileGlobals.MeasurementLink.PinMapFileName,True,FileGlobals.MeasurementLink.PinMapPath)</value>
-															</PostExpr>
-															<StatusExpr classname='ExprValue'>
-																<value/>
-															</StatusExpr>
-															<CanSpecifyModule classname='Bool'>
-																<value>false</value>
-															</CanSpecifyModule>
-															<CanEditCode classname='Bool'>
-																<value>true</value>
-															</CanEditCode>
-															<CanEditModulePrototype classname='Bool'>
-																<value>true</value>
-															</CanEditModulePrototype>
-															<CanEditParameterAdditionalResults classname='Bool'>
-																<value>true</value>
-															</CanEditParameterAdditionalResults>
-															<PrecondIntExe classname='Num'>
-																<value>0</value>
-															</PrecondIntExe>
-															<CustomResults classname='Objs'>
-																<value lbound='[0]' ubound='[]'>
-																	<elemproto>
-																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-																			<subprops>
-																				<Name classname='ExprValue'>
-																					<value/>
-																				</Name>
-																				<ValueToLog classname='ExprValue'>
-																					<value/>
-																				</ValueToLog>
-																				<Condition classname='ExprValue'>
-																					<value/>
-																				</Condition>
-																				<Flags classname='Num'>
-																					<value>8192</value>
-																				</Flags>
-																				<CheckedState classname='Num'>
-																					<value>2</value>
-																				</CheckedState>
-																				<Type classname='PropertyObjectType'>
-																					<subprops>
-																						<ValueType classname='Num'>
-																							<value>3</value>
-																						</ValueType>
-																						<IsObject classname='Bool'>
-																							<value>true</value>
-																						</IsObject>
-																						<TypeName classname='Str'>
-																							<value/>
-																						</TypeName>
-																						<ElementType classname='Objs'>
-																							<value lbound='[0]' ubound='[]'/>
-																						</ElementType>
-																						<ArrayDimensions classname='ArrayDimensions'>
-																							<subprops>
-																								<LowerBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</LowerBounds>
-																								<UpperBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</UpperBounds>
-																							</subprops>
-																						</ArrayDimensions>
-																						<Representation classname='Num'>
-																							<value>1</value>
-																						</Representation>
-																						<ClassName classname='Str'>
-																							<value/>
-																						</ClassName>
-																					</subprops>
-																				</Type>
-																				<Elements classname='Objs'>
-																					<value lbound='[0]' ubound='[]'/>
-																				</Elements>
-																				<IsAnyType classname='Bool'>
-																					<value>true</value>
-																				</IsAnyType>
-																			</subprops>
-																		</_NAME_IN_ATTRIBUTE_>
-																	</elemproto>
-																</value>
-															</CustomResults>
-															<AdditionalResultsHints classname='Objs'>
-																<value lbound='[0]' ubound='[]'>
-																	<elemproto>
-																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-																			<subprops>
-																				<Name classname='ExprValue'>
-																					<value/>
-																				</Name>
-																				<ValueToLog classname='ExprValue'>
-																					<value/>
-																				</ValueToLog>
-																				<Condition classname='ExprValue'>
-																					<value/>
-																				</Condition>
-																				<Flags classname='Num'>
-																					<value>8192</value>
-																				</Flags>
-																				<CheckedState classname='Num'>
-																					<value>2</value>
-																				</CheckedState>
-																				<Type classname='PropertyObjectType'>
-																					<subprops>
-																						<ValueType classname='Num'>
-																							<value>3</value>
-																						</ValueType>
-																						<IsObject classname='Bool'>
-																							<value>true</value>
-																						</IsObject>
-																						<TypeName classname='Str'>
-																							<value/>
-																						</TypeName>
-																						<ElementType classname='Objs'>
-																							<value lbound='[0]' ubound='[]'/>
-																						</ElementType>
-																						<ArrayDimensions classname='ArrayDimensions'>
-																							<subprops>
-																								<LowerBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</LowerBounds>
-																								<UpperBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</UpperBounds>
-																							</subprops>
-																						</ArrayDimensions>
-																						<Representation classname='Num'>
-																							<value>1</value>
-																						</Representation>
-																						<ClassName classname='Str'>
-																							<value/>
-																						</ClassName>
-																					</subprops>
-																				</Type>
-																				<Elements classname='Objs'>
-																					<value lbound='[0]' ubound='[]'/>
-																				</Elements>
-																				<IsAnyType classname='Bool'>
-																					<value>true</value>
-																				</IsAnyType>
-																			</subprops>
-																		</_NAME_IN_ATTRIBUTE_>
-																	</elemproto>
-																</value>
-															</AdditionalResultsHints>
-														</subprops>
-													</TS>
-													<Result classname='Obj'>
-														<subprops>
-															<Error classname='Obj'>
-																<subprops>
-																	<Code classname='Num'>
-																		<value>0</value>
-																	</Code>
-																	<Msg classname='Str'>
-																		<value/>
-																	</Msg>
-																	<Occurred classname='Bool'>
-																		<value>false</value>
-																	</Occurred>
-																</subprops>
-															</Error>
-															<Status classname='Str'>
-																<value/>
-															</Status>
-															<ReportText classname='Str'>
-																<value/>
-															</ReportText>
-															<Common classname='Obj'/>
-														</subprops>
-													</Result>
-												</subprops>
-											</Step>
-										</value>
+									<value lbound='[0]' ubound='[1]'>
 										<value>
 											<Step typename='Action' xsi:type='Action' name='Update pin map'>
 												<subprops>
@@ -5867,301 +5572,6 @@
 															</StatusExpr>
 															<CanSpecifyModule classname='Bool'>
 																<value>true</value>
-															</CanSpecifyModule>
-															<CanEditCode classname='Bool'>
-																<value>true</value>
-															</CanEditCode>
-															<CanEditModulePrototype classname='Bool'>
-																<value>true</value>
-															</CanEditModulePrototype>
-															<CanEditParameterAdditionalResults classname='Bool'>
-																<value>true</value>
-															</CanEditParameterAdditionalResults>
-															<PrecondIntExe classname='Num'>
-																<value>0</value>
-															</PrecondIntExe>
-															<CustomResults classname='Objs'>
-																<value lbound='[0]' ubound='[]'>
-																	<elemproto>
-																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-																			<subprops>
-																				<Name classname='ExprValue'>
-																					<value/>
-																				</Name>
-																				<ValueToLog classname='ExprValue'>
-																					<value/>
-																				</ValueToLog>
-																				<Condition classname='ExprValue'>
-																					<value/>
-																				</Condition>
-																				<Flags classname='Num'>
-																					<value>8192</value>
-																				</Flags>
-																				<CheckedState classname='Num'>
-																					<value>2</value>
-																				</CheckedState>
-																				<Type classname='PropertyObjectType'>
-																					<subprops>
-																						<ValueType classname='Num'>
-																							<value>3</value>
-																						</ValueType>
-																						<IsObject classname='Bool'>
-																							<value>true</value>
-																						</IsObject>
-																						<TypeName classname='Str'>
-																							<value/>
-																						</TypeName>
-																						<ElementType classname='Objs'>
-																							<value lbound='[0]' ubound='[]'/>
-																						</ElementType>
-																						<ArrayDimensions classname='ArrayDimensions'>
-																							<subprops>
-																								<LowerBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</LowerBounds>
-																								<UpperBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</UpperBounds>
-																							</subprops>
-																						</ArrayDimensions>
-																						<Representation classname='Num'>
-																							<value>1</value>
-																						</Representation>
-																						<ClassName classname='Str'>
-																							<value/>
-																						</ClassName>
-																					</subprops>
-																				</Type>
-																				<Elements classname='Objs'>
-																					<value lbound='[0]' ubound='[]'/>
-																				</Elements>
-																				<IsAnyType classname='Bool'>
-																					<value>true</value>
-																				</IsAnyType>
-																			</subprops>
-																		</_NAME_IN_ATTRIBUTE_>
-																	</elemproto>
-																</value>
-															</CustomResults>
-															<AdditionalResultsHints classname='Objs'>
-																<value lbound='[0]' ubound='[]'>
-																	<elemproto>
-																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-																			<subprops>
-																				<Name classname='ExprValue'>
-																					<value/>
-																				</Name>
-																				<ValueToLog classname='ExprValue'>
-																					<value/>
-																				</ValueToLog>
-																				<Condition classname='ExprValue'>
-																					<value/>
-																				</Condition>
-																				<Flags classname='Num'>
-																					<value>8192</value>
-																				</Flags>
-																				<CheckedState classname='Num'>
-																					<value>2</value>
-																				</CheckedState>
-																				<Type classname='PropertyObjectType'>
-																					<subprops>
-																						<ValueType classname='Num'>
-																							<value>3</value>
-																						</ValueType>
-																						<IsObject classname='Bool'>
-																							<value>true</value>
-																						</IsObject>
-																						<TypeName classname='Str'>
-																							<value/>
-																						</TypeName>
-																						<ElementType classname='Objs'>
-																							<value lbound='[0]' ubound='[]'/>
-																						</ElementType>
-																						<ArrayDimensions classname='ArrayDimensions'>
-																							<subprops>
-																								<LowerBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</LowerBounds>
-																								<UpperBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</UpperBounds>
-																							</subprops>
-																						</ArrayDimensions>
-																						<Representation classname='Num'>
-																							<value>1</value>
-																						</Representation>
-																						<ClassName classname='Str'>
-																							<value/>
-																						</ClassName>
-																					</subprops>
-																				</Type>
-																				<Elements classname='Objs'>
-																					<value lbound='[0]' ubound='[]'/>
-																				</Elements>
-																				<IsAnyType classname='Bool'>
-																					<value>true</value>
-																				</IsAnyType>
-																			</subprops>
-																		</_NAME_IN_ATTRIBUTE_>
-																	</elemproto>
-																</value>
-															</AdditionalResultsHints>
-														</subprops>
-													</TS>
-													<Result classname='Obj'>
-														<subprops>
-															<Error classname='Obj'>
-																<subprops>
-																	<Code classname='Num'>
-																		<value>0</value>
-																	</Code>
-																	<Msg classname='Str'>
-																		<value/>
-																	</Msg>
-																	<Occurred classname='Bool'>
-																		<value>false</value>
-																	</Occurred>
-																</subprops>
-															</Error>
-															<Status classname='Str'>
-																<value/>
-															</Status>
-															<ReportText classname='Str'>
-																<value/>
-															</ReportText>
-															<Common classname='Obj'/>
-														</subprops>
-													</Result>
-												</subprops>
-											</Step>
-										</value>
-										<value>
-											<Step typename='Statement' xsi:type='Statement' name='Register active PinMapId'>
-												<subprops>
-													<TS classname='Obj'>
-														<subprops>
-															<Id classname='Str'>
-																<value>ID#:7xzPK+Rw7RGuNrjdh1OqZD</value>
-															</Id>
-															<Icon classname='Str'>
-																<value>StatementStep.ico</value>
-															</Icon>
-															<PreCond classname='ExprValue'>
-																<value/>
-															</PreCond>
-															<LoadOpt classname='Str'>
-																<value>PreloadWhenExecuted</value>
-															</LoadOpt>
-															<UnloadOpt classname='Str'>
-																<value>UnloadWithFile</value>
-															</UnloadOpt>
-															<Mode classname='Str'>
-																<value>Normal</value>
-															</Mode>
-															<WindowActivation classname='Str'>
-																<value>None</value>
-															</WindowActivation>
-															<ResultOption classname='Num'>
-																<value>1</value>
-															</ResultOption>
-															<StepFCSeqF classname='Bool'>
-																<value>true</value>
-															</StepFCSeqF>
-															<IgnoreRTE classname='Bool'>
-																<value>false</value>
-															</IgnoreRTE>
-															<UseMutex classname='Bool'>
-																<value>false</value>
-															</UseMutex>
-															<MutexNameOrRef classname='ExprValue'>
-																<value/>
-															</MutexNameOrRef>
-															<BatchSyncOpt classname='Num'>
-																<value>0</value>
-															</BatchSyncOpt>
-															<SwitchEnabled classname='Bool'>
-																<value>false</value>
-															</SwitchEnabled>
-															<VirtualDeviceName classname='ExprValue'>
-																<value/>
-															</VirtualDeviceName>
-															<SwitchOperation classname='Num'>
-																<value>1</value>
-															</SwitchOperation>
-															<RouteGroupConnect classname='ExprValue'>
-																<value/>
-															</RouteGroupConnect>
-															<RouteGroupDisconnect classname='ExprValue'>
-																<value/>
-															</RouteGroupDisconnect>
-															<MulticonnectMode classname='Num'>
-																<value>1</value>
-															</MulticonnectMode>
-															<OperationOrder classname='Num'>
-																<value>2</value>
-															</OperationOrder>
-															<ConnectionLifetime classname='Num'>
-																<value>0</value>
-															</ConnectionLifetime>
-															<WaitForDebounce classname='Bool'>
-																<value>true</value>
-															</WaitForDebounce>
-															<PassAct classname='Str'>
-																<value>Next</value>
-															</PassAct>
-															<FailAct classname='Str'>
-																<value>Next</value>
-															</FailAct>
-															<PassActTarget classname='ExprValue'>
-																<value/>
-															</PassActTarget>
-															<FailActTarget classname='ExprValue'>
-																<value/>
-															</FailActTarget>
-															<CustExpr classname='ExprValue'>
-																<value/>
-															</CustExpr>
-															<CustTrueAct classname='Str'>
-																<value>Next</value>
-															</CustTrueAct>
-															<CustFalseAct classname='Str'>
-																<value>Next</value>
-															</CustFalseAct>
-															<CustTrueActTarget classname='ExprValue'>
-																<value/>
-															</CustTrueActTarget>
-															<CustFalseActTarget classname='ExprValue'>
-																<value/>
-															</CustFalseActTarget>
-															<LoopType classname='Str'>
-																<value>NoLooping</value>
-															</LoopType>
-															<LoopWhile classname='ExprValue'>
-																<value/>
-															</LoopWhile>
-															<LoopStatus classname='ExprValue'>
-																<value/>
-															</LoopStatus>
-															<LoopIncrement classname='ExprValue'>
-																<value>RunState.LoopIndex += 1</value>
-															</LoopIncrement>
-															<LoopInitialize classname='ExprValue'>
-																<value>RunState.LoopIndex = 0</value>
-															</LoopInitialize>
-															<LoopOpt classname='Num'>
-																<value>0</value>
-															</LoopOpt>
-															<PreExpr classname='ExprValue'>
-																<value/>
-															</PreExpr>
-															<PostExpr classname='ExprValue'>
-																<value>RunState.Engine.TemporaryGlobals.SetValString("NI.MeasurementLink.PinMapId", 0x1, FileGlobals.MeasurementLink.PinMapPath)</value>
-															</PostExpr>
-															<StatusExpr classname='ExprValue'>
-																<value/>
-															</StatusExpr>
-															<CanSpecifyModule classname='Bool'>
-																<value>false</value>
 															</CanSpecifyModule>
 															<CanEditCode classname='Bool'>
 																<value>true</value>
@@ -7102,11 +6512,8 @@
 							<EnableMonitoring classname='Bool'>
 								<value>false</value>
 							</EnableMonitoring>
-							<PinMapFileName classname='Str'>
-								<value>NIDmmMeasurement.pinmap</value>
-							</PinMapFileName>
 							<PinMapPath typename='Path' xsi:type='Path' classname='PathValue'>
-								<value/>
+								<value>NIDmmMeasurement.pinmap</value>
 							</PinMapPath>
 						</subprops>
 					</MeasurementLink>

--- a/examples/nidmm_measurement/NIDmmMeasurement.seq
+++ b/examples/nidmm_measurement/NIDmmMeasurement.seq
@@ -4237,7 +4237,7 @@
 	<Data classname='SequenceFileData' valueflags='4194304'>
 		<subprops>
 			<Seq classname='Objs' valueflags='4194304'>
-				<value lbound='[0]' ubound='[2]'>
+				<value lbound='[0]' ubound='[0]'>
 					<value>
 						<Sequence name='MainSequence'>
 							<subprops>
@@ -4801,93 +4801,6 @@
 									</value>
 								</Main>
 								<Setup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
-								</Setup>
-								<Cleanup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
-								</Cleanup>
-								<RecordResults classname='Bool' valueflags='4194312'>
-									<value>true</value>
-								</RecordResults>
-								<RTS classname='Obj' valueflags='4456456'>
-									<subprops>
-										<Type classname='Num' valueflags='4194304'>
-											<value>0</value>
-										</Type>
-										<OptimizeNonReentrantCalls classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</OptimizeNonReentrantCalls>
-										<EPNameExpr classname='Str' valueflags='4194304'>
-											<value>"Unnamed Entry Point"</value>
-										</EPNameExpr>
-										<EPEnabledExpr classname='Str' valueflags='4194304'>
-											<value>True</value>
-										</EPEnabledExpr>
-										<EPMenuHint classname='Str' valueflags='4194304'>
-											<value/>
-										</EPMenuHint>
-										<EPIgnoreClient classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</EPIgnoreClient>
-										<EPInitiallyHidden classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</EPInitiallyHidden>
-										<EPCheckToSaveTitledFile classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</EPCheckToSaveTitledFile>
-										<ShowEPAlways classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPAlways>
-										<ShowEPForFileWin classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</ShowEPForFileWin>
-										<ShowEPForExeWin classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPForExeWin>
-										<ShowEPForEditorOnly classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPForEditorOnly>
-										<AllowIntExeOfEP classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</AllowIntExeOfEP>
-										<CopyStepsOnOverriding classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</CopyStepsOnOverriding>
-										<Priority classname='Num' valueflags='4194304'>
-											<value>2953567917</value>
-										</Priority>
-									</subprops>
-								</RTS>
-								<Requirements classname='Obj' valueflags='4456456'>
-									<subprops>
-										<Links classname='Strs' valueflags='71303168'>
-											<value lbound='[0]' ubound='[]'/>
-										</Links>
-									</subprops>
-								</Requirements>
-								<FailureAction classname='Num' valueflags='4194312'>
-									<value>2</value>
-								</FailureAction>
-							</subprops>
-						</Sequence>
-					</value>
-					<value>
-						<Sequence name='ProcessSetup'>
-							<comment>Test UUTs and Single Pass call this callback in their setup step group. It is empty in the model file.  Override this in the client file to perform an action before any code in the model executes.</comment>
-							<subprops>
-								<Parameters classname='Obj' valueflags='4456448'/>
-								<Locals classname='Obj' valueflags='4194304'>
-									<subprops>
-										<ResultList classname='Objs'>
-											<value lbound='[0]' ubound='[]'>
-												<elemproto>
-													<_NAME_IN_ATTRIBUTE_ name='' classname='TEResult'/>
-												</elemproto>
-											</value>
-										</ResultList>
-									</subprops>
-								</Locals>
-								<Main classname='Objs' valueflags='4194304'>
 									<value lbound='[0]' ubound='[3]'>
 										<value>
 											<Step typename='Statement' xsi:type='Statement' name='Get absolute path to pinmap file'>
@@ -5236,7 +5149,7 @@
 																				<value>update_pin_map</value>
 																			</FunctionOrAttributeName>
 																			<Parameters classname='Objs'>
-																				<value lbound='[0]' ubound='[1]'>
+																				<value lbound='[0]' ubound='[2]'>
 																					<elemproto>
 																						<_NAME_IN_ATTRIBUTE_ name='' classname='CPythonParameter' structureflags='0'/>
 																					</elemproto>
@@ -5292,7 +5205,7 @@
 																						<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
 																							<subprops>
 																								<Name classname='Str'>
-																									<value>pin_map_id</value>
+																									<value>pin_map_path</value>
 																								</Name>
 																								<Type classname='Num'>
 																									<value>7</value>
@@ -5314,7 +5227,55 @@
 																													<value>8192</value>
 																												</Flags>
 																												<CheckedState classname='Num'>
+																													<value>2</value>
+																												</CheckedState>
+																											</subprops>
+																										</Input>
+																										<Output classname='PythonParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
 																													<value>1</value>
+																												</CheckedState>
+																											</subprops>
+																										</Output>
+																									</subprops>
+																								</AdditionalResults>
+																							</subprops>
+																						</CPythonParameter>
+																					</value>
+																					<value>
+																						<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
+																							<subprops>
+																								<Name classname='Str'>
+																									<value>sequence_context</value>
+																								</Name>
+																								<Type classname='Num'>
+																									<value>7</value>
+																								</Type>
+																								<ArgumentValue classname='ExprValue'>
+																									<value>ThisContext</value>
+																								</ArgumentValue>
+																								<ArgumentDisplayValue classname='ExprValue'>
+																									<value/>
+																								</ArgumentDisplayValue>
+																								<AdditionalResults classname='Obj'>
+																									<subprops>
+																										<Input classname='PythonParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
+																													<value>2</value>
 																												</CheckedState>
 																											</subprops>
 																										</Input>
@@ -5737,13 +5698,13 @@
 																						<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
 																							<subprops>
 																								<Name classname='Str'>
-																									<value>pin_map_id</value>
+																									<value>sequence_context</value>
 																								</Name>
 																								<Type classname='Num'>
 																									<value>7</value>
 																								</Type>
 																								<ArgumentValue classname='ExprValue'>
-																									<value>FileGlobals.MeasurementLink.PinMapPath</value>
+																									<value>ThisContext</value>
 																								</ArgumentValue>
 																								<ArgumentDisplayValue classname='ExprValue'>
 																									<value/>
@@ -5759,7 +5720,7 @@
 																													<value>8192</value>
 																												</Flags>
 																												<CheckedState classname='Num'>
-																													<value>1</value>
+																													<value>2</value>
 																												</CheckedState>
 																											</subprops>
 																										</Input>
@@ -6370,95 +6331,8 @@
 											</Step>
 										</value>
 									</value>
-								</Main>
-								<Setup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
 								</Setup>
 								<Cleanup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
-								</Cleanup>
-								<RecordResults classname='Bool' valueflags='4194312'>
-									<value>false</value>
-								</RecordResults>
-								<RTS classname='Obj' valueflags='4456456'>
-									<subprops>
-										<Type classname='Num' valueflags='4194304'>
-											<value>0</value>
-										</Type>
-										<OptimizeNonReentrantCalls classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</OptimizeNonReentrantCalls>
-										<EPNameExpr classname='Str' valueflags='4194304'>
-											<value>"Unnamed Entry Point"</value>
-										</EPNameExpr>
-										<EPEnabledExpr classname='Str' valueflags='4194304'>
-											<value>True</value>
-										</EPEnabledExpr>
-										<EPMenuHint classname='Str' valueflags='4194304'>
-											<value/>
-										</EPMenuHint>
-										<EPIgnoreClient classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</EPIgnoreClient>
-										<EPInitiallyHidden classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</EPInitiallyHidden>
-										<EPCheckToSaveTitledFile classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</EPCheckToSaveTitledFile>
-										<ShowEPAlways classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPAlways>
-										<ShowEPForFileWin classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</ShowEPForFileWin>
-										<ShowEPForExeWin classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPForExeWin>
-										<ShowEPForEditorOnly classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPForEditorOnly>
-										<CopyStepsOnOverriding classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</CopyStepsOnOverriding>
-										<Priority classname='Num' valueflags='4194304'>
-											<value>2953567917</value>
-										</Priority>
-										<AllowIntExeOfEP classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</AllowIntExeOfEP>
-									</subprops>
-								</RTS>
-								<Requirements classname='Obj' valueflags='4456456'>
-									<subprops>
-										<Links classname='Strs' valueflags='71303168'>
-											<value lbound='[0]' ubound='[]'/>
-										</Links>
-									</subprops>
-								</Requirements>
-								<FailureAction classname='Num' valueflags='4194312'>
-									<value>2</value>
-								</FailureAction>
-							</subprops>
-						</Sequence>
-					</value>
-					<value>
-						<Sequence name='ProcessCleanup'>
-							<comment>Test UUTs and Single Pass call this callback in their cleanup step group. It is empty in the model file.  Override this in the client file to perform an action after all code in the model executes and just before the execution completes.</comment>
-							<subprops>
-								<Parameters classname='Obj' valueflags='4456448'/>
-								<Locals classname='Obj' valueflags='4194304'>
-									<subprops>
-										<ResultList classname='Objs'>
-											<value lbound='[0]' ubound='[]'>
-												<elemproto>
-													<_NAME_IN_ATTRIBUTE_ name='' classname='TEResult'/>
-												</elemproto>
-											</value>
-										</ResultList>
-									</subprops>
-								</Locals>
-								<Main classname='Objs' valueflags='4194304'>
 									<value lbound='[0]' ubound='[1]'>
 										<value>
 											<Step typename='Statement' xsi:type='Statement' name='Unregister active PinMapId'>
@@ -7153,15 +7027,9 @@
 											</Step>
 										</value>
 									</value>
-								</Main>
-								<Setup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
-								</Setup>
-								<Cleanup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
 								</Cleanup>
 								<RecordResults classname='Bool' valueflags='4194312'>
-									<value>false</value>
+									<value>true</value>
 								</RecordResults>
 								<RTS classname='Obj' valueflags='4456456'>
 									<subprops>
@@ -7201,15 +7069,15 @@
 										<ShowEPForEditorOnly classname='Bool' valueflags='4194304'>
 											<value>false</value>
 										</ShowEPForEditorOnly>
+										<AllowIntExeOfEP classname='Bool' valueflags='4194304'>
+											<value>false</value>
+										</AllowIntExeOfEP>
 										<CopyStepsOnOverriding classname='Bool' valueflags='4194304'>
 											<value>true</value>
 										</CopyStepsOnOverriding>
 										<Priority classname='Num' valueflags='4194304'>
 											<value>2953567917</value>
 										</Priority>
-										<AllowIntExeOfEP classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</AllowIntExeOfEP>
 									</subprops>
 								</RTS>
 								<Requirements classname='Obj' valueflags='4456456'>

--- a/examples/nidmm_measurement/README.md
+++ b/examples/nidmm_measurement/README.md
@@ -9,7 +9,10 @@ This is a MeasurementLink example that performs a measurement using an NI DMM.
 - Includes InstrumentStudio and MeasurementLink UI Editor project files
 - Includes a TestStand sequence showing how to configure the pin map, register
   instrument sessions with the session management service, and run a measurement
-  - For the sake of simplicity, the TestStand sequence handles pin map and session registration and unregistration in the `Setup` and `Cleanup` sections of the main sequence. For **Test UUTs** and batch process model use cases, these steps should be moved to the `ProcessSetup` and `ProcessCleanup` callbacks.
+  - For the sake of simplicity, the TestStand sequence handles pin map and session
+    registration and unregistration in the `Setup` and `Cleanup` sections of the main 
+    sequence. For **Test UUTs** and batch process model use cases, these steps should
+    be moved to the `ProcessSetup` and `ProcessCleanup` callbacks.
 - Uses the NI gRPC Device Server to allow sharing instrument sessions with other
   measurement services when running measurements from TestStand
 

--- a/examples/nidmm_measurement/README.md
+++ b/examples/nidmm_measurement/README.md
@@ -9,6 +9,7 @@ This is a MeasurementLink example that performs a measurement using an NI DMM.
 - Includes InstrumentStudio and MeasurementLink UI Editor project files
 - Includes a TestStand sequence showing how to configure the pin map, register
   instrument sessions with the session management service, and run a measurement
+  - For the sake of simplicity, the TestStand sequence handles pin map and session registration and unregistration in the `Setup` and `Cleanup` sections of the main sequence. For **Test UUTs** and batch process model use cases, these steps should be moved to the `ProcessSetup` and `ProcessCleanup` callbacks.
 - Uses the NI gRPC Device Server to allow sharing instrument sessions with other
   measurement services when running measurements from TestStand
 

--- a/examples/nidmm_measurement/teststand_fixture.py
+++ b/examples/nidmm_measurement/teststand_fixture.py
@@ -1,33 +1,49 @@
 """Functions to set up and tear down sessions of NI-DMM devices in NI TestStand."""
+from typing import Any
 
 import nidmm
-from _helpers import GrpcChannelPoolHelper, PinMapClient
+from _helpers import GrpcChannelPoolHelper, PinMapClient, TestStandSupport
 
 import ni_measurementlink_service as nims
 
 
-def update_pin_map(pin_map_id: str) -> None:
+def update_pin_map(pin_map_path: str, sequence_context: Any) -> None:
     """Update registered pin map contents.
 
     Create and register a pin map if a pin map resource for the specified pin map id is not found.
 
     Args:
-        pin_map_id (str): The resource id of the pin map to register as a pin map resource. By
-            convention, the pin_map_id is the .pinmap file path.
-
+        pin_map_path:
+            An absolute or relative path to the pin map file.
+        sequence_context:
+            The SequenceContext COM object from the TestStand sequence execution.
+            (Dynamically typed.)
     """
+    teststand_support = TestStandSupport(sequence_context)
+    pin_map_abs_path = teststand_support.resolve_file_path(pin_map_path)
+
     with GrpcChannelPoolHelper() as grpc_channel_pool:
         pin_map_client = PinMapClient(grpc_channel=grpc_channel_pool.pin_map_channel)
-        pin_map_client.update_pin_map(pin_map_id)
+        pin_map_id = pin_map_client.update_pin_map(pin_map_abs_path)
+
+    teststand_support.set_active_pin_map_id(pin_map_id)
 
 
-def create_nidmm_sessions(pin_map_id: str) -> None:
-    """Create and register all NI-DMM sessions."""
+def create_nidmm_sessions(sequence_context: Any) -> None:
+    """Create and register all NI-DMM sessions.
+
+    Args:
+        sequence_context:
+            The SequenceContext COM object from the TestStand sequence execution.
+            (Dynamically typed.)
+    """
     with GrpcChannelPoolHelper() as grpc_channel_pool:
         session_management_client = nims.session_management.Client(
             grpc_channel=grpc_channel_pool.session_management_channel
         )
 
+        teststand_support = TestStandSupport(sequence_context)
+        pin_map_id = teststand_support.get_active_pin_map_id()
         pin_map_context = nims.session_management.PinMapContext(pin_map_id=pin_map_id, sites=None)
         with session_management_client.reserve_sessions(
             context=pin_map_context,

--- a/examples/nifgen_standard_function/NIFgenStandardFunction.seq
+++ b/examples/nifgen_standard_function/NIFgenStandardFunction.seq
@@ -1670,6 +1670,647 @@
 		</typedef>
 		<protected>E@=3DJC4100hYLECF=_K@0@mKCYo_1KN:&lt;Ta239hF9[gHbEVFDfRINZfQ01CkaUMk5=k`[c;[42MMF9aiNliecVfMFCLXi_`f2H7c\G\X50M=Z4S4aT2QI&gt;A^D:d1\PCI`L11RlV5bM5AIZTc9STI5Mkg&lt;bHlle[O=CL_KEgb?8RiVHS7QmPY@S4X^7I58A@kPaKcPWCOC1;DBf61lViY=]`28BC\B_mEf20ZJS@W@GDDRffLe\Ci;aKbN&gt;i5P_4ScVVBTjIIfn0j8l&lt;e6IcMbZHgCI;n8CRlR7&lt;YcK0@cY[8aDHj=GGkNK;C?KC?b=]mMejoc1gGol1&gt;hL6lf5fZ92?Ia@l1;QL024f^NSm2MhNlcFg_YR[l5kclo:einXehbR&gt;98[4?GC:CX[3hm\UMob2aIMT0eJmgI@\;njRK9]fIl_8f=d]n4bQcRXDEl&lt;o=@Yiik\3Md@?k1=0Joj&gt;?Je`&lt;RUd&lt;JYmeOnOgB3G@Ub\FoGFgIQmQli8nGH=QjKD9i`2nf41XEKj;oDB8iZU`@XP^KWoAKEbOf:ViVAl=_I37KJSec7Ea\nJ5]NZj\OnJF;ASQemRIDbbdglb\U&gt;H[O^bDHO?XMLaOoeVCf=a^CC`d8^TX2B</protected>
 		<protected>E@=3@J\4110h]L]Mg[cK3fBoj\Kifo1C[KY_3VgFm3_6n&gt;DfdTDgjaSF_LdVUJaY::FII@T:GB9LaYOo80OP^053LBBVb1G?:50k4;P1c\^`03ffoj9S72=AOm;a2oh?Na\lC7TUOXcNfaSdfIbVCC_ao20aN9bmo_&lt;R_S=&gt;KV;lhbmh89SY[:2UflXcmGIlnngoE]\\ad_6_gW8X9GAXJSPJYin&gt;C71=c74a79JN&lt;`GPK]_\&gt;2`h9IOC]VA5BU4AMW1Qc`j?lJ\aR4__&gt;R4SI_`[_mmnM33ONg`3P[g4N5aSF;ce]^eVffg6&gt;cIRLhI]7CjE^W[jW`kZkGEWHk1=RR;gTe:O[H;k[bAd7UCaTVXgjlho3Af&gt;?oIJdjMo&gt;3=o;aTo\ZZnG9_cgcO7mjV^k&gt;\:gkoOkSn1jkfm@MgLnb&lt;Amg;\Nmj8klk3llhhnW&gt;nn^GCW_fW_&gt;ji]:Va&gt;TNnNQdK5LolNX?M@\6jN2ddlIHh=MT1E^[o4Q7I54R=RlVg[S\KmOe9GM:Qeh9OnUhWTeC^ZM7SAGP1V=LZ4[i\cOmoH[RS6YBL2L\PAg][JQ&lt;Eo?8;D9Mk3M]&gt;N^6&gt;HgJ]KP^a&gt;cfBkkmZ33RdU`]jB_NIOShWL4oDlbn3lNOCL??R7GCmKaTDhekoi_En`9oJKe&lt;e1`lBjmjXJ&lt;^4_^_^&gt;?7O?nEE_WTY:VYEc]3^eJm^cdC7;LcK_]Ei&gt;b&lt;^`9HR6YcO&gt;l@Amg&gt;PLXQbSb^=?FXRUZd&lt;[n&lt;SGjgCQ`mhTl;7NUbgaRQBkXNY4iX5iAJX6C`gdG[d3d&gt;`Uj3DPMF7h71WBBLLR&gt;Tk9dZlFCYSi__fNBBT`C;A&gt;jeP2CdONN52i5^eBEIEI=8EMHBBe^G^1ohD6&gt;LRiJgM\IPYE8Wn`T9W@jf8iEfN:@L3&lt;Ha_l0CCE&lt;HOJjXBRll_NLReo_^K7CQWihL&lt;B1::YXdSaG&lt;XFnCP94dQXb;^6V07F&gt;TkPem&gt;4QI;?9JkF`g80:`G?AULFSY^XW;4XL^_D=GZV9VVODS^[=]dL]b=N;O[ib6]2aLATM7\AcX=JH&lt;\1j8_?I9_VUO]5;PKjdi^o&gt;Kn=FbmhAmF3EXh?dAPF?cWPU;NHFT9YBblF15fj0n]RK9&gt;d;@lD9HXLGTZOAa;gEd6:MElAPOkOoMom`hnaYko^ne_;PeC\`kMYOoCalP3DR_^NADNSV6R1Nk4f?=Lo;VQ&gt;7&gt;fR@=2j8C:;D@3fk&gt;^=YHE^PQ1fU&gt;TFoNH&gt;GnfRGNMNW`[okK`S56RJfM4Zmo^6E9ZYc&gt;FNEO3PO=T9eK0:bgljYdR7WooKS9eTjd@bcImNVZ8UXa:AC_F_WCj]4\6ST&lt;:ie_AbZFIL7UmlIne:BcTQ5T2U]O2goYWXRN5F8oeQT^`HXPD=2LV[h;ibbNNj1kU]lXlnX4ACO5aRA@TfHY77@P?L=_N@4^cJG;Wi2@3M5OQ:^@&gt;2K9_9W:4Vn1LGaRN@WL9AFFVg1oYHdi`54XIa5G[\i&gt;iPT4506XA7h2^c_T`3d[ARdFICaAS2RM:1KgT7B&gt;MhXVaI&lt;kA^@CX2aS^I:B&gt;=W&lt;U?l&lt;DWU&lt;Jd7^cKe2R]EdIBcBQZni_K1JPCEhV&gt;VH]FBZ&lt;5413k[U]MAFA`Ohma2g2NoU0@E;FI93Yi;RjnlScC;`glEaH^X@K[NY9Y1EUZc6V6\3?FKC0APU0^[aP:_GMI=eeWnJ&lt;6e2]@;AXaAE&lt;S[lhAb`XFjPP@dTXNYS=&lt;568je\`W3?@gn9HDaM84^&gt;SDl0&lt;Ba6YNKCeYZ\CUU?WGnR4=m^aN[KTlFG\?VZ[MC:3HfflAagl\jZUG@ScZW:2K\FU9TQa&lt;h;?iYb&lt;RJI66IEg&lt;WHgdkU:\KFIZG\BDU=9W&gt;:\:W7nM3NIjXT;2YV[@dDaY3bhOQY^af&lt;UVo:ZV^^@0d_M5ObRQ2PIHZ9bbbGm;4Z\KEfEYI=M];D@9j1kZ@2@FIkf9:\CYe5KnKANXH7R@eMc2M;Pl]PZG]@4h2Q7OY:=QFh@\Y6]E6X1bL6mjS76a`JS=H=XQReG6Djb7[c&lt;h@S5UCX4`ABLQ4:ZZ7=JF9JejC5\[T:meE5_[:`Qm=DfI0EDQLRH6o]LAPRXlbTgXSbnW7ZTN?N]lH02JKm;Z4hn&lt;A[89:C8lM5hC]Ab^\\WNK7JGS]XainLm:PWFF3EmC15\]YC\D;I6a&lt;NiIhd2GMIG`A9\[]T00fP:UXIXSHk2jI&gt;XFG&gt;I521bbKDA`Xb]h&gt;oAl&gt;IolbRB7j=i9_H89&lt;FR=U572U\LjNhnkeeemHDJJ\GHX\;J51M&lt;?QV2DneREAR3in6&lt;M75M_Re=Ci3gEOQ2VO`4P8_hfhSO\dZ7m]n\hlV6gSlSC@PoZSe8WUaY3d0_;Z=9H:I6Gf2PVG`mf8CC87@DBlT62^h6QFFhZF64BJ46@Dh&lt;T1=C]0_9J?073S@61ADIUT31&lt;mVE&lt;W?R@RBUJP`@;50X2Bh618KM^bf033T033D?NM@P`?0\dBA3A8AXF0]@KnP[5&lt;EDfUICcBF^EZT=:cWKBKYTDKXD=&lt;A:mkNB7LFDHC9b7nG57NFZ1]Ubo]8]0MN]YWJJ&gt;eS42I?===3_n_?J=384=Go8e^0mdmBiTjRaf;F@8M4_gCZSGQ3cUUnF6J_R9WJV0PNaTJDk&lt;RiWS6=&gt;Rf9EmM:WgL4LHg5oH[aMbbOlnI6b`9KZ^Z]oAdeH\@YgaV8ChHTKjEVA]a^YN&lt;;71CAbR\&lt;jAYI\\Y&lt;R\`1AOol`j1&gt;53?d8MV_@kAN_W4nIdKc0gRYHEo`]U?HWN?0&lt;?l2h:ZC\&gt;^D]Ug4FNZl123fNoZ7fLRB[_HR6O&gt;BaoomWl_8YS0Q\8;RB]@j=GIIe]J&lt;AT[;1I&lt;5ZJ\?Va5g?&gt;7hXgcbU4V=lT&gt;nV[28JKeQJ5QX4^WD3MfTBIBPKU57e&gt;[FRd&gt;_EeSHJhDa4hM9S9TUlOR=KWn]eAJ]W5VROh9ak`n5&lt;LV6L9d&lt;0`?fk]J8FW52OlL2i&lt;L1kO=mGBf9e:\`^[_J:F&gt;7o0_9mGc_`=KP@SW_^NU525JcQcEGhR8Da3gf4mJ?R6a2lLPKjL:TlfL8iHOKf:Mjeb\&gt;Xb3&gt;0kM@iNkaifYHDFNIKP\e^;bhg@V&lt;g0Za7F]R=JKPMgdg&gt;nYaMSb8MAV0o05XKjM5&lt;5^V=albT\&lt;868hhl^jHPRa0KcT4i[31chfOeGW&gt;;``&gt;&gt;I;B:YafYW&gt;jW_7D1&gt;9_X14U9VXJ5E_PA2ZPb&gt;n6eBLcN]SU4eSd&lt;IDGD4D5WHMlFCU0DeARScb:h\?EC1&gt;IBWead&gt;7F&gt;FeBea\oCS]jf@kE47ZHcB?TlP6_K[QC2@_N&gt;ilNn0VdgZE&gt;Z98hXCHa4bNUM16M74Q;DhldmcZ&gt;V?_TG1J?NI:F8&lt;aomhdPX5^AEe6BRYle4clf_gSb6D9LaD2h]ij8SAH@[`J@cb2G7ee@iZWl2A&gt;`Ga95FDhJo7Xo&gt;Zd3[jL&lt;DQ4OILX9a;0T\SUDWY:Bh&gt;WGNb:dHQ[S`[8:1L:F@&gt;H[49RQ6_3QV&lt;UT0oIITF^H_\X=:&lt;42`N``YjM75HWEd]5O`&lt;EX89FTP`^oN:QHgED5k:\CaYbA2GbD1;X5:N;?SoLhVhR`R_9lg3hU4n:I`2Gn:IjDHED]5i=2fcTklTK1H6k4HjK;HBM&gt;;c]9;i[MFD?WaY1O]oS293kLd9S3N6He?:_QKEcBGLOc:jB6H@fR]h]HGB5;:&lt;RE&lt;`3K4Ibi29dR;nU&lt;&lt;TKBRnTdK[ZTT6oiOVVXKgaP6&lt;lMTO_JC\0&lt;RY5NkR352&lt;FbcCB&lt;_3?0XjQ`BJP;OJR::8eHFb3&lt;;M\9FOC8T:MkD:Z;C=eb^0:AMSbSY_^Lc=SGbD5WDh@6j]PCDc@;\X1Nb\[`Z0W_Th5&lt;HD4CafYghb`T95Ko571]SZJDHF2eE&lt;7jViL_\8TQ@dFRo]`G[h3&gt;862l:2F[UU6dVbFjU?NI&gt;OHOk&gt;JNcFNU[mXi]iJ[neWQ\mWa]i[e?IkO^Mf]LHTP[G3?43M8g^Wh``lW3kBT7ADM6b_IUCIPO=C8g5@?9R3&lt;hilXNY7_&lt;THNN&lt;KMLm;eGM6_A6AUDB\c5Q;S2POniP9[mdEeIDnO7;T7Nia2nFN\L2XZIP?ZJKW\2cK0U5fb[dLn?[C&gt;YAMXfVFic02OQA\6LHEk0oBd0f;`kR1hImAUl:@I;^:oFJUF?mDgPlLokm]OIgenn9;n5[Oh3g7@W7OWBCk9X1mYDPF9AQ4LOGeM_D_WR?I7QRlVEmN_0QlA9^lO[HjnfngGjkHokO\A35=_4hVU^jKm;\?Y9^B=RkTG1I&lt;6nI`AQ_kJ;of[GmIi[g0]1\UG_FKUnX]ZcGmoI;NUdDFOolHn;NbMLkT`1GEo;j63N_8b_O`PQ[KRjb&lt;NDHW4;\lT[Ila;nMd`56_c\C25fJLUS;9fn@6[[SMIBBMFK\8d;ZIRSI;fJ5_cojWSIfcY2kNd1jkS0f9A3BNfk8W1m4H0gRbfA3J6Q726nmNm4PQYcWZ___NEf_FmmmOm40IZ1mf4PmS?H8k&gt;=J3g&lt;\1K6j;CNTGZ8kY61mk30RLUO`T`_H`Hg&lt;`\K67=HJ3g&lt;\3K6iGRVO9``_1H`L`\K6`f=371ikY61mf30S&lt;W]K86enT`_H`Hg&lt;=fbaLQO`c@&lt;hK;Rmmf&gt;KT=]4\mm;NkW]^mcFgV[_]l=8aHk_j]MgIEYV5XJkiW]l^^CKnYn2OgNJ0g&lt;fR\mWo;?JNcFN^cfL_eWZ[Eff[LeWebL[d?YfWFm3O0neW6m3NP3nGQ@G_M?lS61c3KG?`NUXHYTJ?j1SoC7V&gt;RGj_]d[blRO_M^Qg&gt;f_[0oQJWgg`CkhXXJ\hG;1Ujg`4MNjIg_6l3GG;oohYSNBallm3eZnFmebBeaLSDIS17WJfDBN9nUo^n2oC_;Q\;4O3WWk7mAZI17;2]ChHfZeJ;I\fY;^dB\J;NW@cEDj]HE]B8GSiKJgN9M6f4UIKhV02kFjYnXXBH9lF?3gDC&lt;EC`d=4l&lt;aIYa?]YS&lt;9Zl8]AkXcPg:6L69WWX^8R2;YXfC&lt;Xg6AQg@oOoChH=41ln]AG?J3U0Wn&gt;8[8cdWGUnL2Z&gt;Ll4HaNcI&lt;f]SiWCVXSMeP?^a7:Tf&lt;`L3cKdmDl7?Uj&gt;FnPG5NSQBkHE`Yj&gt;ZNQ^;UbDk0kCT]3]YV&lt;50o&lt;2&lt;aTY7THb5hg;3^hl@GYRZE@mbL?5gdHJNW5`6W8[eho^38?;R459L4WN1Jg[egNX[3[_&gt;lAAY&gt;L9Z_H5YN]9:KZMj\cPGZco]??=ig[hH7YShgPS8:44leI:@9R?fLHKlH6UZ]nlAXHFAFUn7AdT=;FK^oZgocoK[2W_=Aj]T;2mBd8`7h`B0K&gt;IP&lt;04@S6]dA9N`8Q8YBk19T@8RFF4T29OB1V7TX7QM01@hI@3`QJ=4@H\nBkS2d5P1BDgN8?4B230Y8lb8ONC@?IPH0A@OMPD?HZ@1`&gt;mj`5N5c60PN06hNI1c8`@k6b0M9IN3`QM68;M1l5Bl&gt;6cX&gt;XD78V@S2j5Ad;C&lt;0cA7OX0nM8&lt;iaN3K0@0Kil664BNSOe:0@R=6NA66f9@PX0d0dHb:LL\6@1aSJl[5h6I38X&lt;0`;0&lt;Al748MXb84H=@Y&lt;lI\5@GNMD;RJd?DeY0Ac1J230g&gt;d1e00LP8d;&gt;V@59CQA1BG&lt;@2[2A45hE8CX:H0A=a\KRAC&lt;Q0YPRb5D&lt;IR63P1QX&lt;JXCS9a3FQ&gt;daQVRjO4I;1da1URZ;LZ444@R2PX2XAXA9Te@FngkoKI_ea&gt;NZN^m\`1H5CMhX9Bn1?ZYS0WAbR2RD8F3W@XajF1=AXS6&lt;TS4i09PN?`gPUG9G3J26`2GbAW]jGY5&lt;AGn^iZAjM_;W5&lt;g^kKMC]B[X13GZm3mmNffKMhb:cJ]DAT&gt;a?_4H8jZX2PIja6[DFTFC:]l]=1AN=PD`VJ&gt;HX2k?Pj7:bQ`W[XWe0\38&lt;V=I\:]2HOl74S6e0a;ZmCFf:3FnRcED67[hUWZPU7ZZKLUVD\PFX_FVE23Q7WUaWV=U&gt;&lt;ZRLQB8LDd0hS94OC1D?6J9N:\\`US2k:iaJY8jY]eTVWO0KLeICMh3dn\dH86aYA7eY]eZZ3=d6WJLE7IPEWIe=_c4FYLEhdA\b5XoJQE;n[HFdKI7C3oK`RFK6l`B8RhhCXhP8XnP3841548PB6P6B[DKHS41JU&lt;Qne:U\ARQ=B[VDHSOT307XA07Qhn2d8RBoajKU&gt;9P@S2lYle3RId0IIf072nP8&gt;;NUah=0ilGD:G5\RN_\=;5jTD@iTfQNGIfmQJ2oJl[SBFC]DLncWBE4mFZe6d_Ob&gt;3YC4APEA@D_mOFNI8ALek79bT&gt;:a8]EjYToY&lt;]8C`FV4Z``X`1aB@L&lt;?V9ARCQ4c:K71jA4o8X@_N2@;?hf9D0M0]D;:A]?]T5@Y1`&gt;Vi=L5H`I25YCYJTF@F?fd@VbI9Pf6?dDZY8JdAcR`QM5&gt;MT&lt;aOnO7&lt;DiRiB;\k?RRIHVCkC&lt;FWi=5fXF\he2n@Q&gt;2TEkZIo6kBK3\C@]3\oE]=7UY8knVi7O5=^_a6d;G^?DaLI=YY]ARAc7NRDMhAYZlK90=KQlem6G@;;lecBDFecfKNA=H&gt;mJl3I59=NFgn`nf[B1:05f5E[`fiTPQ4EDe1H=4ZRWkf3TWlOP&gt;Ela5hZDn]cQJC=UBXIIJdWiR@KZe]DHRbmfI;]VYoi&gt;o?3K1h=6</protected>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='21'>
+			<Action classname='StepType' isroottypedef='true' typecategory='1' timestamp='1618215606' typeversion='21.0.0.2' typelastmodversion='21.0.0.0' typeminprodversion='21.0.0.0' typeflags='33554446'>
+				<subprops>
+					<Substeps typename='StepTypeSubstepsArray' xsi:type='StepTypeSubstepsArray' classname='Objs' flagsforinstances='524312' instanceoverrideflags='655384'>
+						<value lbound='[0]' ubound='[]'/>
+					</Substeps>
+					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
+						<value>ResStr("NI_STEPTYPES", "ACTION_DESCRIPTION_NAME") + (("%ModuleDescription" == "") ? "" : ",  %ModuleDescription")</value>
+					</DescriptionFormat>
+					<DefaultNameFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
+						<value>ResStr("NI_STEPTYPES", "ACTION_DEF_STEP_NAME")</value>
+					</DefaultNameFormat>
+					<Menu typename='StepTypeMenu' xsi:type='StepTypeMenu' classname='Obj' flagsforinstances='524312' instanceoverrideflags='524312'>
+						<subprops>
+							<CanBeSubstepType classname='Bool'>
+								<value>false</value>
+							</CanBeSubstepType>
+							<CanOnlyBeSubstepType classname='Bool'>
+								<value>false</value>
+							</CanOnlyBeSubstepType>
+							<Category classname='Str'>
+								<value>""</value>
+							</Category>
+							<ItemName classname='ExprValue'>
+								<value>ResStr("NI_STEPTYPES", "ACTION_MENU_ITEM_NAME")</value>
+							</ItemName>
+							<SingularItemName classname='Str'>
+								<value>""</value>
+							</SingularItemName>
+							<SeparatorBeforeCategory classname='Bool'>
+								<value>false</value>
+							</SeparatorBeforeCategory>
+							<SeparatorBeforeItemName classname='Bool'>
+								<value>false</value>
+							</SeparatorBeforeItemName>
+							<Group classname='Str'>
+								<value>Action</value>
+							</Group>
+						</subprops>
+					</Menu>
+					<AdditionalResultsHints classname='Objs' valueflags='4194328' structureflags='524288'>
+						<value lbound='[0]' ubound='[]'>
+							<elemproto>
+								<_NAME_IN_ATTRIBUTE_ typename='NI_CustomResult' xsi:type='NI_CustomResult' name='' classname='CustomResult'>
+									<subprops>
+										<Name classname='ExprValue'>
+											<value/>
+										</Name>
+										<ValueToLog classname='ExprValue'>
+											<value/>
+										</ValueToLog>
+										<Condition classname='ExprValue'>
+											<value/>
+										</Condition>
+										<Flags classname='Num'>
+											<value>8192</value>
+										</Flags>
+										<CheckedState classname='Num'>
+											<value>2</value>
+										</CheckedState>
+										<Type classname='PropertyObjectType'>
+											<subprops>
+												<ValueType classname='Num'>
+													<value>3</value>
+												</ValueType>
+												<IsObject classname='Bool'>
+													<value>true</value>
+												</IsObject>
+												<TypeName classname='Str'>
+													<value/>
+												</TypeName>
+												<ElementType classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</ElementType>
+												<ArrayDimensions classname='ArrayDimensions'>
+													<subprops>
+														<LowerBounds classname='Nums'>
+															<value lbound='[0]' ubound='[]'/>
+														</LowerBounds>
+														<UpperBounds classname='Nums'>
+															<value lbound='[0]' ubound='[]'/>
+														</UpperBounds>
+													</subprops>
+												</ArrayDimensions>
+												<Representation classname='Num'>
+													<value>1</value>
+												</Representation>
+												<ClassName classname='Str'>
+													<value/>
+												</ClassName>
+											</subprops>
+										</Type>
+										<Elements classname='Objs'>
+											<value lbound='[0]' ubound='[]'/>
+										</Elements>
+										<IsAnyType classname='Bool'>
+											<value>true</value>
+										</IsAnyType>
+									</subprops>
+								</_NAME_IN_ATTRIBUTE_>
+							</elemproto>
+						</value>
+					</AdditionalResultsHints>
+					<TS typename='TEInf' xsi:type='TEInf' classname='Obj' flagsforinstances='262168' instanceoverrideflags='4456472'>
+						<subprops>
+							<Id classname='Str'>
+								<value/>
+							</Id>
+							<Icon classname='Str'>
+								<value/>
+							</Icon>
+							<SData classname='Obj' flagsforinstances='2097152' instanceoverrideflags='7143448' structureflags='2097152'/>
+							<PreCond classname='ExprValue'>
+								<value/>
+							</PreCond>
+							<LoadOpt classname='Str'>
+								<value>PreloadWhenExecuted</value>
+							</LoadOpt>
+							<UnloadOpt classname='Str'>
+								<value>UnloadWithFile</value>
+							</UnloadOpt>
+							<Mode classname='Str'>
+								<value>Normal</value>
+							</Mode>
+							<WindowActivation classname='Str'>
+								<value>None</value>
+							</WindowActivation>
+							<ResultOption classname='Num'>
+								<value>1</value>
+							</ResultOption>
+							<StepFCSeqF classname='Bool'>
+								<value>true</value>
+							</StepFCSeqF>
+							<IgnoreRTE classname='Bool'>
+								<value>false</value>
+							</IgnoreRTE>
+							<UseMutex classname='Bool'>
+								<value>false</value>
+							</UseMutex>
+							<MutexNameOrRef classname='ExprValue'>
+								<value/>
+							</MutexNameOrRef>
+							<BatchSyncOpt classname='Num'>
+								<value>0</value>
+							</BatchSyncOpt>
+							<SwitchEnabled classname='Bool'>
+								<value>false</value>
+							</SwitchEnabled>
+							<VirtualDeviceName classname='ExprValue'>
+								<value/>
+							</VirtualDeviceName>
+							<SwitchOperation classname='Num'>
+								<value>1</value>
+							</SwitchOperation>
+							<RouteGroupConnect classname='ExprValue'>
+								<value/>
+							</RouteGroupConnect>
+							<RouteGroupDisconnect classname='ExprValue'>
+								<value/>
+							</RouteGroupDisconnect>
+							<MulticonnectMode classname='Num'>
+								<value>1</value>
+							</MulticonnectMode>
+							<OperationOrder classname='Num'>
+								<value>2</value>
+							</OperationOrder>
+							<ConnectionLifetime classname='Num'>
+								<value>0</value>
+							</ConnectionLifetime>
+							<WaitForDebounce classname='Bool'>
+								<value>true</value>
+							</WaitForDebounce>
+							<PassAct classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
+								<value>Next</value>
+							</PassAct>
+							<FailAct classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
+								<value>Next</value>
+							</FailAct>
+							<PassActTarget classname='ExprValue' flagsforinstances='1' instanceoverrideflags='5046297'>
+								<value/>
+							</PassActTarget>
+							<FailActTarget classname='ExprValue' flagsforinstances='1' instanceoverrideflags='5046297'>
+								<value/>
+							</FailActTarget>
+							<CustExpr classname='ExprValue'>
+								<value/>
+							</CustExpr>
+							<CustTrueAct classname='Str'>
+								<value>Next</value>
+							</CustTrueAct>
+							<CustFalseAct classname='Str'>
+								<value>Next</value>
+							</CustFalseAct>
+							<CustTrueActTarget classname='ExprValue'>
+								<value/>
+							</CustTrueActTarget>
+							<CustFalseActTarget classname='ExprValue'>
+								<value/>
+							</CustFalseActTarget>
+							<LoopType classname='Str'>
+								<value>NoLooping</value>
+							</LoopType>
+							<LoopWhile classname='ExprValue'>
+								<value/>
+							</LoopWhile>
+							<LoopStatus classname='ExprValue'>
+								<value/>
+							</LoopStatus>
+							<LoopIncrement classname='ExprValue'>
+								<value>RunState.LoopIndex += 1</value>
+							</LoopIncrement>
+							<LoopInitialize classname='ExprValue'>
+								<value>RunState.LoopIndex = 0</value>
+							</LoopInitialize>
+							<LoopOpt classname='Num'>
+								<value>0</value>
+							</LoopOpt>
+							<PreExpr classname='ExprValue'>
+								<value/>
+							</PreExpr>
+							<PostExpr classname='ExprValue'>
+								<value/>
+							</PostExpr>
+							<StatusExpr classname='ExprValue'>
+								<value/>
+							</StatusExpr>
+							<CanSpecifyModule classname='Bool'>
+								<value>true</value>
+							</CanSpecifyModule>
+							<CanEditCode classname='Bool'>
+								<value>true</value>
+							</CanEditCode>
+							<CanEditModulePrototype classname='Bool'>
+								<value>true</value>
+							</CanEditModulePrototype>
+							<CanEditParameterAdditionalResults classname='Bool'>
+								<value>true</value>
+							</CanEditParameterAdditionalResults>
+							<PrecondIntExe classname='Num'>
+								<value>0</value>
+							</PrecondIntExe>
+							<Requirements classname='Obj' flagsforinstances='1' valueflags='1' structureflags='2097152'>
+								<subprops>
+									<Links classname='Strs' flagsforinstances='71303168' instanceoverrideflags='72286233' valueflags='71303168'>
+										<value lbound='[0]' ubound='[]'/>
+									</Links>
+								</subprops>
+							</Requirements>
+							<CustomResults classname='Objs'>
+								<value lbound='[0]' ubound='[]'>
+									<elemproto>
+										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+											<subprops>
+												<Name classname='ExprValue'>
+													<value/>
+												</Name>
+												<ValueToLog classname='ExprValue'>
+													<value/>
+												</ValueToLog>
+												<Condition classname='ExprValue'>
+													<value/>
+												</Condition>
+												<Flags classname='Num'>
+													<value>8192</value>
+												</Flags>
+												<CheckedState classname='Num'>
+													<value>2</value>
+												</CheckedState>
+												<Type classname='PropertyObjectType'>
+													<subprops>
+														<ValueType classname='Num'>
+															<value>3</value>
+														</ValueType>
+														<IsObject classname='Bool'>
+															<value>true</value>
+														</IsObject>
+														<TypeName classname='Str'>
+															<value/>
+														</TypeName>
+														<ElementType classname='Objs'>
+															<value lbound='[0]' ubound='[]'/>
+														</ElementType>
+														<ArrayDimensions classname='ArrayDimensions'>
+															<subprops>
+																<LowerBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</LowerBounds>
+																<UpperBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</UpperBounds>
+															</subprops>
+														</ArrayDimensions>
+														<Representation classname='Num'>
+															<value>1</value>
+														</Representation>
+														<ClassName classname='Str'>
+															<value/>
+														</ClassName>
+													</subprops>
+												</Type>
+												<Elements classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</Elements>
+												<IsAnyType classname='Bool'>
+													<value>true</value>
+												</IsAnyType>
+											</subprops>
+										</_NAME_IN_ATTRIBUTE_>
+									</elemproto>
+								</value>
+							</CustomResults>
+							<AdditionalResultsHints classname='Objs'>
+								<value lbound='[0]' ubound='[]'>
+									<elemproto>
+										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+											<subprops>
+												<Name classname='ExprValue'>
+													<value/>
+												</Name>
+												<ValueToLog classname='ExprValue'>
+													<value/>
+												</ValueToLog>
+												<Condition classname='ExprValue'>
+													<value/>
+												</Condition>
+												<Flags classname='Num'>
+													<value>8192</value>
+												</Flags>
+												<CheckedState classname='Num'>
+													<value>2</value>
+												</CheckedState>
+												<Type classname='PropertyObjectType'>
+													<subprops>
+														<ValueType classname='Num'>
+															<value>3</value>
+														</ValueType>
+														<IsObject classname='Bool'>
+															<value>true</value>
+														</IsObject>
+														<TypeName classname='Str'>
+															<value/>
+														</TypeName>
+														<ElementType classname='Objs'>
+															<value lbound='[0]' ubound='[]'/>
+														</ElementType>
+														<ArrayDimensions classname='ArrayDimensions'>
+															<subprops>
+																<LowerBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</LowerBounds>
+																<UpperBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</UpperBounds>
+															</subprops>
+														</ArrayDimensions>
+														<Representation classname='Num'>
+															<value>1</value>
+														</Representation>
+														<ClassName classname='Str'>
+															<value/>
+														</ClassName>
+													</subprops>
+												</Type>
+												<Elements classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</Elements>
+												<IsAnyType classname='Bool'>
+													<value>true</value>
+												</IsAnyType>
+											</subprops>
+										</_NAME_IN_ATTRIBUTE_>
+									</elemproto>
+								</value>
+							</AdditionalResultsHints>
+						</subprops>
+					</TS>
+					<NI_Data typename='StepTypeNIData' xsi:type='StepTypeNIData' classname='Obj'>
+						<subprops>
+							<EditPanels classname='Strs'>
+								<value lbound='[0]' ubound='[]'/>
+							</EditPanels>
+						</subprops>
+					</NI_Data>
+					<Result classname='Obj' flagsforinstances='4194304' valueflags='4194304'>
+						<subprops>
+							<Error typename='Error' xsi:type='Error' classname='Obj' flagsforinstances='4194304' instanceoverrideflags='4194304' valueflags='4194304'>
+								<subprops>
+									<Code classname='Num'>
+										<value>0</value>
+									</Code>
+									<Msg classname='Str'>
+										<value/>
+									</Msg>
+									<Occurred classname='Bool'>
+										<value>false</value>
+									</Occurred>
+								</subprops>
+							</Error>
+							<Status classname='Str' flagsforinstances='4194304' valueflags='4194304'>
+								<value/>
+							</Status>
+							<ReportText classname='Str' flagsforinstances='4194304' valueflags='4194304'>
+								<value/>
+							</ReportText>
+							<Common typename='CommonResults' xsi:type='CommonResults' classname='Obj' instanceoverrideflags='4194304'/>
+						</subprops>
+					</Result>
+					<CodeTemplates classname='Str' valueflags='4194328' structureflags='524288'>
+						<value>DefaultLabVIEW|DefaultLabVIEWNXG|DefaultCVI|DefaultVB.NET|DefaultCSharp.NET|DefaultC++.NET|DefaultVC++_Template|DefaultHTB72_Template|DefaultHTB80_Template|Default_Template</value>
+					</CodeTemplates>
+					<BlockStartTypes classname='Str' valueflags='4194328' structureflags='524288'>
+						<value/>
+					</BlockStartTypes>
+					<BlockEndTypes classname='Str' valueflags='4194328' structureflags='524288'>
+						<value/>
+					</BlockEndTypes>
+					<AppliesToBlockStructure classname='Bool' valueflags='4194328' structureflags='524288'>
+						<value>false</value>
+					</AppliesToBlockStructure>
+					<CanEncapsulate classname='Bool' valueflags='4194328' structureflags='524288'>
+						<value>false</value>
+					</CanEncapsulate>
+					<Category classname='Str' valueflags='24' structureflags='524288'>
+						<value>Action</value>
+					</Category>
+				</subprops>
+			</Action>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='29'>
+			<NI_PythonParameterResult classname='PythonParameterResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+				<subprops>
+					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</Condition>
+					<Flags classname='Num'>
+						<value>8192</value>
+						<numericfmt>%#x</numericfmt>
+					</Flags>
+					<CheckedState classname='Num'>
+						<value>1</value>
+					</CheckedState>
+				</subprops>
+			</NI_PythonParameterResult>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='28'>
+			<NI_PythonParameter classname='CPythonParameter' isroottypedef='true' typecategory='3' timestamp='1650060872' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+				<subprops>
+					<Name classname='Str'>
+						<value>_notNamed</value>
+					</Name>
+					<Type classname='Num'>
+						<value>7</value>
+					</Type>
+					<ArgumentValue typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</ArgumentValue>
+					<ArgumentDisplayValue typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</ArgumentDisplayValue>
+					<AdditionalResults classname='Obj'>
+						<subprops>
+							<Input typename='NI_PythonParameterResult' xsi:type='NI_PythonParameterResult' classname='PythonParameterResult'>
+								<subprops>
+									<Condition classname='ExprValue'>
+										<value/>
+									</Condition>
+									<Flags classname='Num'>
+										<value>8192</value>
+									</Flags>
+									<CheckedState classname='Num'>
+										<value>1</value>
+									</CheckedState>
+								</subprops>
+							</Input>
+							<Output typename='NI_PythonParameterResult' xsi:type='NI_PythonParameterResult' classname='PythonParameterResult'>
+								<subprops>
+									<Condition classname='ExprValue'>
+										<value/>
+									</Condition>
+									<Flags classname='Num'>
+										<value>8192</value>
+									</Flags>
+									<CheckedState classname='Num'>
+										<value>1</value>
+									</CheckedState>
+								</subprops>
+							</Output>
+						</subprops>
+					</AdditionalResults>
+				</subprops>
+			</NI_PythonParameter>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='27'>
+			<PythonStepAdditions classname='CPythonModule' isroottypedef='true' typecategory='3' timestamp='1650060872' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+				<subprops>
+					<PythonCall classname='CPythonCall'>
+						<subprops>
+							<UseAdapterSettingsForInterpreterSession classname='Bool'>
+								<value>true</value>
+							</UseAdapterSettingsForInterpreterSession>
+							<InterpreterSessionScope classname='Num'>
+								<value>3</value>
+							</InterpreterSessionScope>
+							<PythonVersion classname='Str'>
+								<value/>
+							</PythonVersion>
+							<PythonVirtualEnvironmentPath classname='Str'>
+								<value/>
+							</PythonVirtualEnvironmentPath>
+							<InterpreterLocation typename='Expression' xsi:type='Expression' classname='ExprValue'>
+								<value/>
+							</InterpreterLocation>
+							<CreateIfInterpreterDoesNotExist classname='Bool'>
+								<value>true</value>
+							</CreateIfInterpreterDoesNotExist>
+							<ModulePath typename='Path' xsi:type='Path' classname='PathValue'>
+								<value/>
+							</ModulePath>
+							<OperationType classname='Num'>
+								<value>1</value>
+							</OperationType>
+							<OperationScope classname='Num'>
+								<value>0</value>
+							</OperationScope>
+							<ClassName classname='Str'>
+								<value/>
+							</ClassName>
+							<ClassInstanceLocation typename='Expression' xsi:type='Expression' classname='ExprValue'>
+								<value/>
+							</ClassInstanceLocation>
+							<FunctionOrAttributeName classname='Str'>
+								<value/>
+							</FunctionOrAttributeName>
+							<Parameters classname='Objs'>
+								<value lbound='[0]' ubound='[0]'>
+									<elemproto>
+										<_NAME_IN_ATTRIBUTE_ typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name='' classname='CPythonParameter' structureflags='131072'>
+											<subprops>
+												<Name classname='Str'>
+													<value>_notNamed</value>
+												</Name>
+												<Type classname='Num'>
+													<value>7</value>
+												</Type>
+												<ArgumentValue classname='ExprValue'>
+													<value/>
+												</ArgumentValue>
+												<ArgumentDisplayValue classname='ExprValue'>
+													<value/>
+												</ArgumentDisplayValue>
+												<AdditionalResults classname='Obj'>
+													<subprops>
+														<Input classname='PythonParameterResult'>
+															<subprops>
+																<Condition classname='ExprValue'>
+																	<value/>
+																</Condition>
+																<Flags classname='Num'>
+																	<value>8192</value>
+																</Flags>
+																<CheckedState classname='Num'>
+																	<value>1</value>
+																</CheckedState>
+															</subprops>
+														</Input>
+														<Output classname='PythonParameterResult'>
+															<subprops>
+																<Condition classname='ExprValue'>
+																	<value/>
+																</Condition>
+																<Flags classname='Num'>
+																	<value>8192</value>
+																</Flags>
+																<CheckedState classname='Num'>
+																	<value>1</value>
+																</CheckedState>
+															</subprops>
+														</Output>
+													</subprops>
+												</AdditionalResults>
+											</subprops>
+										</_NAME_IN_ATTRIBUTE_>
+									</elemproto>
+									<value>
+										<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
+											<subprops>
+												<Name classname='Str'>
+													<value>Return Value</value>
+												</Name>
+												<Type classname='Num'>
+													<value>7</value>
+												</Type>
+												<ArgumentValue classname='ExprValue'>
+													<value/>
+												</ArgumentValue>
+												<ArgumentDisplayValue classname='ExprValue'>
+													<value/>
+												</ArgumentDisplayValue>
+												<AdditionalResults classname='Obj'>
+													<subprops>
+														<Input classname='PythonParameterResult'>
+															<subprops>
+																<Condition classname='ExprValue'>
+																	<value/>
+																</Condition>
+																<Flags classname='Num'>
+																	<value>8192</value>
+																</Flags>
+																<CheckedState classname='Num'>
+																	<value>1</value>
+																</CheckedState>
+															</subprops>
+														</Input>
+														<Output classname='PythonParameterResult'>
+															<subprops>
+																<Condition classname='ExprValue'>
+																	<value/>
+																</Condition>
+																<Flags classname='Num'>
+																	<value>8192</value>
+																</Flags>
+																<CheckedState classname='Num'>
+																	<value>1</value>
+																</CheckedState>
+															</subprops>
+														</Output>
+													</subprops>
+												</AdditionalResults>
+											</subprops>
+										</CPythonParameter>
+									</value>
+								</value>
+							</Parameters>
+							<DefaultParamCategoryForArray classname='Num'>
+								<value>5</value>
+							</DefaultParamCategoryForArray>
+						</subprops>
+					</PythonCall>
+				</subprops>
+			</PythonStepAdditions>
+		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='22'>
 			<EditSubstep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
 				<subprops>
@@ -3592,647 +4233,6 @@
 				</subprops>
 			</Statement>
 		</typedef>
-		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='21'>
-			<Action classname='StepType' isroottypedef='true' typecategory='1' timestamp='1618215606' typeversion='21.0.0.2' typelastmodversion='21.0.0.0' typeminprodversion='21.0.0.0' typeflags='33554446'>
-				<subprops>
-					<Substeps typename='StepTypeSubstepsArray' xsi:type='StepTypeSubstepsArray' classname='Objs' flagsforinstances='524312' instanceoverrideflags='655384'>
-						<value lbound='[0]' ubound='[]'/>
-					</Substeps>
-					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
-						<value>ResStr("NI_STEPTYPES", "ACTION_DESCRIPTION_NAME") + (("%ModuleDescription" == "") ? "" : ",  %ModuleDescription")</value>
-					</DescriptionFormat>
-					<DefaultNameFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
-						<value>ResStr("NI_STEPTYPES", "ACTION_DEF_STEP_NAME")</value>
-					</DefaultNameFormat>
-					<Menu typename='StepTypeMenu' xsi:type='StepTypeMenu' classname='Obj' flagsforinstances='524312' instanceoverrideflags='524312'>
-						<subprops>
-							<CanBeSubstepType classname='Bool'>
-								<value>false</value>
-							</CanBeSubstepType>
-							<CanOnlyBeSubstepType classname='Bool'>
-								<value>false</value>
-							</CanOnlyBeSubstepType>
-							<Category classname='Str'>
-								<value>""</value>
-							</Category>
-							<ItemName classname='ExprValue'>
-								<value>ResStr("NI_STEPTYPES", "ACTION_MENU_ITEM_NAME")</value>
-							</ItemName>
-							<SingularItemName classname='Str'>
-								<value>""</value>
-							</SingularItemName>
-							<SeparatorBeforeCategory classname='Bool'>
-								<value>false</value>
-							</SeparatorBeforeCategory>
-							<SeparatorBeforeItemName classname='Bool'>
-								<value>false</value>
-							</SeparatorBeforeItemName>
-							<Group classname='Str'>
-								<value>Action</value>
-							</Group>
-						</subprops>
-					</Menu>
-					<AdditionalResultsHints classname='Objs' valueflags='4194328' structureflags='524288'>
-						<value lbound='[0]' ubound='[]'>
-							<elemproto>
-								<_NAME_IN_ATTRIBUTE_ typename='NI_CustomResult' xsi:type='NI_CustomResult' name='' classname='CustomResult'>
-									<subprops>
-										<Name classname='ExprValue'>
-											<value/>
-										</Name>
-										<ValueToLog classname='ExprValue'>
-											<value/>
-										</ValueToLog>
-										<Condition classname='ExprValue'>
-											<value/>
-										</Condition>
-										<Flags classname='Num'>
-											<value>8192</value>
-										</Flags>
-										<CheckedState classname='Num'>
-											<value>2</value>
-										</CheckedState>
-										<Type classname='PropertyObjectType'>
-											<subprops>
-												<ValueType classname='Num'>
-													<value>3</value>
-												</ValueType>
-												<IsObject classname='Bool'>
-													<value>true</value>
-												</IsObject>
-												<TypeName classname='Str'>
-													<value/>
-												</TypeName>
-												<ElementType classname='Objs'>
-													<value lbound='[0]' ubound='[]'/>
-												</ElementType>
-												<ArrayDimensions classname='ArrayDimensions'>
-													<subprops>
-														<LowerBounds classname='Nums'>
-															<value lbound='[0]' ubound='[]'/>
-														</LowerBounds>
-														<UpperBounds classname='Nums'>
-															<value lbound='[0]' ubound='[]'/>
-														</UpperBounds>
-													</subprops>
-												</ArrayDimensions>
-												<Representation classname='Num'>
-													<value>1</value>
-												</Representation>
-												<ClassName classname='Str'>
-													<value/>
-												</ClassName>
-											</subprops>
-										</Type>
-										<Elements classname='Objs'>
-											<value lbound='[0]' ubound='[]'/>
-										</Elements>
-										<IsAnyType classname='Bool'>
-											<value>true</value>
-										</IsAnyType>
-									</subprops>
-								</_NAME_IN_ATTRIBUTE_>
-							</elemproto>
-						</value>
-					</AdditionalResultsHints>
-					<TS typename='TEInf' xsi:type='TEInf' classname='Obj' flagsforinstances='262168' instanceoverrideflags='4456472'>
-						<subprops>
-							<Id classname='Str'>
-								<value/>
-							</Id>
-							<Icon classname='Str'>
-								<value/>
-							</Icon>
-							<SData classname='Obj' flagsforinstances='2097152' instanceoverrideflags='7143448' structureflags='2097152'/>
-							<PreCond classname='ExprValue'>
-								<value/>
-							</PreCond>
-							<LoadOpt classname='Str'>
-								<value>PreloadWhenExecuted</value>
-							</LoadOpt>
-							<UnloadOpt classname='Str'>
-								<value>UnloadWithFile</value>
-							</UnloadOpt>
-							<Mode classname='Str'>
-								<value>Normal</value>
-							</Mode>
-							<WindowActivation classname='Str'>
-								<value>None</value>
-							</WindowActivation>
-							<ResultOption classname='Num'>
-								<value>1</value>
-							</ResultOption>
-							<StepFCSeqF classname='Bool'>
-								<value>true</value>
-							</StepFCSeqF>
-							<IgnoreRTE classname='Bool'>
-								<value>false</value>
-							</IgnoreRTE>
-							<UseMutex classname='Bool'>
-								<value>false</value>
-							</UseMutex>
-							<MutexNameOrRef classname='ExprValue'>
-								<value/>
-							</MutexNameOrRef>
-							<BatchSyncOpt classname='Num'>
-								<value>0</value>
-							</BatchSyncOpt>
-							<SwitchEnabled classname='Bool'>
-								<value>false</value>
-							</SwitchEnabled>
-							<VirtualDeviceName classname='ExprValue'>
-								<value/>
-							</VirtualDeviceName>
-							<SwitchOperation classname='Num'>
-								<value>1</value>
-							</SwitchOperation>
-							<RouteGroupConnect classname='ExprValue'>
-								<value/>
-							</RouteGroupConnect>
-							<RouteGroupDisconnect classname='ExprValue'>
-								<value/>
-							</RouteGroupDisconnect>
-							<MulticonnectMode classname='Num'>
-								<value>1</value>
-							</MulticonnectMode>
-							<OperationOrder classname='Num'>
-								<value>2</value>
-							</OperationOrder>
-							<ConnectionLifetime classname='Num'>
-								<value>0</value>
-							</ConnectionLifetime>
-							<WaitForDebounce classname='Bool'>
-								<value>true</value>
-							</WaitForDebounce>
-							<PassAct classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
-								<value>Next</value>
-							</PassAct>
-							<FailAct classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
-								<value>Next</value>
-							</FailAct>
-							<PassActTarget classname='ExprValue' flagsforinstances='1' instanceoverrideflags='5046297'>
-								<value/>
-							</PassActTarget>
-							<FailActTarget classname='ExprValue' flagsforinstances='1' instanceoverrideflags='5046297'>
-								<value/>
-							</FailActTarget>
-							<CustExpr classname='ExprValue'>
-								<value/>
-							</CustExpr>
-							<CustTrueAct classname='Str'>
-								<value>Next</value>
-							</CustTrueAct>
-							<CustFalseAct classname='Str'>
-								<value>Next</value>
-							</CustFalseAct>
-							<CustTrueActTarget classname='ExprValue'>
-								<value/>
-							</CustTrueActTarget>
-							<CustFalseActTarget classname='ExprValue'>
-								<value/>
-							</CustFalseActTarget>
-							<LoopType classname='Str'>
-								<value>NoLooping</value>
-							</LoopType>
-							<LoopWhile classname='ExprValue'>
-								<value/>
-							</LoopWhile>
-							<LoopStatus classname='ExprValue'>
-								<value/>
-							</LoopStatus>
-							<LoopIncrement classname='ExprValue'>
-								<value>RunState.LoopIndex += 1</value>
-							</LoopIncrement>
-							<LoopInitialize classname='ExprValue'>
-								<value>RunState.LoopIndex = 0</value>
-							</LoopInitialize>
-							<LoopOpt classname='Num'>
-								<value>0</value>
-							</LoopOpt>
-							<PreExpr classname='ExprValue'>
-								<value/>
-							</PreExpr>
-							<PostExpr classname='ExprValue'>
-								<value/>
-							</PostExpr>
-							<StatusExpr classname='ExprValue'>
-								<value/>
-							</StatusExpr>
-							<CanSpecifyModule classname='Bool'>
-								<value>true</value>
-							</CanSpecifyModule>
-							<CanEditCode classname='Bool'>
-								<value>true</value>
-							</CanEditCode>
-							<CanEditModulePrototype classname='Bool'>
-								<value>true</value>
-							</CanEditModulePrototype>
-							<CanEditParameterAdditionalResults classname='Bool'>
-								<value>true</value>
-							</CanEditParameterAdditionalResults>
-							<PrecondIntExe classname='Num'>
-								<value>0</value>
-							</PrecondIntExe>
-							<Requirements classname='Obj' flagsforinstances='1' valueflags='1' structureflags='2097152'>
-								<subprops>
-									<Links classname='Strs' flagsforinstances='71303168' instanceoverrideflags='72286233' valueflags='71303168'>
-										<value lbound='[0]' ubound='[]'/>
-									</Links>
-								</subprops>
-							</Requirements>
-							<CustomResults classname='Objs'>
-								<value lbound='[0]' ubound='[]'>
-									<elemproto>
-										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-											<subprops>
-												<Name classname='ExprValue'>
-													<value/>
-												</Name>
-												<ValueToLog classname='ExprValue'>
-													<value/>
-												</ValueToLog>
-												<Condition classname='ExprValue'>
-													<value/>
-												</Condition>
-												<Flags classname='Num'>
-													<value>8192</value>
-												</Flags>
-												<CheckedState classname='Num'>
-													<value>2</value>
-												</CheckedState>
-												<Type classname='PropertyObjectType'>
-													<subprops>
-														<ValueType classname='Num'>
-															<value>3</value>
-														</ValueType>
-														<IsObject classname='Bool'>
-															<value>true</value>
-														</IsObject>
-														<TypeName classname='Str'>
-															<value/>
-														</TypeName>
-														<ElementType classname='Objs'>
-															<value lbound='[0]' ubound='[]'/>
-														</ElementType>
-														<ArrayDimensions classname='ArrayDimensions'>
-															<subprops>
-																<LowerBounds classname='Nums'>
-																	<value lbound='[0]' ubound='[]'/>
-																</LowerBounds>
-																<UpperBounds classname='Nums'>
-																	<value lbound='[0]' ubound='[]'/>
-																</UpperBounds>
-															</subprops>
-														</ArrayDimensions>
-														<Representation classname='Num'>
-															<value>1</value>
-														</Representation>
-														<ClassName classname='Str'>
-															<value/>
-														</ClassName>
-													</subprops>
-												</Type>
-												<Elements classname='Objs'>
-													<value lbound='[0]' ubound='[]'/>
-												</Elements>
-												<IsAnyType classname='Bool'>
-													<value>true</value>
-												</IsAnyType>
-											</subprops>
-										</_NAME_IN_ATTRIBUTE_>
-									</elemproto>
-								</value>
-							</CustomResults>
-							<AdditionalResultsHints classname='Objs'>
-								<value lbound='[0]' ubound='[]'>
-									<elemproto>
-										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-											<subprops>
-												<Name classname='ExprValue'>
-													<value/>
-												</Name>
-												<ValueToLog classname='ExprValue'>
-													<value/>
-												</ValueToLog>
-												<Condition classname='ExprValue'>
-													<value/>
-												</Condition>
-												<Flags classname='Num'>
-													<value>8192</value>
-												</Flags>
-												<CheckedState classname='Num'>
-													<value>2</value>
-												</CheckedState>
-												<Type classname='PropertyObjectType'>
-													<subprops>
-														<ValueType classname='Num'>
-															<value>3</value>
-														</ValueType>
-														<IsObject classname='Bool'>
-															<value>true</value>
-														</IsObject>
-														<TypeName classname='Str'>
-															<value/>
-														</TypeName>
-														<ElementType classname='Objs'>
-															<value lbound='[0]' ubound='[]'/>
-														</ElementType>
-														<ArrayDimensions classname='ArrayDimensions'>
-															<subprops>
-																<LowerBounds classname='Nums'>
-																	<value lbound='[0]' ubound='[]'/>
-																</LowerBounds>
-																<UpperBounds classname='Nums'>
-																	<value lbound='[0]' ubound='[]'/>
-																</UpperBounds>
-															</subprops>
-														</ArrayDimensions>
-														<Representation classname='Num'>
-															<value>1</value>
-														</Representation>
-														<ClassName classname='Str'>
-															<value/>
-														</ClassName>
-													</subprops>
-												</Type>
-												<Elements classname='Objs'>
-													<value lbound='[0]' ubound='[]'/>
-												</Elements>
-												<IsAnyType classname='Bool'>
-													<value>true</value>
-												</IsAnyType>
-											</subprops>
-										</_NAME_IN_ATTRIBUTE_>
-									</elemproto>
-								</value>
-							</AdditionalResultsHints>
-						</subprops>
-					</TS>
-					<NI_Data typename='StepTypeNIData' xsi:type='StepTypeNIData' classname='Obj'>
-						<subprops>
-							<EditPanels classname='Strs'>
-								<value lbound='[0]' ubound='[]'/>
-							</EditPanels>
-						</subprops>
-					</NI_Data>
-					<Result classname='Obj' flagsforinstances='4194304' valueflags='4194304'>
-						<subprops>
-							<Error typename='Error' xsi:type='Error' classname='Obj' flagsforinstances='4194304' instanceoverrideflags='4194304' valueflags='4194304'>
-								<subprops>
-									<Code classname='Num'>
-										<value>0</value>
-									</Code>
-									<Msg classname='Str'>
-										<value/>
-									</Msg>
-									<Occurred classname='Bool'>
-										<value>false</value>
-									</Occurred>
-								</subprops>
-							</Error>
-							<Status classname='Str' flagsforinstances='4194304' valueflags='4194304'>
-								<value/>
-							</Status>
-							<ReportText classname='Str' flagsforinstances='4194304' valueflags='4194304'>
-								<value/>
-							</ReportText>
-							<Common typename='CommonResults' xsi:type='CommonResults' classname='Obj' instanceoverrideflags='4194304'/>
-						</subprops>
-					</Result>
-					<CodeTemplates classname='Str' valueflags='4194328' structureflags='524288'>
-						<value>DefaultLabVIEW|DefaultLabVIEWNXG|DefaultCVI|DefaultVB.NET|DefaultCSharp.NET|DefaultC++.NET|DefaultVC++_Template|DefaultHTB72_Template|DefaultHTB80_Template|Default_Template</value>
-					</CodeTemplates>
-					<BlockStartTypes classname='Str' valueflags='4194328' structureflags='524288'>
-						<value/>
-					</BlockStartTypes>
-					<BlockEndTypes classname='Str' valueflags='4194328' structureflags='524288'>
-						<value/>
-					</BlockEndTypes>
-					<AppliesToBlockStructure classname='Bool' valueflags='4194328' structureflags='524288'>
-						<value>false</value>
-					</AppliesToBlockStructure>
-					<CanEncapsulate classname='Bool' valueflags='4194328' structureflags='524288'>
-						<value>false</value>
-					</CanEncapsulate>
-					<Category classname='Str' valueflags='24' structureflags='524288'>
-						<value>Action</value>
-					</Category>
-				</subprops>
-			</Action>
-		</typedef>
-		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='29'>
-			<NI_PythonParameterResult classname='PythonParameterResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
-				<subprops>
-					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
-						<value/>
-					</Condition>
-					<Flags classname='Num'>
-						<value>8192</value>
-						<numericfmt>%#x</numericfmt>
-					</Flags>
-					<CheckedState classname='Num'>
-						<value>1</value>
-					</CheckedState>
-				</subprops>
-			</NI_PythonParameterResult>
-		</typedef>
-		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='28'>
-			<NI_PythonParameter classname='CPythonParameter' isroottypedef='true' typecategory='3' timestamp='1650060872' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
-				<subprops>
-					<Name classname='Str'>
-						<value>_notNamed</value>
-					</Name>
-					<Type classname='Num'>
-						<value>7</value>
-					</Type>
-					<ArgumentValue typename='Expression' xsi:type='Expression' classname='ExprValue'>
-						<value/>
-					</ArgumentValue>
-					<ArgumentDisplayValue typename='Expression' xsi:type='Expression' classname='ExprValue'>
-						<value/>
-					</ArgumentDisplayValue>
-					<AdditionalResults classname='Obj'>
-						<subprops>
-							<Input typename='NI_PythonParameterResult' xsi:type='NI_PythonParameterResult' classname='PythonParameterResult'>
-								<subprops>
-									<Condition classname='ExprValue'>
-										<value/>
-									</Condition>
-									<Flags classname='Num'>
-										<value>8192</value>
-									</Flags>
-									<CheckedState classname='Num'>
-										<value>1</value>
-									</CheckedState>
-								</subprops>
-							</Input>
-							<Output typename='NI_PythonParameterResult' xsi:type='NI_PythonParameterResult' classname='PythonParameterResult'>
-								<subprops>
-									<Condition classname='ExprValue'>
-										<value/>
-									</Condition>
-									<Flags classname='Num'>
-										<value>8192</value>
-									</Flags>
-									<CheckedState classname='Num'>
-										<value>1</value>
-									</CheckedState>
-								</subprops>
-							</Output>
-						</subprops>
-					</AdditionalResults>
-				</subprops>
-			</NI_PythonParameter>
-		</typedef>
-		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='27'>
-			<PythonStepAdditions classname='CPythonModule' isroottypedef='true' typecategory='3' timestamp='1650060872' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
-				<subprops>
-					<PythonCall classname='CPythonCall'>
-						<subprops>
-							<UseAdapterSettingsForInterpreterSession classname='Bool'>
-								<value>true</value>
-							</UseAdapterSettingsForInterpreterSession>
-							<InterpreterSessionScope classname='Num'>
-								<value>3</value>
-							</InterpreterSessionScope>
-							<PythonVersion classname='Str'>
-								<value/>
-							</PythonVersion>
-							<PythonVirtualEnvironmentPath classname='Str'>
-								<value/>
-							</PythonVirtualEnvironmentPath>
-							<InterpreterLocation typename='Expression' xsi:type='Expression' classname='ExprValue'>
-								<value/>
-							</InterpreterLocation>
-							<CreateIfInterpreterDoesNotExist classname='Bool'>
-								<value>true</value>
-							</CreateIfInterpreterDoesNotExist>
-							<ModulePath typename='Path' xsi:type='Path' classname='PathValue'>
-								<value/>
-							</ModulePath>
-							<OperationType classname='Num'>
-								<value>1</value>
-							</OperationType>
-							<OperationScope classname='Num'>
-								<value>0</value>
-							</OperationScope>
-							<ClassName classname='Str'>
-								<value/>
-							</ClassName>
-							<ClassInstanceLocation typename='Expression' xsi:type='Expression' classname='ExprValue'>
-								<value/>
-							</ClassInstanceLocation>
-							<FunctionOrAttributeName classname='Str'>
-								<value/>
-							</FunctionOrAttributeName>
-							<Parameters classname='Objs'>
-								<value lbound='[0]' ubound='[0]'>
-									<elemproto>
-										<_NAME_IN_ATTRIBUTE_ typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name='' classname='CPythonParameter' structureflags='131072'>
-											<subprops>
-												<Name classname='Str'>
-													<value>_notNamed</value>
-												</Name>
-												<Type classname='Num'>
-													<value>7</value>
-												</Type>
-												<ArgumentValue classname='ExprValue'>
-													<value/>
-												</ArgumentValue>
-												<ArgumentDisplayValue classname='ExprValue'>
-													<value/>
-												</ArgumentDisplayValue>
-												<AdditionalResults classname='Obj'>
-													<subprops>
-														<Input classname='PythonParameterResult'>
-															<subprops>
-																<Condition classname='ExprValue'>
-																	<value/>
-																</Condition>
-																<Flags classname='Num'>
-																	<value>8192</value>
-																</Flags>
-																<CheckedState classname='Num'>
-																	<value>1</value>
-																</CheckedState>
-															</subprops>
-														</Input>
-														<Output classname='PythonParameterResult'>
-															<subprops>
-																<Condition classname='ExprValue'>
-																	<value/>
-																</Condition>
-																<Flags classname='Num'>
-																	<value>8192</value>
-																</Flags>
-																<CheckedState classname='Num'>
-																	<value>1</value>
-																</CheckedState>
-															</subprops>
-														</Output>
-													</subprops>
-												</AdditionalResults>
-											</subprops>
-										</_NAME_IN_ATTRIBUTE_>
-									</elemproto>
-									<value>
-										<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
-											<subprops>
-												<Name classname='Str'>
-													<value>Return Value</value>
-												</Name>
-												<Type classname='Num'>
-													<value>7</value>
-												</Type>
-												<ArgumentValue classname='ExprValue'>
-													<value/>
-												</ArgumentValue>
-												<ArgumentDisplayValue classname='ExprValue'>
-													<value/>
-												</ArgumentDisplayValue>
-												<AdditionalResults classname='Obj'>
-													<subprops>
-														<Input classname='PythonParameterResult'>
-															<subprops>
-																<Condition classname='ExprValue'>
-																	<value/>
-																</Condition>
-																<Flags classname='Num'>
-																	<value>8192</value>
-																</Flags>
-																<CheckedState classname='Num'>
-																	<value>1</value>
-																</CheckedState>
-															</subprops>
-														</Input>
-														<Output classname='PythonParameterResult'>
-															<subprops>
-																<Condition classname='ExprValue'>
-																	<value/>
-																</Condition>
-																<Flags classname='Num'>
-																	<value>8192</value>
-																</Flags>
-																<CheckedState classname='Num'>
-																	<value>1</value>
-																</CheckedState>
-															</subprops>
-														</Output>
-													</subprops>
-												</AdditionalResults>
-											</subprops>
-										</CPythonParameter>
-									</value>
-								</value>
-							</Parameters>
-							<DefaultParamCategoryForArray classname='Num'>
-								<value>5</value>
-							</DefaultParamCategoryForArray>
-						</subprops>
-					</PythonCall>
-				</subprops>
-			</PythonStepAdditions>
-		</typedef>
 	</typelist>
 	<Data classname='SequenceFileData' valueflags='4194304'>
 		<subprops>
@@ -4741,302 +4741,7 @@
 									</value>
 								</Main>
 								<Setup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[3]'>
-										<value>
-											<Step typename='Statement' xsi:type='Statement' name='Get absolute path to pinmap file'>
-												<subprops>
-													<TS classname='Obj'>
-														<subprops>
-															<Id classname='Str'>
-																<value>ID#:CHEZyO1w7RGuNrjdh1OqZD</value>
-															</Id>
-															<Icon classname='Str'>
-																<value>StatementStep.ico</value>
-															</Icon>
-															<PreCond classname='ExprValue'>
-																<value/>
-															</PreCond>
-															<LoadOpt classname='Str'>
-																<value>PreloadWhenExecuted</value>
-															</LoadOpt>
-															<UnloadOpt classname='Str'>
-																<value>UnloadWithFile</value>
-															</UnloadOpt>
-															<Mode classname='Str'>
-																<value>Normal</value>
-															</Mode>
-															<WindowActivation classname='Str'>
-																<value>None</value>
-															</WindowActivation>
-															<ResultOption classname='Num'>
-																<value>1</value>
-															</ResultOption>
-															<StepFCSeqF classname='Bool'>
-																<value>true</value>
-															</StepFCSeqF>
-															<IgnoreRTE classname='Bool'>
-																<value>false</value>
-															</IgnoreRTE>
-															<UseMutex classname='Bool'>
-																<value>false</value>
-															</UseMutex>
-															<MutexNameOrRef classname='ExprValue'>
-																<value/>
-															</MutexNameOrRef>
-															<BatchSyncOpt classname='Num'>
-																<value>0</value>
-															</BatchSyncOpt>
-															<SwitchEnabled classname='Bool'>
-																<value>false</value>
-															</SwitchEnabled>
-															<VirtualDeviceName classname='ExprValue'>
-																<value/>
-															</VirtualDeviceName>
-															<SwitchOperation classname='Num'>
-																<value>1</value>
-															</SwitchOperation>
-															<RouteGroupConnect classname='ExprValue'>
-																<value/>
-															</RouteGroupConnect>
-															<RouteGroupDisconnect classname='ExprValue'>
-																<value/>
-															</RouteGroupDisconnect>
-															<MulticonnectMode classname='Num'>
-																<value>1</value>
-															</MulticonnectMode>
-															<OperationOrder classname='Num'>
-																<value>2</value>
-															</OperationOrder>
-															<ConnectionLifetime classname='Num'>
-																<value>0</value>
-															</ConnectionLifetime>
-															<WaitForDebounce classname='Bool'>
-																<value>true</value>
-															</WaitForDebounce>
-															<PassAct classname='Str'>
-																<value>Next</value>
-															</PassAct>
-															<FailAct classname='Str'>
-																<value>Next</value>
-															</FailAct>
-															<PassActTarget classname='ExprValue'>
-																<value/>
-															</PassActTarget>
-															<FailActTarget classname='ExprValue'>
-																<value/>
-															</FailActTarget>
-															<CustExpr classname='ExprValue'>
-																<value/>
-															</CustExpr>
-															<CustTrueAct classname='Str'>
-																<value>Next</value>
-															</CustTrueAct>
-															<CustFalseAct classname='Str'>
-																<value>Next</value>
-															</CustFalseAct>
-															<CustTrueActTarget classname='ExprValue'>
-																<value/>
-															</CustTrueActTarget>
-															<CustFalseActTarget classname='ExprValue'>
-																<value/>
-															</CustFalseActTarget>
-															<LoopType classname='Str'>
-																<value>NoLooping</value>
-															</LoopType>
-															<LoopWhile classname='ExprValue'>
-																<value/>
-															</LoopWhile>
-															<LoopStatus classname='ExprValue'>
-																<value/>
-															</LoopStatus>
-															<LoopIncrement classname='ExprValue'>
-																<value>RunState.LoopIndex += 1</value>
-															</LoopIncrement>
-															<LoopInitialize classname='ExprValue'>
-																<value>RunState.LoopIndex = 0</value>
-															</LoopInitialize>
-															<LoopOpt classname='Num'>
-																<value>0</value>
-															</LoopOpt>
-															<PreExpr classname='ExprValue'>
-																<value/>
-															</PreExpr>
-															<PostExpr classname='ExprValue'>
-																<value>FindFile(FileGlobals.MeasurementLink.PinMapFileName,True,FileGlobals.MeasurementLink.PinMapPath)</value>
-															</PostExpr>
-															<StatusExpr classname='ExprValue'>
-																<value/>
-															</StatusExpr>
-															<CanSpecifyModule classname='Bool'>
-																<value>false</value>
-															</CanSpecifyModule>
-															<CanEditCode classname='Bool'>
-																<value>true</value>
-															</CanEditCode>
-															<CanEditModulePrototype classname='Bool'>
-																<value>true</value>
-															</CanEditModulePrototype>
-															<CanEditParameterAdditionalResults classname='Bool'>
-																<value>true</value>
-															</CanEditParameterAdditionalResults>
-															<PrecondIntExe classname='Num'>
-																<value>0</value>
-															</PrecondIntExe>
-															<CustomResults classname='Objs'>
-																<value lbound='[0]' ubound='[]'>
-																	<elemproto>
-																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-																			<subprops>
-																				<Name classname='ExprValue'>
-																					<value/>
-																				</Name>
-																				<ValueToLog classname='ExprValue'>
-																					<value/>
-																				</ValueToLog>
-																				<Condition classname='ExprValue'>
-																					<value/>
-																				</Condition>
-																				<Flags classname='Num'>
-																					<value>8192</value>
-																				</Flags>
-																				<CheckedState classname='Num'>
-																					<value>2</value>
-																				</CheckedState>
-																				<Type classname='PropertyObjectType'>
-																					<subprops>
-																						<ValueType classname='Num'>
-																							<value>3</value>
-																						</ValueType>
-																						<IsObject classname='Bool'>
-																							<value>true</value>
-																						</IsObject>
-																						<TypeName classname='Str'>
-																							<value/>
-																						</TypeName>
-																						<ElementType classname='Objs'>
-																							<value lbound='[0]' ubound='[]'/>
-																						</ElementType>
-																						<ArrayDimensions classname='ArrayDimensions'>
-																							<subprops>
-																								<LowerBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</LowerBounds>
-																								<UpperBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</UpperBounds>
-																							</subprops>
-																						</ArrayDimensions>
-																						<Representation classname='Num'>
-																							<value>1</value>
-																						</Representation>
-																						<ClassName classname='Str'>
-																							<value/>
-																						</ClassName>
-																					</subprops>
-																				</Type>
-																				<Elements classname='Objs'>
-																					<value lbound='[0]' ubound='[]'/>
-																				</Elements>
-																				<IsAnyType classname='Bool'>
-																					<value>true</value>
-																				</IsAnyType>
-																			</subprops>
-																		</_NAME_IN_ATTRIBUTE_>
-																	</elemproto>
-																</value>
-															</CustomResults>
-															<AdditionalResultsHints classname='Objs'>
-																<value lbound='[0]' ubound='[]'>
-																	<elemproto>
-																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-																			<subprops>
-																				<Name classname='ExprValue'>
-																					<value/>
-																				</Name>
-																				<ValueToLog classname='ExprValue'>
-																					<value/>
-																				</ValueToLog>
-																				<Condition classname='ExprValue'>
-																					<value/>
-																				</Condition>
-																				<Flags classname='Num'>
-																					<value>8192</value>
-																				</Flags>
-																				<CheckedState classname='Num'>
-																					<value>2</value>
-																				</CheckedState>
-																				<Type classname='PropertyObjectType'>
-																					<subprops>
-																						<ValueType classname='Num'>
-																							<value>3</value>
-																						</ValueType>
-																						<IsObject classname='Bool'>
-																							<value>true</value>
-																						</IsObject>
-																						<TypeName classname='Str'>
-																							<value/>
-																						</TypeName>
-																						<ElementType classname='Objs'>
-																							<value lbound='[0]' ubound='[]'/>
-																						</ElementType>
-																						<ArrayDimensions classname='ArrayDimensions'>
-																							<subprops>
-																								<LowerBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</LowerBounds>
-																								<UpperBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</UpperBounds>
-																							</subprops>
-																						</ArrayDimensions>
-																						<Representation classname='Num'>
-																							<value>1</value>
-																						</Representation>
-																						<ClassName classname='Str'>
-																							<value/>
-																						</ClassName>
-																					</subprops>
-																				</Type>
-																				<Elements classname='Objs'>
-																					<value lbound='[0]' ubound='[]'/>
-																				</Elements>
-																				<IsAnyType classname='Bool'>
-																					<value>true</value>
-																				</IsAnyType>
-																			</subprops>
-																		</_NAME_IN_ATTRIBUTE_>
-																	</elemproto>
-																</value>
-															</AdditionalResultsHints>
-														</subprops>
-													</TS>
-													<Result classname='Obj'>
-														<subprops>
-															<Error classname='Obj'>
-																<subprops>
-																	<Code classname='Num'>
-																		<value>0</value>
-																	</Code>
-																	<Msg classname='Str'>
-																		<value/>
-																	</Msg>
-																	<Occurred classname='Bool'>
-																		<value>false</value>
-																	</Occurred>
-																</subprops>
-															</Error>
-															<Status classname='Str'>
-																<value/>
-															</Status>
-															<ReportText classname='Str'>
-																<value/>
-															</ReportText>
-															<Common classname='Obj'/>
-														</subprops>
-													</Result>
-												</subprops>
-											</Step>
-										</value>
+									<value lbound='[0]' ubound='[1]'>
 										<value>
 											<Step typename='Action' xsi:type='Action' name='Update pin map'>
 												<subprops>
@@ -5807,301 +5512,6 @@
 															</StatusExpr>
 															<CanSpecifyModule classname='Bool'>
 																<value>true</value>
-															</CanSpecifyModule>
-															<CanEditCode classname='Bool'>
-																<value>true</value>
-															</CanEditCode>
-															<CanEditModulePrototype classname='Bool'>
-																<value>true</value>
-															</CanEditModulePrototype>
-															<CanEditParameterAdditionalResults classname='Bool'>
-																<value>true</value>
-															</CanEditParameterAdditionalResults>
-															<PrecondIntExe classname='Num'>
-																<value>0</value>
-															</PrecondIntExe>
-															<CustomResults classname='Objs'>
-																<value lbound='[0]' ubound='[]'>
-																	<elemproto>
-																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-																			<subprops>
-																				<Name classname='ExprValue'>
-																					<value/>
-																				</Name>
-																				<ValueToLog classname='ExprValue'>
-																					<value/>
-																				</ValueToLog>
-																				<Condition classname='ExprValue'>
-																					<value/>
-																				</Condition>
-																				<Flags classname='Num'>
-																					<value>8192</value>
-																				</Flags>
-																				<CheckedState classname='Num'>
-																					<value>2</value>
-																				</CheckedState>
-																				<Type classname='PropertyObjectType'>
-																					<subprops>
-																						<ValueType classname='Num'>
-																							<value>3</value>
-																						</ValueType>
-																						<IsObject classname='Bool'>
-																							<value>true</value>
-																						</IsObject>
-																						<TypeName classname='Str'>
-																							<value/>
-																						</TypeName>
-																						<ElementType classname='Objs'>
-																							<value lbound='[0]' ubound='[]'/>
-																						</ElementType>
-																						<ArrayDimensions classname='ArrayDimensions'>
-																							<subprops>
-																								<LowerBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</LowerBounds>
-																								<UpperBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</UpperBounds>
-																							</subprops>
-																						</ArrayDimensions>
-																						<Representation classname='Num'>
-																							<value>1</value>
-																						</Representation>
-																						<ClassName classname='Str'>
-																							<value/>
-																						</ClassName>
-																					</subprops>
-																				</Type>
-																				<Elements classname='Objs'>
-																					<value lbound='[0]' ubound='[]'/>
-																				</Elements>
-																				<IsAnyType classname='Bool'>
-																					<value>true</value>
-																				</IsAnyType>
-																			</subprops>
-																		</_NAME_IN_ATTRIBUTE_>
-																	</elemproto>
-																</value>
-															</CustomResults>
-															<AdditionalResultsHints classname='Objs'>
-																<value lbound='[0]' ubound='[]'>
-																	<elemproto>
-																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-																			<subprops>
-																				<Name classname='ExprValue'>
-																					<value/>
-																				</Name>
-																				<ValueToLog classname='ExprValue'>
-																					<value/>
-																				</ValueToLog>
-																				<Condition classname='ExprValue'>
-																					<value/>
-																				</Condition>
-																				<Flags classname='Num'>
-																					<value>8192</value>
-																				</Flags>
-																				<CheckedState classname='Num'>
-																					<value>2</value>
-																				</CheckedState>
-																				<Type classname='PropertyObjectType'>
-																					<subprops>
-																						<ValueType classname='Num'>
-																							<value>3</value>
-																						</ValueType>
-																						<IsObject classname='Bool'>
-																							<value>true</value>
-																						</IsObject>
-																						<TypeName classname='Str'>
-																							<value/>
-																						</TypeName>
-																						<ElementType classname='Objs'>
-																							<value lbound='[0]' ubound='[]'/>
-																						</ElementType>
-																						<ArrayDimensions classname='ArrayDimensions'>
-																							<subprops>
-																								<LowerBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</LowerBounds>
-																								<UpperBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</UpperBounds>
-																							</subprops>
-																						</ArrayDimensions>
-																						<Representation classname='Num'>
-																							<value>1</value>
-																						</Representation>
-																						<ClassName classname='Str'>
-																							<value/>
-																						</ClassName>
-																					</subprops>
-																				</Type>
-																				<Elements classname='Objs'>
-																					<value lbound='[0]' ubound='[]'/>
-																				</Elements>
-																				<IsAnyType classname='Bool'>
-																					<value>true</value>
-																				</IsAnyType>
-																			</subprops>
-																		</_NAME_IN_ATTRIBUTE_>
-																	</elemproto>
-																</value>
-															</AdditionalResultsHints>
-														</subprops>
-													</TS>
-													<Result classname='Obj'>
-														<subprops>
-															<Error classname='Obj'>
-																<subprops>
-																	<Code classname='Num'>
-																		<value>0</value>
-																	</Code>
-																	<Msg classname='Str'>
-																		<value/>
-																	</Msg>
-																	<Occurred classname='Bool'>
-																		<value>false</value>
-																	</Occurred>
-																</subprops>
-															</Error>
-															<Status classname='Str'>
-																<value/>
-															</Status>
-															<ReportText classname='Str'>
-																<value/>
-															</ReportText>
-															<Common classname='Obj'/>
-														</subprops>
-													</Result>
-												</subprops>
-											</Step>
-										</value>
-										<value>
-											<Step typename='Statement' xsi:type='Statement' name='Register active PinMapId'>
-												<subprops>
-													<TS classname='Obj'>
-														<subprops>
-															<Id classname='Str'>
-																<value>ID#:7xzPK+Rw7RGuNrjdh1OqZD</value>
-															</Id>
-															<Icon classname='Str'>
-																<value>StatementStep.ico</value>
-															</Icon>
-															<PreCond classname='ExprValue'>
-																<value/>
-															</PreCond>
-															<LoadOpt classname='Str'>
-																<value>PreloadWhenExecuted</value>
-															</LoadOpt>
-															<UnloadOpt classname='Str'>
-																<value>UnloadWithFile</value>
-															</UnloadOpt>
-															<Mode classname='Str'>
-																<value>Normal</value>
-															</Mode>
-															<WindowActivation classname='Str'>
-																<value>None</value>
-															</WindowActivation>
-															<ResultOption classname='Num'>
-																<value>1</value>
-															</ResultOption>
-															<StepFCSeqF classname='Bool'>
-																<value>true</value>
-															</StepFCSeqF>
-															<IgnoreRTE classname='Bool'>
-																<value>false</value>
-															</IgnoreRTE>
-															<UseMutex classname='Bool'>
-																<value>false</value>
-															</UseMutex>
-															<MutexNameOrRef classname='ExprValue'>
-																<value/>
-															</MutexNameOrRef>
-															<BatchSyncOpt classname='Num'>
-																<value>0</value>
-															</BatchSyncOpt>
-															<SwitchEnabled classname='Bool'>
-																<value>false</value>
-															</SwitchEnabled>
-															<VirtualDeviceName classname='ExprValue'>
-																<value/>
-															</VirtualDeviceName>
-															<SwitchOperation classname='Num'>
-																<value>1</value>
-															</SwitchOperation>
-															<RouteGroupConnect classname='ExprValue'>
-																<value/>
-															</RouteGroupConnect>
-															<RouteGroupDisconnect classname='ExprValue'>
-																<value/>
-															</RouteGroupDisconnect>
-															<MulticonnectMode classname='Num'>
-																<value>1</value>
-															</MulticonnectMode>
-															<OperationOrder classname='Num'>
-																<value>2</value>
-															</OperationOrder>
-															<ConnectionLifetime classname='Num'>
-																<value>0</value>
-															</ConnectionLifetime>
-															<WaitForDebounce classname='Bool'>
-																<value>true</value>
-															</WaitForDebounce>
-															<PassAct classname='Str'>
-																<value>Next</value>
-															</PassAct>
-															<FailAct classname='Str'>
-																<value>Next</value>
-															</FailAct>
-															<PassActTarget classname='ExprValue'>
-																<value/>
-															</PassActTarget>
-															<FailActTarget classname='ExprValue'>
-																<value/>
-															</FailActTarget>
-															<CustExpr classname='ExprValue'>
-																<value/>
-															</CustExpr>
-															<CustTrueAct classname='Str'>
-																<value>Next</value>
-															</CustTrueAct>
-															<CustFalseAct classname='Str'>
-																<value>Next</value>
-															</CustFalseAct>
-															<CustTrueActTarget classname='ExprValue'>
-																<value/>
-															</CustTrueActTarget>
-															<CustFalseActTarget classname='ExprValue'>
-																<value/>
-															</CustFalseActTarget>
-															<LoopType classname='Str'>
-																<value>NoLooping</value>
-															</LoopType>
-															<LoopWhile classname='ExprValue'>
-																<value/>
-															</LoopWhile>
-															<LoopStatus classname='ExprValue'>
-																<value/>
-															</LoopStatus>
-															<LoopIncrement classname='ExprValue'>
-																<value>RunState.LoopIndex += 1</value>
-															</LoopIncrement>
-															<LoopInitialize classname='ExprValue'>
-																<value>RunState.LoopIndex = 0</value>
-															</LoopInitialize>
-															<LoopOpt classname='Num'>
-																<value>0</value>
-															</LoopOpt>
-															<PreExpr classname='ExprValue'>
-																<value/>
-															</PreExpr>
-															<PostExpr classname='ExprValue'>
-																<value>RunState.Engine.TemporaryGlobals.SetValString("NI.MeasurementLink.PinMapId", 0x1, FileGlobals.MeasurementLink.PinMapPath)</value>
-															</PostExpr>
-															<StatusExpr classname='ExprValue'>
-																<value/>
-															</StatusExpr>
-															<CanSpecifyModule classname='Bool'>
-																<value>false</value>
 															</CanSpecifyModule>
 															<CanEditCode classname='Bool'>
 																<value>true</value>
@@ -7042,11 +6452,8 @@
 							<EnableMonitoring classname='Bool'>
 								<value>false</value>
 							</EnableMonitoring>
-							<PinMapFileName classname='Str'>
-								<value>NIFgenStandardFunction.pinmap</value>
-							</PinMapFileName>
 							<PinMapPath typename='Path' xsi:type='Path' classname='PathValue'>
-								<value/>
+								<value>NIFgenStandardFunction.pinmap</value>
 							</PinMapPath>
 						</subprops>
 					</MeasurementLink>

--- a/examples/nifgen_standard_function/NIFgenStandardFunction.seq
+++ b/examples/nifgen_standard_function/NIFgenStandardFunction.seq
@@ -4237,7 +4237,7 @@
 	<Data classname='SequenceFileData' valueflags='4194304'>
 		<subprops>
 			<Seq classname='Objs' valueflags='4194304'>
-				<value lbound='[0]' ubound='[2]'>
+				<value lbound='[0]' ubound='[0]'>
 					<value>
 						<Sequence name='MainSequence'>
 							<subprops>
@@ -4741,93 +4741,6 @@
 									</value>
 								</Main>
 								<Setup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
-								</Setup>
-								<Cleanup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
-								</Cleanup>
-								<RecordResults classname='Bool' valueflags='4194312'>
-									<value>true</value>
-								</RecordResults>
-								<RTS classname='Obj' valueflags='4456456'>
-									<subprops>
-										<Type classname='Num' valueflags='4194304'>
-											<value>0</value>
-										</Type>
-										<OptimizeNonReentrantCalls classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</OptimizeNonReentrantCalls>
-										<EPNameExpr classname='Str' valueflags='4194304'>
-											<value>"Unnamed Entry Point"</value>
-										</EPNameExpr>
-										<EPEnabledExpr classname='Str' valueflags='4194304'>
-											<value>True</value>
-										</EPEnabledExpr>
-										<EPMenuHint classname='Str' valueflags='4194304'>
-											<value/>
-										</EPMenuHint>
-										<EPIgnoreClient classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</EPIgnoreClient>
-										<EPInitiallyHidden classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</EPInitiallyHidden>
-										<EPCheckToSaveTitledFile classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</EPCheckToSaveTitledFile>
-										<ShowEPAlways classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPAlways>
-										<ShowEPForFileWin classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</ShowEPForFileWin>
-										<ShowEPForExeWin classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPForExeWin>
-										<ShowEPForEditorOnly classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPForEditorOnly>
-										<AllowIntExeOfEP classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</AllowIntExeOfEP>
-										<CopyStepsOnOverriding classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</CopyStepsOnOverriding>
-										<Priority classname='Num' valueflags='4194304'>
-											<value>2953567917</value>
-										</Priority>
-									</subprops>
-								</RTS>
-								<Requirements classname='Obj' valueflags='4456456'>
-									<subprops>
-										<Links classname='Strs' valueflags='71303168'>
-											<value lbound='[0]' ubound='[]'/>
-										</Links>
-									</subprops>
-								</Requirements>
-								<FailureAction classname='Num' valueflags='4194312'>
-									<value>2</value>
-								</FailureAction>
-							</subprops>
-						</Sequence>
-					</value>
-					<value>
-						<Sequence name='ProcessSetup'>
-							<comment>Test UUTs and Single Pass call this callback in their setup step group. It is empty in the model file.  Override this in the client file to perform an action before any code in the model executes.</comment>
-							<subprops>
-								<Parameters classname='Obj' valueflags='4456448'/>
-								<Locals classname='Obj' valueflags='4194304'>
-									<subprops>
-										<ResultList classname='Objs'>
-											<value lbound='[0]' ubound='[]'>
-												<elemproto>
-													<_NAME_IN_ATTRIBUTE_ name='' classname='TEResult'/>
-												</elemproto>
-											</value>
-										</ResultList>
-									</subprops>
-								</Locals>
-								<Main classname='Objs' valueflags='4194304'>
 									<value lbound='[0]' ubound='[3]'>
 										<value>
 											<Step typename='Statement' xsi:type='Statement' name='Get absolute path to pinmap file'>
@@ -5176,7 +5089,7 @@
 																				<value>update_pin_map</value>
 																			</FunctionOrAttributeName>
 																			<Parameters classname='Objs'>
-																				<value lbound='[0]' ubound='[1]'>
+																				<value lbound='[0]' ubound='[2]'>
 																					<elemproto>
 																						<_NAME_IN_ATTRIBUTE_ name='' classname='CPythonParameter' structureflags='0'/>
 																					</elemproto>
@@ -5232,7 +5145,7 @@
 																						<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
 																							<subprops>
 																								<Name classname='Str'>
-																									<value>pin_map_id</value>
+																									<value>pin_map_path</value>
 																								</Name>
 																								<Type classname='Num'>
 																									<value>7</value>
@@ -5254,7 +5167,55 @@
 																													<value>8192</value>
 																												</Flags>
 																												<CheckedState classname='Num'>
+																													<value>2</value>
+																												</CheckedState>
+																											</subprops>
+																										</Input>
+																										<Output classname='PythonParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
 																													<value>1</value>
+																												</CheckedState>
+																											</subprops>
+																										</Output>
+																									</subprops>
+																								</AdditionalResults>
+																							</subprops>
+																						</CPythonParameter>
+																					</value>
+																					<value>
+																						<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
+																							<subprops>
+																								<Name classname='Str'>
+																									<value>sequence_context</value>
+																								</Name>
+																								<Type classname='Num'>
+																									<value>7</value>
+																								</Type>
+																								<ArgumentValue classname='ExprValue'>
+																									<value>ThisContext</value>
+																								</ArgumentValue>
+																								<ArgumentDisplayValue classname='ExprValue'>
+																									<value/>
+																								</ArgumentDisplayValue>
+																								<AdditionalResults classname='Obj'>
+																									<subprops>
+																										<Input classname='PythonParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
+																													<value>2</value>
 																												</CheckedState>
 																											</subprops>
 																										</Input>
@@ -5677,13 +5638,13 @@
 																						<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
 																							<subprops>
 																								<Name classname='Str'>
-																									<value>pin_map_id</value>
+																									<value>sequence_context</value>
 																								</Name>
 																								<Type classname='Num'>
 																									<value>7</value>
 																								</Type>
 																								<ArgumentValue classname='ExprValue'>
-																									<value>FileGlobals.MeasurementLink.PinMapPath</value>
+																									<value>ThisContext</value>
 																								</ArgumentValue>
 																								<ArgumentDisplayValue classname='ExprValue'>
 																									<value/>
@@ -5699,7 +5660,7 @@
 																													<value>8192</value>
 																												</Flags>
 																												<CheckedState classname='Num'>
-																													<value>1</value>
+																													<value>2</value>
 																												</CheckedState>
 																											</subprops>
 																										</Input>
@@ -6310,95 +6271,8 @@
 											</Step>
 										</value>
 									</value>
-								</Main>
-								<Setup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
 								</Setup>
 								<Cleanup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
-								</Cleanup>
-								<RecordResults classname='Bool' valueflags='4194312'>
-									<value>false</value>
-								</RecordResults>
-								<RTS classname='Obj' valueflags='4456456'>
-									<subprops>
-										<Type classname='Num' valueflags='4194304'>
-											<value>0</value>
-										</Type>
-										<OptimizeNonReentrantCalls classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</OptimizeNonReentrantCalls>
-										<EPNameExpr classname='Str' valueflags='4194304'>
-											<value>"Unnamed Entry Point"</value>
-										</EPNameExpr>
-										<EPEnabledExpr classname='Str' valueflags='4194304'>
-											<value>True</value>
-										</EPEnabledExpr>
-										<EPMenuHint classname='Str' valueflags='4194304'>
-											<value/>
-										</EPMenuHint>
-										<EPIgnoreClient classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</EPIgnoreClient>
-										<EPInitiallyHidden classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</EPInitiallyHidden>
-										<EPCheckToSaveTitledFile classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</EPCheckToSaveTitledFile>
-										<ShowEPAlways classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPAlways>
-										<ShowEPForFileWin classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</ShowEPForFileWin>
-										<ShowEPForExeWin classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPForExeWin>
-										<ShowEPForEditorOnly classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPForEditorOnly>
-										<CopyStepsOnOverriding classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</CopyStepsOnOverriding>
-										<Priority classname='Num' valueflags='4194304'>
-											<value>2953567917</value>
-										</Priority>
-										<AllowIntExeOfEP classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</AllowIntExeOfEP>
-									</subprops>
-								</RTS>
-								<Requirements classname='Obj' valueflags='4456456'>
-									<subprops>
-										<Links classname='Strs' valueflags='71303168'>
-											<value lbound='[0]' ubound='[]'/>
-										</Links>
-									</subprops>
-								</Requirements>
-								<FailureAction classname='Num' valueflags='4194312'>
-									<value>2</value>
-								</FailureAction>
-							</subprops>
-						</Sequence>
-					</value>
-					<value>
-						<Sequence name='ProcessCleanup'>
-							<comment>Test UUTs and Single Pass call this callback in their cleanup step group. It is empty in the model file.  Override this in the client file to perform an action after all code in the model executes and just before the execution completes.</comment>
-							<subprops>
-								<Parameters classname='Obj' valueflags='4456448'/>
-								<Locals classname='Obj' valueflags='4194304'>
-									<subprops>
-										<ResultList classname='Objs'>
-											<value lbound='[0]' ubound='[]'>
-												<elemproto>
-													<_NAME_IN_ATTRIBUTE_ name='' classname='TEResult'/>
-												</elemproto>
-											</value>
-										</ResultList>
-									</subprops>
-								</Locals>
-								<Main classname='Objs' valueflags='4194304'>
 									<value lbound='[0]' ubound='[1]'>
 										<value>
 											<Step typename='Statement' xsi:type='Statement' name='Unregister active PinMapId'>
@@ -7093,15 +6967,9 @@
 											</Step>
 										</value>
 									</value>
-								</Main>
-								<Setup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
-								</Setup>
-								<Cleanup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
 								</Cleanup>
 								<RecordResults classname='Bool' valueflags='4194312'>
-									<value>false</value>
+									<value>true</value>
 								</RecordResults>
 								<RTS classname='Obj' valueflags='4456456'>
 									<subprops>
@@ -7141,15 +7009,15 @@
 										<ShowEPForEditorOnly classname='Bool' valueflags='4194304'>
 											<value>false</value>
 										</ShowEPForEditorOnly>
+										<AllowIntExeOfEP classname='Bool' valueflags='4194304'>
+											<value>false</value>
+										</AllowIntExeOfEP>
 										<CopyStepsOnOverriding classname='Bool' valueflags='4194304'>
 											<value>true</value>
 										</CopyStepsOnOverriding>
 										<Priority classname='Num' valueflags='4194304'>
 											<value>2953567917</value>
 										</Priority>
-										<AllowIntExeOfEP classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</AllowIntExeOfEP>
 									</subprops>
 								</RTS>
 								<Requirements classname='Obj' valueflags='4456456'>

--- a/examples/nifgen_standard_function/README.md
+++ b/examples/nifgen_standard_function/README.md
@@ -14,7 +14,10 @@ using an NI waveform generator.
 - Includes InstrumentStudio and MeasurementLink UI Editor project files
 - Includes a TestStand sequence showing how to configure the pin map, register
   instrument sessions with the session management service, and run a measurement
-  - For the sake of simplicity, the TestStand sequence handles pin map and session registration and unregistration in the `Setup` and `Cleanup` sections of the main sequence. For **Test UUTs** and batch process model use cases, these steps should be moved to the `ProcessSetup` and `ProcessCleanup` callbacks.
+  - For the sake of simplicity, the TestStand sequence handles pin map and session 
+    registration and unregistration in the `Setup` and `Cleanup` sections of the main 
+    sequence. For **Test UUTs** and batch process model use cases, these steps should 
+    be moved to the `ProcessSetup` and `ProcessCleanup` callbacks.
 - Uses the NI gRPC Device Server to allow sharing instrument sessions with other
   measurement services when running measurements from TestStand
 

--- a/examples/nifgen_standard_function/README.md
+++ b/examples/nifgen_standard_function/README.md
@@ -14,6 +14,7 @@ using an NI waveform generator.
 - Includes InstrumentStudio and MeasurementLink UI Editor project files
 - Includes a TestStand sequence showing how to configure the pin map, register
   instrument sessions with the session management service, and run a measurement
+  - For the sake of simplicity, the TestStand sequence handles pin map and session registration and unregistration in the `Setup` and `Cleanup` sections of the main sequence. For **Test UUTs** and batch process model use cases, these steps should be moved to the `ProcessSetup` and `ProcessCleanup` callbacks.
 - Uses the NI gRPC Device Server to allow sharing instrument sessions with other
   measurement services when running measurements from TestStand
 

--- a/examples/nifgen_standard_function/teststand_fixture.py
+++ b/examples/nifgen_standard_function/teststand_fixture.py
@@ -1,33 +1,49 @@
 """Functions to set up and tear down sessions of NI-FGEN devices in NI TestStand."""
+from typing import Any
 
 import nifgen
-from _helpers import GrpcChannelPoolHelper, PinMapClient
+from _helpers import GrpcChannelPoolHelper, PinMapClient, TestStandSupport
 
 import ni_measurementlink_service as nims
 
 
-def update_pin_map(pin_map_id: str) -> None:
+def update_pin_map(pin_map_path: str, sequence_context: Any) -> None:
     """Update registered pin map contents.
 
     Create and register a pin map if a pin map resource for the specified pin map id is not found.
 
     Args:
-        pin_map_id (str): The resource id of the pin map to register as a pin map resource. By
-            convention, the pin_map_id is the .pinmap file path.
-
+        pin_map_path:
+            An absolute or relative path to the pin map file.
+        sequence_context:
+            The SequenceContext COM object from the TestStand sequence execution.
+            (Dynamically typed.)
     """
+    teststand_support = TestStandSupport(sequence_context)
+    pin_map_abs_path = teststand_support.resolve_file_path(pin_map_path)
+
     with GrpcChannelPoolHelper() as grpc_channel_pool:
         pin_map_client = PinMapClient(grpc_channel=grpc_channel_pool.pin_map_channel)
-        pin_map_client.update_pin_map(pin_map_id)
+        pin_map_id = pin_map_client.update_pin_map(pin_map_abs_path)
+
+    teststand_support.set_active_pin_map_id(pin_map_id)
 
 
-def create_nifgen_sessions(pin_map_id: str) -> None:
-    """Create and register all NI-FGEN sessions."""
+def create_nifgen_sessions(sequence_context: Any) -> None:
+    """Create and register all NI-FGEN sessions.
+
+    Args:
+        sequence_context:
+            The SequenceContext COM object from the TestStand sequence execution.
+            (Dynamically typed.)
+    """
     with GrpcChannelPoolHelper() as grpc_channel_pool:
         session_management_client = nims.session_management.Client(
             grpc_channel=grpc_channel_pool.session_management_channel
         )
 
+        teststand_support = TestStandSupport(sequence_context)
+        pin_map_id = teststand_support.get_active_pin_map_id()
         pin_map_context = nims.session_management.PinMapContext(pin_map_id=pin_map_id, sites=None)
         with session_management_client.reserve_sessions(
             context=pin_map_context,

--- a/examples/niscope_acquire_waveform/NIScopeAcquireWaveform.seq
+++ b/examples/niscope_acquire_waveform/NIScopeAcquireWaveform.seq
@@ -4588,16 +4588,16 @@
 																					<value>pin_names</value>
 																				</Name>
 																				<ArgumentValue classname='ExprValue'>
-																					<value>"Pin1,Pin2,Pin3,Pin4"</value>
+																					<value>{"Pin1","Pin2","Pin3","Pin4"}</value>
 																				</ArgumentValue>
 																				<Direction classname='Str'>
 																					<value>In</value>
 																				</Direction>
 																				<Log classname='Bool'>
-																					<value>false</value>
+																					<value>true</value>
 																				</Log>
 																				<Dimension classname='Num'>
-																					<value representation='UInt64'>0</value>
+																					<value representation='UInt64'>1</value>
 																				</Dimension>
 																				<Type classname='Str'>
 																					<value>TypeString</value>
@@ -5071,93 +5071,6 @@
 									</value>
 								</Main>
 								<Setup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
-								</Setup>
-								<Cleanup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
-								</Cleanup>
-								<RecordResults classname='Bool' valueflags='4194312'>
-									<value>true</value>
-								</RecordResults>
-								<RTS classname='Obj' valueflags='4456456'>
-									<subprops>
-										<Type classname='Num' valueflags='4194304'>
-											<value>0</value>
-										</Type>
-										<OptimizeNonReentrantCalls classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</OptimizeNonReentrantCalls>
-										<EPNameExpr classname='Str' valueflags='4194304'>
-											<value>"Unnamed Entry Point"</value>
-										</EPNameExpr>
-										<EPEnabledExpr classname='Str' valueflags='4194304'>
-											<value>True</value>
-										</EPEnabledExpr>
-										<EPMenuHint classname='Str' valueflags='4194304'>
-											<value/>
-										</EPMenuHint>
-										<EPIgnoreClient classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</EPIgnoreClient>
-										<EPInitiallyHidden classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</EPInitiallyHidden>
-										<EPCheckToSaveTitledFile classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</EPCheckToSaveTitledFile>
-										<ShowEPAlways classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPAlways>
-										<ShowEPForFileWin classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</ShowEPForFileWin>
-										<ShowEPForExeWin classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPForExeWin>
-										<ShowEPForEditorOnly classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPForEditorOnly>
-										<AllowIntExeOfEP classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</AllowIntExeOfEP>
-										<CopyStepsOnOverriding classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</CopyStepsOnOverriding>
-										<Priority classname='Num' valueflags='4194304'>
-											<value>2953567917</value>
-										</Priority>
-									</subprops>
-								</RTS>
-								<Requirements classname='Obj' valueflags='4456456'>
-									<subprops>
-										<Links classname='Strs' valueflags='71303168'>
-											<value lbound='[0]' ubound='[]'/>
-										</Links>
-									</subprops>
-								</Requirements>
-								<FailureAction classname='Num' valueflags='4194312'>
-									<value>2</value>
-								</FailureAction>
-							</subprops>
-						</Sequence>
-					</value>
-					<value>
-						<Sequence name='ProcessSetup'>
-							<comment>Test UUTs and Single Pass call this callback in their setup step group. It is empty in the model file.  Override this in the client file to perform an action before any code in the model executes.</comment>
-							<subprops>
-								<Parameters classname='Obj' valueflags='4456448'/>
-								<Locals classname='Obj' valueflags='4194304'>
-									<subprops>
-										<ResultList classname='Objs'>
-											<value lbound='[0]' ubound='[]'>
-												<elemproto>
-													<_NAME_IN_ATTRIBUTE_ name='' classname='TEResult'/>
-												</elemproto>
-											</value>
-										</ResultList>
-									</subprops>
-								</Locals>
-								<Main classname='Objs' valueflags='4194304'>
 									<value lbound='[0]' ubound='[3]'>
 										<value>
 											<Step typename='Statement' xsi:type='Statement' name='Get absolute path to pinmap file'>
@@ -5506,7 +5419,7 @@
 																				<value>update_pin_map</value>
 																			</FunctionOrAttributeName>
 																			<Parameters classname='Objs'>
-																				<value lbound='[0]' ubound='[1]'>
+																				<value lbound='[0]' ubound='[2]'>
 																					<elemproto>
 																						<_NAME_IN_ATTRIBUTE_ name='' classname='CPythonParameter' structureflags='0'/>
 																					</elemproto>
@@ -5562,7 +5475,7 @@
 																						<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
 																							<subprops>
 																								<Name classname='Str'>
-																									<value>pin_map_id</value>
+																									<value>pin_map_path</value>
 																								</Name>
 																								<Type classname='Num'>
 																									<value>7</value>
@@ -5584,7 +5497,55 @@
 																													<value>8192</value>
 																												</Flags>
 																												<CheckedState classname='Num'>
+																													<value>2</value>
+																												</CheckedState>
+																											</subprops>
+																										</Input>
+																										<Output classname='PythonParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
 																													<value>1</value>
+																												</CheckedState>
+																											</subprops>
+																										</Output>
+																									</subprops>
+																								</AdditionalResults>
+																							</subprops>
+																						</CPythonParameter>
+																					</value>
+																					<value>
+																						<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
+																							<subprops>
+																								<Name classname='Str'>
+																									<value>sequence_context</value>
+																								</Name>
+																								<Type classname='Num'>
+																									<value>7</value>
+																								</Type>
+																								<ArgumentValue classname='ExprValue'>
+																									<value>ThisContext</value>
+																								</ArgumentValue>
+																								<ArgumentDisplayValue classname='ExprValue'>
+																									<value/>
+																								</ArgumentDisplayValue>
+																								<AdditionalResults classname='Obj'>
+																									<subprops>
+																										<Input classname='PythonParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
+																													<value>2</value>
 																												</CheckedState>
 																											</subprops>
 																										</Input>
@@ -6007,13 +5968,13 @@
 																						<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
 																							<subprops>
 																								<Name classname='Str'>
-																									<value>pin_map_id</value>
+																									<value>sequence_context</value>
 																								</Name>
 																								<Type classname='Num'>
 																									<value>7</value>
 																								</Type>
 																								<ArgumentValue classname='ExprValue'>
-																									<value>FileGlobals.MeasurementLink.PinMapPath</value>
+																									<value>ThisContext</value>
 																								</ArgumentValue>
 																								<ArgumentDisplayValue classname='ExprValue'>
 																									<value/>
@@ -6029,7 +5990,7 @@
 																													<value>8192</value>
 																												</Flags>
 																												<CheckedState classname='Num'>
-																													<value>1</value>
+																													<value>2</value>
 																												</CheckedState>
 																											</subprops>
 																										</Input>
@@ -6640,95 +6601,8 @@
 											</Step>
 										</value>
 									</value>
-								</Main>
-								<Setup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
 								</Setup>
 								<Cleanup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
-								</Cleanup>
-								<RecordResults classname='Bool' valueflags='4194312'>
-									<value>false</value>
-								</RecordResults>
-								<RTS classname='Obj' valueflags='4456456'>
-									<subprops>
-										<Type classname='Num' valueflags='4194304'>
-											<value>0</value>
-										</Type>
-										<OptimizeNonReentrantCalls classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</OptimizeNonReentrantCalls>
-										<EPNameExpr classname='Str' valueflags='4194304'>
-											<value>"Unnamed Entry Point"</value>
-										</EPNameExpr>
-										<EPEnabledExpr classname='Str' valueflags='4194304'>
-											<value>True</value>
-										</EPEnabledExpr>
-										<EPMenuHint classname='Str' valueflags='4194304'>
-											<value/>
-										</EPMenuHint>
-										<EPIgnoreClient classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</EPIgnoreClient>
-										<EPInitiallyHidden classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</EPInitiallyHidden>
-										<EPCheckToSaveTitledFile classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</EPCheckToSaveTitledFile>
-										<ShowEPAlways classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPAlways>
-										<ShowEPForFileWin classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</ShowEPForFileWin>
-										<ShowEPForExeWin classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPForExeWin>
-										<ShowEPForEditorOnly classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPForEditorOnly>
-										<CopyStepsOnOverriding classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</CopyStepsOnOverriding>
-										<Priority classname='Num' valueflags='4194304'>
-											<value>2953567917</value>
-										</Priority>
-										<AllowIntExeOfEP classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</AllowIntExeOfEP>
-									</subprops>
-								</RTS>
-								<Requirements classname='Obj' valueflags='4456456'>
-									<subprops>
-										<Links classname='Strs' valueflags='71303168'>
-											<value lbound='[0]' ubound='[]'/>
-										</Links>
-									</subprops>
-								</Requirements>
-								<FailureAction classname='Num' valueflags='4194312'>
-									<value>2</value>
-								</FailureAction>
-							</subprops>
-						</Sequence>
-					</value>
-					<value>
-						<Sequence name='ProcessCleanup'>
-							<comment>Test UUTs and Single Pass call this callback in their cleanup step group. It is empty in the model file.  Override this in the client file to perform an action after all code in the model executes and just before the execution completes.</comment>
-							<subprops>
-								<Parameters classname='Obj' valueflags='4456448'/>
-								<Locals classname='Obj' valueflags='4194304'>
-									<subprops>
-										<ResultList classname='Objs'>
-											<value lbound='[0]' ubound='[]'>
-												<elemproto>
-													<_NAME_IN_ATTRIBUTE_ name='' classname='TEResult'/>
-												</elemproto>
-											</value>
-										</ResultList>
-									</subprops>
-								</Locals>
-								<Main classname='Objs' valueflags='4194304'>
 									<value lbound='[0]' ubound='[1]'>
 										<value>
 											<Step typename='Statement' xsi:type='Statement' name='Unregister active PinMapId'>
@@ -7423,6 +7297,180 @@
 											</Step>
 										</value>
 									</value>
+								</Cleanup>
+								<RecordResults classname='Bool' valueflags='4194312'>
+									<value>true</value>
+								</RecordResults>
+								<RTS classname='Obj' valueflags='4456456'>
+									<subprops>
+										<Type classname='Num' valueflags='4194304'>
+											<value>0</value>
+										</Type>
+										<OptimizeNonReentrantCalls classname='Bool' valueflags='4194304'>
+											<value>true</value>
+										</OptimizeNonReentrantCalls>
+										<EPNameExpr classname='Str' valueflags='4194304'>
+											<value>"Unnamed Entry Point"</value>
+										</EPNameExpr>
+										<EPEnabledExpr classname='Str' valueflags='4194304'>
+											<value>True</value>
+										</EPEnabledExpr>
+										<EPMenuHint classname='Str' valueflags='4194304'>
+											<value/>
+										</EPMenuHint>
+										<EPIgnoreClient classname='Bool' valueflags='4194304'>
+											<value>false</value>
+										</EPIgnoreClient>
+										<EPInitiallyHidden classname='Bool' valueflags='4194304'>
+											<value>false</value>
+										</EPInitiallyHidden>
+										<EPCheckToSaveTitledFile classname='Bool' valueflags='4194304'>
+											<value>true</value>
+										</EPCheckToSaveTitledFile>
+										<ShowEPAlways classname='Bool' valueflags='4194304'>
+											<value>false</value>
+										</ShowEPAlways>
+										<ShowEPForFileWin classname='Bool' valueflags='4194304'>
+											<value>true</value>
+										</ShowEPForFileWin>
+										<ShowEPForExeWin classname='Bool' valueflags='4194304'>
+											<value>false</value>
+										</ShowEPForExeWin>
+										<ShowEPForEditorOnly classname='Bool' valueflags='4194304'>
+											<value>false</value>
+										</ShowEPForEditorOnly>
+										<AllowIntExeOfEP classname='Bool' valueflags='4194304'>
+											<value>false</value>
+										</AllowIntExeOfEP>
+										<CopyStepsOnOverriding classname='Bool' valueflags='4194304'>
+											<value>true</value>
+										</CopyStepsOnOverriding>
+										<Priority classname='Num' valueflags='4194304'>
+											<value>2953567917</value>
+										</Priority>
+									</subprops>
+								</RTS>
+								<Requirements classname='Obj' valueflags='4456456'>
+									<subprops>
+										<Links classname='Strs' valueflags='71303168'>
+											<value lbound='[0]' ubound='[]'/>
+										</Links>
+									</subprops>
+								</Requirements>
+								<FailureAction classname='Num' valueflags='4194312'>
+									<value>2</value>
+								</FailureAction>
+							</subprops>
+						</Sequence>
+					</value>
+					<value>
+						<Sequence name='ProcessSetup'>
+							<comment>Test UUTs and Single Pass call this callback in their setup step group. It is empty in the model file.  Override this in the client file to perform an action before any code in the model executes.</comment>
+							<subprops>
+								<Parameters classname='Obj' valueflags='4456448'/>
+								<Locals classname='Obj' valueflags='4194304'>
+									<subprops>
+										<ResultList classname='Objs'>
+											<value lbound='[0]' ubound='[]'>
+												<elemproto>
+													<_NAME_IN_ATTRIBUTE_ name='' classname='TEResult'/>
+												</elemproto>
+											</value>
+										</ResultList>
+									</subprops>
+								</Locals>
+								<Main classname='Objs' valueflags='4194304'>
+									<value lbound='[0]' ubound='[]'/>
+								</Main>
+								<Setup classname='Objs' valueflags='4194304'>
+									<value lbound='[0]' ubound='[]'/>
+								</Setup>
+								<Cleanup classname='Objs' valueflags='4194304'>
+									<value lbound='[0]' ubound='[]'/>
+								</Cleanup>
+								<RecordResults classname='Bool' valueflags='4194312'>
+									<value>false</value>
+								</RecordResults>
+								<RTS classname='Obj' valueflags='4456456'>
+									<subprops>
+										<Type classname='Num' valueflags='4194304'>
+											<value>0</value>
+										</Type>
+										<OptimizeNonReentrantCalls classname='Bool' valueflags='4194304'>
+											<value>true</value>
+										</OptimizeNonReentrantCalls>
+										<EPNameExpr classname='Str' valueflags='4194304'>
+											<value>"Unnamed Entry Point"</value>
+										</EPNameExpr>
+										<EPEnabledExpr classname='Str' valueflags='4194304'>
+											<value>True</value>
+										</EPEnabledExpr>
+										<EPMenuHint classname='Str' valueflags='4194304'>
+											<value/>
+										</EPMenuHint>
+										<EPIgnoreClient classname='Bool' valueflags='4194304'>
+											<value>false</value>
+										</EPIgnoreClient>
+										<EPInitiallyHidden classname='Bool' valueflags='4194304'>
+											<value>false</value>
+										</EPInitiallyHidden>
+										<EPCheckToSaveTitledFile classname='Bool' valueflags='4194304'>
+											<value>true</value>
+										</EPCheckToSaveTitledFile>
+										<ShowEPAlways classname='Bool' valueflags='4194304'>
+											<value>false</value>
+										</ShowEPAlways>
+										<ShowEPForFileWin classname='Bool' valueflags='4194304'>
+											<value>true</value>
+										</ShowEPForFileWin>
+										<ShowEPForExeWin classname='Bool' valueflags='4194304'>
+											<value>false</value>
+										</ShowEPForExeWin>
+										<ShowEPForEditorOnly classname='Bool' valueflags='4194304'>
+											<value>false</value>
+										</ShowEPForEditorOnly>
+										<CopyStepsOnOverriding classname='Bool' valueflags='4194304'>
+											<value>true</value>
+										</CopyStepsOnOverriding>
+										<Priority classname='Num' valueflags='4194304'>
+											<value>2953567917</value>
+										</Priority>
+										<AllowIntExeOfEP classname='Bool' valueflags='4194304'>
+											<value>false</value>
+										</AllowIntExeOfEP>
+									</subprops>
+								</RTS>
+								<Requirements classname='Obj' valueflags='4456456'>
+									<subprops>
+										<Links classname='Strs' valueflags='71303168'>
+											<value lbound='[0]' ubound='[]'/>
+										</Links>
+									</subprops>
+								</Requirements>
+								<FailureAction classname='Num' valueflags='4194312'>
+									<value>2</value>
+								</FailureAction>
+							</subprops>
+						</Sequence>
+					</value>
+					<value>
+						<Sequence name='ProcessCleanup'>
+							<comment>Test UUTs and Single Pass call this callback in their cleanup step group. It is empty in the model file.  Override this in the client file to perform an action after all code in the model executes and just before the execution completes.</comment>
+							<subprops>
+								<Parameters classname='Obj' valueflags='4456448'/>
+								<Locals classname='Obj' valueflags='4194304'>
+									<subprops>
+										<ResultList classname='Objs'>
+											<value lbound='[0]' ubound='[]'>
+												<elemproto>
+													<_NAME_IN_ATTRIBUTE_ name='' classname='TEResult'/>
+												</elemproto>
+											</value>
+										</ResultList>
+									</subprops>
+								</Locals>
+								<Main classname='Objs' valueflags='4194304'>
+									<value lbound='[0]' ubound='[]'/>
 								</Main>
 								<Setup classname='Objs' valueflags='4194304'>
 									<value lbound='[0]' ubound='[]'/>

--- a/examples/niscope_acquire_waveform/NIScopeAcquireWaveform.seq
+++ b/examples/niscope_acquire_waveform/NIScopeAcquireWaveform.seq
@@ -1670,6 +1670,647 @@
 		</typedef>
 		<protected>E@=3DJC4100hYLECF=_K@0@mKCYo_1KN:&lt;Ta239hF9[gHbEVFDfRINZfQ01CkaUMk5=k`[c;[42MMF9aiNliecVfMFCLXi_`f2H7c\G\X50M=Z4S4aT2QI&gt;A^D:d1\PCI`L11RlV5bM5AIZTc9STI5Mkg&lt;bHlle[O=CL_KEgb?8RiVHS7QmPY@S4X^7I58A@kPaKcPWCOC1;DBf61lViY=]`28BC\B_mEf20ZJS@W@GDDRffLe\Ci;aKbN&gt;i5P_4ScVVBTjIIfn0j8l&lt;e6IcMbZHgCI;n8CRlR7&lt;YcK0@cY[8aDHj=GGkNK;C?KC?b=]mMejoc1gGol1&gt;hL6lf5fZ92?Ia@l1;QL024f^NSm2MhNlcFg_YR[l5kclo:einXehbR&gt;98[4?GC:CX[3hm\UMob2aIMT0eJmgI@\;njRK9]fIl_8f=d]n4bQcRXDEl&lt;o=@Yiik\3Md@?k1=0Joj&gt;?Je`&lt;RUd&lt;JYmeOnOgB3G@Ub\FoGFgIQmQli8nGH=QjKD9i`2nf41XEKj;oDB8iZU`@XP^KWoAKEbOf:ViVAl=_I37KJSec7Ea\nJ5]NZj\OnJF;ASQemRIDbbdglb\U&gt;H[O^bDHO?XMLaOoeVCf=a^CC`d8^TX2B</protected>
 		<protected>E@=3@J\4110h]L]Mg[cK3fBoj\Kifo1C[KY_3VgFm3_6n&gt;DfdTDgjaSF_LdVUJaY::FII@T:GB9LaYOo80OP^053LBBVb1G?:50k4;P1c\^`03ffoj9S72=AOm;a2oh?Na\lC7TUOXcNfaSdfIbVCC_ao20aN9bmo_&lt;R_S=&gt;KV;lhbmh89SY[:2UflXcmGIlnngoE]\\ad_6_gW8X9GAXJSPJYin&gt;C71=c74a79JN&lt;`GPK]_\&gt;2`h9IOC]VA5BU4AMW1Qc`j?lJ\aR4__&gt;R4SI_`[_mmnM33ONg`3P[g4N5aSF;ce]^eVffg6&gt;cIRLhI]7CjE^W[jW`kZkGEWHk1=RR;gTe:O[H;k[bAd7UCaTVXgjlho3Af&gt;?oIJdjMo&gt;3=o;aTo\ZZnG9_cgcO7mjV^k&gt;\:gkoOkSn1jkfm@MgLnb&lt;Amg;\Nmj8klk3llhhnW&gt;nn^GCW_fW_&gt;ji]:Va&gt;TNnNQdK5LolNX?M@\6jN2ddlIHh=MT1E^[o4Q7I54R=RlVg[S\KmOe9GM:Qeh9OnUhWTeC^ZM7SAGP1V=LZ4[i\cOmoH[RS6YBL2L\PAg][JQ&lt;Eo?8;D9Mk3M]&gt;N^6&gt;HgJ]KP^a&gt;cfBkkmZ33RdU`]jB_NIOShWL4oDlbn3lNOCL??R7GCmKaTDhekoi_En`9oJKe&lt;e1`lBjmjXJ&lt;^4_^_^&gt;?7O?nEE_WTY:VYEc]3^eJm^cdC7;LcK_]Ei&gt;b&lt;^`9HR6YcO&gt;l@Amg&gt;PLXQbSb^=?FXRUZd&lt;[n&lt;SGjgCQ`mhTl;7NUbgaRQBkXNY4iX5iAJX6C`gdG[d3d&gt;`Uj3DPMF7h71WBBLLR&gt;Tk9dZlFCYSi__fNBBT`C;A&gt;jeP2CdONN52i5^eBEIEI=8EMHBBe^G^1ohD6&gt;LRiJgM\IPYE8Wn`T9W@jf8iEfN:@L3&lt;Ha_l0CCE&lt;HOJjXBRll_NLReo_^K7CQWihL&lt;B1::YXdSaG&lt;XFnCP94dQXb;^6V07F&gt;TkPem&gt;4QI;?9JkF`g80:`G?AULFSY^XW;4XL^_D=GZV9VVODS^[=]dL]b=N;O[ib6]2aLATM7\AcX=JH&lt;\1j8_?I9_VUO]5;PKjdi^o&gt;Kn=FbmhAmF3EXh?dAPF?cWPU;NHFT9YBblF15fj0n]RK9&gt;d;@lD9HXLGTZOAa;gEd6:MElAPOkOoMom`hnaYko^ne_;PeC\`kMYOoCalP3DR_^NADNSV6R1Nk4f?=Lo;VQ&gt;7&gt;fR@=2j8C:;D@3fk&gt;^=YHE^PQ1fU&gt;TFoNH&gt;GnfRGNMNW`[okK`S56RJfM4Zmo^6E9ZYc&gt;FNEO3PO=T9eK0:bgljYdR7WooKS9eTjd@bcImNVZ8UXa:AC_F_WCj]4\6ST&lt;:ie_AbZFIL7UmlIne:BcTQ5T2U]O2goYWXRN5F8oeQT^`HXPD=2LV[h;ibbNNj1kU]lXlnX4ACO5aRA@TfHY77@P?L=_N@4^cJG;Wi2@3M5OQ:^@&gt;2K9_9W:4Vn1LGaRN@WL9AFFVg1oYHdi`54XIa5G[\i&gt;iPT4506XA7h2^c_T`3d[ARdFICaAS2RM:1KgT7B&gt;MhXVaI&lt;kA^@CX2aS^I:B&gt;=W&lt;U?l&lt;DWU&lt;Jd7^cKe2R]EdIBcBQZni_K1JPCEhV&gt;VH]FBZ&lt;5413k[U]MAFA`Ohma2g2NoU0@E;FI93Yi;RjnlScC;`glEaH^X@K[NY9Y1EUZc6V6\3?FKC0APU0^[aP:_GMI=eeWnJ&lt;6e2]@;AXaAE&lt;S[lhAb`XFjPP@dTXNYS=&lt;568je\`W3?@gn9HDaM84^&gt;SDl0&lt;Ba6YNKCeYZ\CUU?WGnR4=m^aN[KTlFG\?VZ[MC:3HfflAagl\jZUG@ScZW:2K\FU9TQa&lt;h;?iYb&lt;RJI66IEg&lt;WHgdkU:\KFIZG\BDU=9W&gt;:\:W7nM3NIjXT;2YV[@dDaY3bhOQY^af&lt;UVo:ZV^^@0d_M5ObRQ2PIHZ9bbbGm;4Z\KEfEYI=M];D@9j1kZ@2@FIkf9:\CYe5KnKANXH7R@eMc2M;Pl]PZG]@4h2Q7OY:=QFh@\Y6]E6X1bL6mjS76a`JS=H=XQReG6Djb7[c&lt;h@S5UCX4`ABLQ4:ZZ7=JF9JejC5\[T:meE5_[:`Qm=DfI0EDQLRH6o]LAPRXlbTgXSbnW7ZTN?N]lH02JKm;Z4hn&lt;A[89:C8lM5hC]Ab^\\WNK7JGS]XainLm:PWFF3EmC15\]YC\D;I6a&lt;NiIhd2GMIG`A9\[]T00fP:UXIXSHk2jI&gt;XFG&gt;I521bbKDA`Xb]h&gt;oAl&gt;IolbRB7j=i9_H89&lt;FR=U572U\LjNhnkeeemHDJJ\GHX\;J51M&lt;?QV2DneREAR3in6&lt;M75M_Re=Ci3gEOQ2VO`4P8_hfhSO\dZ7m]n\hlV6gSlSC@PoZSe8WUaY3d0_;Z=9H:I6Gf2PVG`mf8CC87@DBlT62^h6QFFhZF64BJ46@Dh&lt;T1=C]0_9J?073S@61ADIUT31&lt;mVE&lt;W?R@RBUJP`@;50X2Bh618KM^bf033T033D?NM@P`?0\dBA3A8AXF0]@KnP[5&lt;EDfUICcBF^EZT=:cWKBKYTDKXD=&lt;A:mkNB7LFDHC9b7nG57NFZ1]Ubo]8]0MN]YWJJ&gt;eS42I?===3_n_?J=384=Go8e^0mdmBiTjRaf;F@8M4_gCZSGQ3cUUnF6J_R9WJV0PNaTJDk&lt;RiWS6=&gt;Rf9EmM:WgL4LHg5oH[aMbbOlnI6b`9KZ^Z]oAdeH\@YgaV8ChHTKjEVA]a^YN&lt;;71CAbR\&lt;jAYI\\Y&lt;R\`1AOol`j1&gt;53?d8MV_@kAN_W4nIdKc0gRYHEo`]U?HWN?0&lt;?l2h:ZC\&gt;^D]Ug4FNZl123fNoZ7fLRB[_HR6O&gt;BaoomWl_8YS0Q\8;RB]@j=GIIe]J&lt;AT[;1I&lt;5ZJ\?Va5g?&gt;7hXgcbU4V=lT&gt;nV[28JKeQJ5QX4^WD3MfTBIBPKU57e&gt;[FRd&gt;_EeSHJhDa4hM9S9TUlOR=KWn]eAJ]W5VROh9ak`n5&lt;LV6L9d&lt;0`?fk]J8FW52OlL2i&lt;L1kO=mGBf9e:\`^[_J:F&gt;7o0_9mGc_`=KP@SW_^NU525JcQcEGhR8Da3gf4mJ?R6a2lLPKjL:TlfL8iHOKf:Mjeb\&gt;Xb3&gt;0kM@iNkaifYHDFNIKP\e^;bhg@V&lt;g0Za7F]R=JKPMgdg&gt;nYaMSb8MAV0o05XKjM5&lt;5^V=albT\&lt;868hhl^jHPRa0KcT4i[31chfOeGW&gt;;``&gt;&gt;I;B:YafYW&gt;jW_7D1&gt;9_X14U9VXJ5E_PA2ZPb&gt;n6eBLcN]SU4eSd&lt;IDGD4D5WHMlFCU0DeARScb:h\?EC1&gt;IBWead&gt;7F&gt;FeBea\oCS]jf@kE47ZHcB?TlP6_K[QC2@_N&gt;ilNn0VdgZE&gt;Z98hXCHa4bNUM16M74Q;DhldmcZ&gt;V?_TG1J?NI:F8&lt;aomhdPX5^AEe6BRYle4clf_gSb6D9LaD2h]ij8SAH@[`J@cb2G7ee@iZWl2A&gt;`Ga95FDhJo7Xo&gt;Zd3[jL&lt;DQ4OILX9a;0T\SUDWY:Bh&gt;WGNb:dHQ[S`[8:1L:F@&gt;H[49RQ6_3QV&lt;UT0oIITF^H_\X=:&lt;42`N``YjM75HWEd]5O`&lt;EX89FTP`^oN:QHgED5k:\CaYbA2GbD1;X5:N;?SoLhVhR`R_9lg3hU4n:I`2Gn:IjDHED]5i=2fcTklTK1H6k4HjK;HBM&gt;;c]9;i[MFD?WaY1O]oS293kLd9S3N6He?:_QKEcBGLOc:jB6H@fR]h]HGB5;:&lt;RE&lt;`3K4Ibi29dR;nU&lt;&lt;TKBRnTdK[ZTT6oiOVVXKgaP6&lt;lMTO_JC\0&lt;RY5NkR352&lt;FbcCB&lt;_3?0XjQ`BJP;OJR::8eHFb3&lt;;M\9FOC8T:MkD:Z;C=eb^0:AMSbSY_^Lc=SGbD5WDh@6j]PCDc@;\X1Nb\[`Z0W_Th5&lt;HD4CafYghb`T95Ko571]SZJDHF2eE&lt;7jViL_\8TQ@dFRo]`G[h3&gt;862l:2F[UU6dVbFjU?NI&gt;OHOk&gt;JNcFNU[mXi]iJ[neWQ\mWa]i[e?IkO^Mf]LHTP[G3?43M8g^Wh``lW3kBT7ADM6b_IUCIPO=C8g5@?9R3&lt;hilXNY7_&lt;THNN&lt;KMLm;eGM6_A6AUDB\c5Q;S2POniP9[mdEeIDnO7;T7Nia2nFN\L2XZIP?ZJKW\2cK0U5fb[dLn?[C&gt;YAMXfVFic02OQA\6LHEk0oBd0f;`kR1hImAUl:@I;^:oFJUF?mDgPlLokm]OIgenn9;n5[Oh3g7@W7OWBCk9X1mYDPF9AQ4LOGeM_D_WR?I7QRlVEmN_0QlA9^lO[HjnfngGjkHokO\A35=_4hVU^jKm;\?Y9^B=RkTG1I&lt;6nI`AQ_kJ;of[GmIi[g0]1\UG_FKUnX]ZcGmoI;NUdDFOolHn;NbMLkT`1GEo;j63N_8b_O`PQ[KRjb&lt;NDHW4;\lT[Ila;nMd`56_c\C25fJLUS;9fn@6[[SMIBBMFK\8d;ZIRSI;fJ5_cojWSIfcY2kNd1jkS0f9A3BNfk8W1m4H0gRbfA3J6Q726nmNm4PQYcWZ___NEf_FmmmOm40IZ1mf4PmS?H8k&gt;=J3g&lt;\1K6j;CNTGZ8kY61mk30RLUO`T`_H`Hg&lt;`\K67=HJ3g&lt;\3K6iGRVO9``_1H`L`\K6`f=371ikY61mf30S&lt;W]K86enT`_H`Hg&lt;=fbaLQO`c@&lt;hK;Rmmf&gt;KT=]4\mm;NkW]^mcFgV[_]l=8aHk_j]MgIEYV5XJkiW]l^^CKnYn2OgNJ0g&lt;fR\mWo;?JNcFN^cfL_eWZ[Eff[LeWebL[d?YfWFm3O0neW6m3NP3nGQ@G_M?lS61c3KG?`NUXHYTJ?j1SoC7V&gt;RGj_]d[blRO_M^Qg&gt;f_[0oQJWgg`CkhXXJ\hG;1Ujg`4MNjIg_6l3GG;oohYSNBallm3eZnFmebBeaLSDIS17WJfDBN9nUo^n2oC_;Q\;4O3WWk7mAZI17;2]ChHfZeJ;I\fY;^dB\J;NW@cEDj]HE]B8GSiKJgN9M6f4UIKhV02kFjYnXXBH9lF?3gDC&lt;EC`d=4l&lt;aIYa?]YS&lt;9Zl8]AkXcPg:6L69WWX^8R2;YXfC&lt;Xg6AQg@oOoChH=41ln]AG?J3U0Wn&gt;8[8cdWGUnL2Z&gt;Ll4HaNcI&lt;f]SiWCVXSMeP?^a7:Tf&lt;`L3cKdmDl7?Uj&gt;FnPG5NSQBkHE`Yj&gt;ZNQ^;UbDk0kCT]3]YV&lt;50o&lt;2&lt;aTY7THb5hg;3^hl@GYRZE@mbL?5gdHJNW5`6W8[eho^38?;R459L4WN1Jg[egNX[3[_&gt;lAAY&gt;L9Z_H5YN]9:KZMj\cPGZco]??=ig[hH7YShgPS8:44leI:@9R?fLHKlH6UZ]nlAXHFAFUn7AdT=;FK^oZgocoK[2W_=Aj]T;2mBd8`7h`B0K&gt;IP&lt;04@S6]dA9N`8Q8YBk19T@8RFF4T29OB1V7TX7QM01@hI@3`QJ=4@H\nBkS2d5P1BDgN8?4B230Y8lb8ONC@?IPH0A@OMPD?HZ@1`&gt;mj`5N5c60PN06hNI1c8`@k6b0M9IN3`QM68;M1l5Bl&gt;6cX&gt;XD78V@S2j5Ad;C&lt;0cA7OX0nM8&lt;iaN3K0@0Kil664BNSOe:0@R=6NA66f9@PX0d0dHb:LL\6@1aSJl[5h6I38X&lt;0`;0&lt;Al748MXb84H=@Y&lt;lI\5@GNMD;RJd?DeY0Ac1J230g&gt;d1e00LP8d;&gt;V@59CQA1BG&lt;@2[2A45hE8CX:H0A=a\KRAC&lt;Q0YPRb5D&lt;IR63P1QX&lt;JXCS9a3FQ&gt;daQVRjO4I;1da1URZ;LZ444@R2PX2XAXA9Te@FngkoKI_ea&gt;NZN^m\`1H5CMhX9Bn1?ZYS0WAbR2RD8F3W@XajF1=AXS6&lt;TS4i09PN?`gPUG9G3J26`2GbAW]jGY5&lt;AGn^iZAjM_;W5&lt;g^kKMC]B[X13GZm3mmNffKMhb:cJ]DAT&gt;a?_4H8jZX2PIja6[DFTFC:]l]=1AN=PD`VJ&gt;HX2k?Pj7:bQ`W[XWe0\38&lt;V=I\:]2HOl74S6e0a;ZmCFf:3FnRcED67[hUWZPU7ZZKLUVD\PFX_FVE23Q7WUaWV=U&gt;&lt;ZRLQB8LDd0hS94OC1D?6J9N:\\`US2k:iaJY8jY]eTVWO0KLeICMh3dn\dH86aYA7eY]eZZ3=d6WJLE7IPEWIe=_c4FYLEhdA\b5XoJQE;n[HFdKI7C3oK`RFK6l`B8RhhCXhP8XnP3841548PB6P6B[DKHS41JU&lt;Qne:U\ARQ=B[VDHSOT307XA07Qhn2d8RBoajKU&gt;9P@S2lYle3RId0IIf072nP8&gt;;NUah=0ilGD:G5\RN_\=;5jTD@iTfQNGIfmQJ2oJl[SBFC]DLncWBE4mFZe6d_Ob&gt;3YC4APEA@D_mOFNI8ALek79bT&gt;:a8]EjYToY&lt;]8C`FV4Z``X`1aB@L&lt;?V9ARCQ4c:K71jA4o8X@_N2@;?hf9D0M0]D;:A]?]T5@Y1`&gt;Vi=L5H`I25YCYJTF@F?fd@VbI9Pf6?dDZY8JdAcR`QM5&gt;MT&lt;aOnO7&lt;DiRiB;\k?RRIHVCkC&lt;FWi=5fXF\he2n@Q&gt;2TEkZIo6kBK3\C@]3\oE]=7UY8knVi7O5=^_a6d;G^?DaLI=YY]ARAc7NRDMhAYZlK90=KQlem6G@;;lecBDFecfKNA=H&gt;mJl3I59=NFgn`nf[B1:05f5E[`fiTPQ4EDe1H=4ZRWkf3TWlOP&gt;Ela5hZDn]cQJC=UBXIIJdWiR@KZe]DHRbmfI;]VYoi&gt;o?3K1h=6</protected>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='21'>
+			<Action classname='StepType' isroottypedef='true' typecategory='1' timestamp='1618215606' typeversion='21.0.0.2' typelastmodversion='21.0.0.0' typeminprodversion='21.0.0.0' typeflags='33554446'>
+				<subprops>
+					<Substeps typename='StepTypeSubstepsArray' xsi:type='StepTypeSubstepsArray' classname='Objs' flagsforinstances='524312' instanceoverrideflags='655384'>
+						<value lbound='[0]' ubound='[]'/>
+					</Substeps>
+					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
+						<value>ResStr("NI_STEPTYPES", "ACTION_DESCRIPTION_NAME") + (("%ModuleDescription" == "") ? "" : ",  %ModuleDescription")</value>
+					</DescriptionFormat>
+					<DefaultNameFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
+						<value>ResStr("NI_STEPTYPES", "ACTION_DEF_STEP_NAME")</value>
+					</DefaultNameFormat>
+					<Menu typename='StepTypeMenu' xsi:type='StepTypeMenu' classname='Obj' flagsforinstances='524312' instanceoverrideflags='524312'>
+						<subprops>
+							<CanBeSubstepType classname='Bool'>
+								<value>false</value>
+							</CanBeSubstepType>
+							<CanOnlyBeSubstepType classname='Bool'>
+								<value>false</value>
+							</CanOnlyBeSubstepType>
+							<Category classname='Str'>
+								<value>""</value>
+							</Category>
+							<ItemName classname='ExprValue'>
+								<value>ResStr("NI_STEPTYPES", "ACTION_MENU_ITEM_NAME")</value>
+							</ItemName>
+							<SingularItemName classname='Str'>
+								<value>""</value>
+							</SingularItemName>
+							<SeparatorBeforeCategory classname='Bool'>
+								<value>false</value>
+							</SeparatorBeforeCategory>
+							<SeparatorBeforeItemName classname='Bool'>
+								<value>false</value>
+							</SeparatorBeforeItemName>
+							<Group classname='Str'>
+								<value>Action</value>
+							</Group>
+						</subprops>
+					</Menu>
+					<AdditionalResultsHints classname='Objs' valueflags='4194328' structureflags='524288'>
+						<value lbound='[0]' ubound='[]'>
+							<elemproto>
+								<_NAME_IN_ATTRIBUTE_ typename='NI_CustomResult' xsi:type='NI_CustomResult' name='' classname='CustomResult'>
+									<subprops>
+										<Name classname='ExprValue'>
+											<value/>
+										</Name>
+										<ValueToLog classname='ExprValue'>
+											<value/>
+										</ValueToLog>
+										<Condition classname='ExprValue'>
+											<value/>
+										</Condition>
+										<Flags classname='Num'>
+											<value>8192</value>
+										</Flags>
+										<CheckedState classname='Num'>
+											<value>2</value>
+										</CheckedState>
+										<Type classname='PropertyObjectType'>
+											<subprops>
+												<ValueType classname='Num'>
+													<value>3</value>
+												</ValueType>
+												<IsObject classname='Bool'>
+													<value>true</value>
+												</IsObject>
+												<TypeName classname='Str'>
+													<value/>
+												</TypeName>
+												<ElementType classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</ElementType>
+												<ArrayDimensions classname='ArrayDimensions'>
+													<subprops>
+														<LowerBounds classname='Nums'>
+															<value lbound='[0]' ubound='[]'/>
+														</LowerBounds>
+														<UpperBounds classname='Nums'>
+															<value lbound='[0]' ubound='[]'/>
+														</UpperBounds>
+													</subprops>
+												</ArrayDimensions>
+												<Representation classname='Num'>
+													<value>1</value>
+												</Representation>
+												<ClassName classname='Str'>
+													<value/>
+												</ClassName>
+											</subprops>
+										</Type>
+										<Elements classname='Objs'>
+											<value lbound='[0]' ubound='[]'/>
+										</Elements>
+										<IsAnyType classname='Bool'>
+											<value>true</value>
+										</IsAnyType>
+									</subprops>
+								</_NAME_IN_ATTRIBUTE_>
+							</elemproto>
+						</value>
+					</AdditionalResultsHints>
+					<TS typename='TEInf' xsi:type='TEInf' classname='Obj' flagsforinstances='262168' instanceoverrideflags='4456472'>
+						<subprops>
+							<Id classname='Str'>
+								<value/>
+							</Id>
+							<Icon classname='Str'>
+								<value/>
+							</Icon>
+							<SData classname='Obj' flagsforinstances='2097152' instanceoverrideflags='7143448' structureflags='2097152'/>
+							<PreCond classname='ExprValue'>
+								<value/>
+							</PreCond>
+							<LoadOpt classname='Str'>
+								<value>PreloadWhenExecuted</value>
+							</LoadOpt>
+							<UnloadOpt classname='Str'>
+								<value>UnloadWithFile</value>
+							</UnloadOpt>
+							<Mode classname='Str'>
+								<value>Normal</value>
+							</Mode>
+							<WindowActivation classname='Str'>
+								<value>None</value>
+							</WindowActivation>
+							<ResultOption classname='Num'>
+								<value>1</value>
+							</ResultOption>
+							<StepFCSeqF classname='Bool'>
+								<value>true</value>
+							</StepFCSeqF>
+							<IgnoreRTE classname='Bool'>
+								<value>false</value>
+							</IgnoreRTE>
+							<UseMutex classname='Bool'>
+								<value>false</value>
+							</UseMutex>
+							<MutexNameOrRef classname='ExprValue'>
+								<value/>
+							</MutexNameOrRef>
+							<BatchSyncOpt classname='Num'>
+								<value>0</value>
+							</BatchSyncOpt>
+							<SwitchEnabled classname='Bool'>
+								<value>false</value>
+							</SwitchEnabled>
+							<VirtualDeviceName classname='ExprValue'>
+								<value/>
+							</VirtualDeviceName>
+							<SwitchOperation classname='Num'>
+								<value>1</value>
+							</SwitchOperation>
+							<RouteGroupConnect classname='ExprValue'>
+								<value/>
+							</RouteGroupConnect>
+							<RouteGroupDisconnect classname='ExprValue'>
+								<value/>
+							</RouteGroupDisconnect>
+							<MulticonnectMode classname='Num'>
+								<value>1</value>
+							</MulticonnectMode>
+							<OperationOrder classname='Num'>
+								<value>2</value>
+							</OperationOrder>
+							<ConnectionLifetime classname='Num'>
+								<value>0</value>
+							</ConnectionLifetime>
+							<WaitForDebounce classname='Bool'>
+								<value>true</value>
+							</WaitForDebounce>
+							<PassAct classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
+								<value>Next</value>
+							</PassAct>
+							<FailAct classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
+								<value>Next</value>
+							</FailAct>
+							<PassActTarget classname='ExprValue' flagsforinstances='1' instanceoverrideflags='5046297'>
+								<value/>
+							</PassActTarget>
+							<FailActTarget classname='ExprValue' flagsforinstances='1' instanceoverrideflags='5046297'>
+								<value/>
+							</FailActTarget>
+							<CustExpr classname='ExprValue'>
+								<value/>
+							</CustExpr>
+							<CustTrueAct classname='Str'>
+								<value>Next</value>
+							</CustTrueAct>
+							<CustFalseAct classname='Str'>
+								<value>Next</value>
+							</CustFalseAct>
+							<CustTrueActTarget classname='ExprValue'>
+								<value/>
+							</CustTrueActTarget>
+							<CustFalseActTarget classname='ExprValue'>
+								<value/>
+							</CustFalseActTarget>
+							<LoopType classname='Str'>
+								<value>NoLooping</value>
+							</LoopType>
+							<LoopWhile classname='ExprValue'>
+								<value/>
+							</LoopWhile>
+							<LoopStatus classname='ExprValue'>
+								<value/>
+							</LoopStatus>
+							<LoopIncrement classname='ExprValue'>
+								<value>RunState.LoopIndex += 1</value>
+							</LoopIncrement>
+							<LoopInitialize classname='ExprValue'>
+								<value>RunState.LoopIndex = 0</value>
+							</LoopInitialize>
+							<LoopOpt classname='Num'>
+								<value>0</value>
+							</LoopOpt>
+							<PreExpr classname='ExprValue'>
+								<value/>
+							</PreExpr>
+							<PostExpr classname='ExprValue'>
+								<value/>
+							</PostExpr>
+							<StatusExpr classname='ExprValue'>
+								<value/>
+							</StatusExpr>
+							<CanSpecifyModule classname='Bool'>
+								<value>true</value>
+							</CanSpecifyModule>
+							<CanEditCode classname='Bool'>
+								<value>true</value>
+							</CanEditCode>
+							<CanEditModulePrototype classname='Bool'>
+								<value>true</value>
+							</CanEditModulePrototype>
+							<CanEditParameterAdditionalResults classname='Bool'>
+								<value>true</value>
+							</CanEditParameterAdditionalResults>
+							<PrecondIntExe classname='Num'>
+								<value>0</value>
+							</PrecondIntExe>
+							<Requirements classname='Obj' flagsforinstances='1' valueflags='1' structureflags='2097152'>
+								<subprops>
+									<Links classname='Strs' flagsforinstances='71303168' instanceoverrideflags='72286233' valueflags='71303168'>
+										<value lbound='[0]' ubound='[]'/>
+									</Links>
+								</subprops>
+							</Requirements>
+							<CustomResults classname='Objs'>
+								<value lbound='[0]' ubound='[]'>
+									<elemproto>
+										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+											<subprops>
+												<Name classname='ExprValue'>
+													<value/>
+												</Name>
+												<ValueToLog classname='ExprValue'>
+													<value/>
+												</ValueToLog>
+												<Condition classname='ExprValue'>
+													<value/>
+												</Condition>
+												<Flags classname='Num'>
+													<value>8192</value>
+												</Flags>
+												<CheckedState classname='Num'>
+													<value>2</value>
+												</CheckedState>
+												<Type classname='PropertyObjectType'>
+													<subprops>
+														<ValueType classname='Num'>
+															<value>3</value>
+														</ValueType>
+														<IsObject classname='Bool'>
+															<value>true</value>
+														</IsObject>
+														<TypeName classname='Str'>
+															<value/>
+														</TypeName>
+														<ElementType classname='Objs'>
+															<value lbound='[0]' ubound='[]'/>
+														</ElementType>
+														<ArrayDimensions classname='ArrayDimensions'>
+															<subprops>
+																<LowerBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</LowerBounds>
+																<UpperBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</UpperBounds>
+															</subprops>
+														</ArrayDimensions>
+														<Representation classname='Num'>
+															<value>1</value>
+														</Representation>
+														<ClassName classname='Str'>
+															<value/>
+														</ClassName>
+													</subprops>
+												</Type>
+												<Elements classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</Elements>
+												<IsAnyType classname='Bool'>
+													<value>true</value>
+												</IsAnyType>
+											</subprops>
+										</_NAME_IN_ATTRIBUTE_>
+									</elemproto>
+								</value>
+							</CustomResults>
+							<AdditionalResultsHints classname='Objs'>
+								<value lbound='[0]' ubound='[]'>
+									<elemproto>
+										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+											<subprops>
+												<Name classname='ExprValue'>
+													<value/>
+												</Name>
+												<ValueToLog classname='ExprValue'>
+													<value/>
+												</ValueToLog>
+												<Condition classname='ExprValue'>
+													<value/>
+												</Condition>
+												<Flags classname='Num'>
+													<value>8192</value>
+												</Flags>
+												<CheckedState classname='Num'>
+													<value>2</value>
+												</CheckedState>
+												<Type classname='PropertyObjectType'>
+													<subprops>
+														<ValueType classname='Num'>
+															<value>3</value>
+														</ValueType>
+														<IsObject classname='Bool'>
+															<value>true</value>
+														</IsObject>
+														<TypeName classname='Str'>
+															<value/>
+														</TypeName>
+														<ElementType classname='Objs'>
+															<value lbound='[0]' ubound='[]'/>
+														</ElementType>
+														<ArrayDimensions classname='ArrayDimensions'>
+															<subprops>
+																<LowerBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</LowerBounds>
+																<UpperBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</UpperBounds>
+															</subprops>
+														</ArrayDimensions>
+														<Representation classname='Num'>
+															<value>1</value>
+														</Representation>
+														<ClassName classname='Str'>
+															<value/>
+														</ClassName>
+													</subprops>
+												</Type>
+												<Elements classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</Elements>
+												<IsAnyType classname='Bool'>
+													<value>true</value>
+												</IsAnyType>
+											</subprops>
+										</_NAME_IN_ATTRIBUTE_>
+									</elemproto>
+								</value>
+							</AdditionalResultsHints>
+						</subprops>
+					</TS>
+					<NI_Data typename='StepTypeNIData' xsi:type='StepTypeNIData' classname='Obj'>
+						<subprops>
+							<EditPanels classname='Strs'>
+								<value lbound='[0]' ubound='[]'/>
+							</EditPanels>
+						</subprops>
+					</NI_Data>
+					<Result classname='Obj' flagsforinstances='4194304' valueflags='4194304'>
+						<subprops>
+							<Error typename='Error' xsi:type='Error' classname='Obj' flagsforinstances='4194304' instanceoverrideflags='4194304' valueflags='4194304'>
+								<subprops>
+									<Code classname='Num'>
+										<value>0</value>
+									</Code>
+									<Msg classname='Str'>
+										<value/>
+									</Msg>
+									<Occurred classname='Bool'>
+										<value>false</value>
+									</Occurred>
+								</subprops>
+							</Error>
+							<Status classname='Str' flagsforinstances='4194304' valueflags='4194304'>
+								<value/>
+							</Status>
+							<ReportText classname='Str' flagsforinstances='4194304' valueflags='4194304'>
+								<value/>
+							</ReportText>
+							<Common typename='CommonResults' xsi:type='CommonResults' classname='Obj' instanceoverrideflags='4194304'/>
+						</subprops>
+					</Result>
+					<CodeTemplates classname='Str' valueflags='4194328' structureflags='524288'>
+						<value>DefaultLabVIEW|DefaultLabVIEWNXG|DefaultCVI|DefaultVB.NET|DefaultCSharp.NET|DefaultC++.NET|DefaultVC++_Template|DefaultHTB72_Template|DefaultHTB80_Template|Default_Template</value>
+					</CodeTemplates>
+					<BlockStartTypes classname='Str' valueflags='4194328' structureflags='524288'>
+						<value/>
+					</BlockStartTypes>
+					<BlockEndTypes classname='Str' valueflags='4194328' structureflags='524288'>
+						<value/>
+					</BlockEndTypes>
+					<AppliesToBlockStructure classname='Bool' valueflags='4194328' structureflags='524288'>
+						<value>false</value>
+					</AppliesToBlockStructure>
+					<CanEncapsulate classname='Bool' valueflags='4194328' structureflags='524288'>
+						<value>false</value>
+					</CanEncapsulate>
+					<Category classname='Str' valueflags='24' structureflags='524288'>
+						<value>Action</value>
+					</Category>
+				</subprops>
+			</Action>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='29'>
+			<NI_PythonParameterResult classname='PythonParameterResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+				<subprops>
+					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</Condition>
+					<Flags classname='Num'>
+						<value>8192</value>
+						<numericfmt>%#x</numericfmt>
+					</Flags>
+					<CheckedState classname='Num'>
+						<value>1</value>
+					</CheckedState>
+				</subprops>
+			</NI_PythonParameterResult>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='28'>
+			<NI_PythonParameter classname='CPythonParameter' isroottypedef='true' typecategory='3' timestamp='1650060872' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+				<subprops>
+					<Name classname='Str'>
+						<value>_notNamed</value>
+					</Name>
+					<Type classname='Num'>
+						<value>7</value>
+					</Type>
+					<ArgumentValue typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</ArgumentValue>
+					<ArgumentDisplayValue typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</ArgumentDisplayValue>
+					<AdditionalResults classname='Obj'>
+						<subprops>
+							<Input typename='NI_PythonParameterResult' xsi:type='NI_PythonParameterResult' classname='PythonParameterResult'>
+								<subprops>
+									<Condition classname='ExprValue'>
+										<value/>
+									</Condition>
+									<Flags classname='Num'>
+										<value>8192</value>
+									</Flags>
+									<CheckedState classname='Num'>
+										<value>1</value>
+									</CheckedState>
+								</subprops>
+							</Input>
+							<Output typename='NI_PythonParameterResult' xsi:type='NI_PythonParameterResult' classname='PythonParameterResult'>
+								<subprops>
+									<Condition classname='ExprValue'>
+										<value/>
+									</Condition>
+									<Flags classname='Num'>
+										<value>8192</value>
+									</Flags>
+									<CheckedState classname='Num'>
+										<value>1</value>
+									</CheckedState>
+								</subprops>
+							</Output>
+						</subprops>
+					</AdditionalResults>
+				</subprops>
+			</NI_PythonParameter>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='27'>
+			<PythonStepAdditions classname='CPythonModule' isroottypedef='true' typecategory='3' timestamp='1650060872' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+				<subprops>
+					<PythonCall classname='CPythonCall'>
+						<subprops>
+							<UseAdapterSettingsForInterpreterSession classname='Bool'>
+								<value>true</value>
+							</UseAdapterSettingsForInterpreterSession>
+							<InterpreterSessionScope classname='Num'>
+								<value>3</value>
+							</InterpreterSessionScope>
+							<PythonVersion classname='Str'>
+								<value/>
+							</PythonVersion>
+							<PythonVirtualEnvironmentPath classname='Str'>
+								<value/>
+							</PythonVirtualEnvironmentPath>
+							<InterpreterLocation typename='Expression' xsi:type='Expression' classname='ExprValue'>
+								<value/>
+							</InterpreterLocation>
+							<CreateIfInterpreterDoesNotExist classname='Bool'>
+								<value>true</value>
+							</CreateIfInterpreterDoesNotExist>
+							<ModulePath typename='Path' xsi:type='Path' classname='PathValue'>
+								<value/>
+							</ModulePath>
+							<OperationType classname='Num'>
+								<value>1</value>
+							</OperationType>
+							<OperationScope classname='Num'>
+								<value>0</value>
+							</OperationScope>
+							<ClassName classname='Str'>
+								<value/>
+							</ClassName>
+							<ClassInstanceLocation typename='Expression' xsi:type='Expression' classname='ExprValue'>
+								<value/>
+							</ClassInstanceLocation>
+							<FunctionOrAttributeName classname='Str'>
+								<value/>
+							</FunctionOrAttributeName>
+							<Parameters classname='Objs'>
+								<value lbound='[0]' ubound='[0]'>
+									<elemproto>
+										<_NAME_IN_ATTRIBUTE_ typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name='' classname='CPythonParameter' structureflags='131072'>
+											<subprops>
+												<Name classname='Str'>
+													<value>_notNamed</value>
+												</Name>
+												<Type classname='Num'>
+													<value>7</value>
+												</Type>
+												<ArgumentValue classname='ExprValue'>
+													<value/>
+												</ArgumentValue>
+												<ArgumentDisplayValue classname='ExprValue'>
+													<value/>
+												</ArgumentDisplayValue>
+												<AdditionalResults classname='Obj'>
+													<subprops>
+														<Input classname='PythonParameterResult'>
+															<subprops>
+																<Condition classname='ExprValue'>
+																	<value/>
+																</Condition>
+																<Flags classname='Num'>
+																	<value>8192</value>
+																</Flags>
+																<CheckedState classname='Num'>
+																	<value>1</value>
+																</CheckedState>
+															</subprops>
+														</Input>
+														<Output classname='PythonParameterResult'>
+															<subprops>
+																<Condition classname='ExprValue'>
+																	<value/>
+																</Condition>
+																<Flags classname='Num'>
+																	<value>8192</value>
+																</Flags>
+																<CheckedState classname='Num'>
+																	<value>1</value>
+																</CheckedState>
+															</subprops>
+														</Output>
+													</subprops>
+												</AdditionalResults>
+											</subprops>
+										</_NAME_IN_ATTRIBUTE_>
+									</elemproto>
+									<value>
+										<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
+											<subprops>
+												<Name classname='Str'>
+													<value>Return Value</value>
+												</Name>
+												<Type classname='Num'>
+													<value>7</value>
+												</Type>
+												<ArgumentValue classname='ExprValue'>
+													<value/>
+												</ArgumentValue>
+												<ArgumentDisplayValue classname='ExprValue'>
+													<value/>
+												</ArgumentDisplayValue>
+												<AdditionalResults classname='Obj'>
+													<subprops>
+														<Input classname='PythonParameterResult'>
+															<subprops>
+																<Condition classname='ExprValue'>
+																	<value/>
+																</Condition>
+																<Flags classname='Num'>
+																	<value>8192</value>
+																</Flags>
+																<CheckedState classname='Num'>
+																	<value>1</value>
+																</CheckedState>
+															</subprops>
+														</Input>
+														<Output classname='PythonParameterResult'>
+															<subprops>
+																<Condition classname='ExprValue'>
+																	<value/>
+																</Condition>
+																<Flags classname='Num'>
+																	<value>8192</value>
+																</Flags>
+																<CheckedState classname='Num'>
+																	<value>1</value>
+																</CheckedState>
+															</subprops>
+														</Output>
+													</subprops>
+												</AdditionalResults>
+											</subprops>
+										</CPythonParameter>
+									</value>
+								</value>
+							</Parameters>
+							<DefaultParamCategoryForArray classname='Num'>
+								<value>5</value>
+							</DefaultParamCategoryForArray>
+						</subprops>
+					</PythonCall>
+				</subprops>
+			</PythonStepAdditions>
+		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='22'>
 			<EditSubstep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
 				<subprops>
@@ -3592,652 +4233,11 @@
 				</subprops>
 			</Statement>
 		</typedef>
-		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='21'>
-			<Action classname='StepType' isroottypedef='true' typecategory='1' timestamp='1618215606' typeversion='21.0.0.2' typelastmodversion='21.0.0.0' typeminprodversion='21.0.0.0' typeflags='33554446'>
-				<subprops>
-					<Substeps typename='StepTypeSubstepsArray' xsi:type='StepTypeSubstepsArray' classname='Objs' flagsforinstances='524312' instanceoverrideflags='655384'>
-						<value lbound='[0]' ubound='[]'/>
-					</Substeps>
-					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
-						<value>ResStr("NI_STEPTYPES", "ACTION_DESCRIPTION_NAME") + (("%ModuleDescription" == "") ? "" : ",  %ModuleDescription")</value>
-					</DescriptionFormat>
-					<DefaultNameFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
-						<value>ResStr("NI_STEPTYPES", "ACTION_DEF_STEP_NAME")</value>
-					</DefaultNameFormat>
-					<Menu typename='StepTypeMenu' xsi:type='StepTypeMenu' classname='Obj' flagsforinstances='524312' instanceoverrideflags='524312'>
-						<subprops>
-							<CanBeSubstepType classname='Bool'>
-								<value>false</value>
-							</CanBeSubstepType>
-							<CanOnlyBeSubstepType classname='Bool'>
-								<value>false</value>
-							</CanOnlyBeSubstepType>
-							<Category classname='Str'>
-								<value>""</value>
-							</Category>
-							<ItemName classname='ExprValue'>
-								<value>ResStr("NI_STEPTYPES", "ACTION_MENU_ITEM_NAME")</value>
-							</ItemName>
-							<SingularItemName classname='Str'>
-								<value>""</value>
-							</SingularItemName>
-							<SeparatorBeforeCategory classname='Bool'>
-								<value>false</value>
-							</SeparatorBeforeCategory>
-							<SeparatorBeforeItemName classname='Bool'>
-								<value>false</value>
-							</SeparatorBeforeItemName>
-							<Group classname='Str'>
-								<value>Action</value>
-							</Group>
-						</subprops>
-					</Menu>
-					<AdditionalResultsHints classname='Objs' valueflags='4194328' structureflags='524288'>
-						<value lbound='[0]' ubound='[]'>
-							<elemproto>
-								<_NAME_IN_ATTRIBUTE_ typename='NI_CustomResult' xsi:type='NI_CustomResult' name='' classname='CustomResult'>
-									<subprops>
-										<Name classname='ExprValue'>
-											<value/>
-										</Name>
-										<ValueToLog classname='ExprValue'>
-											<value/>
-										</ValueToLog>
-										<Condition classname='ExprValue'>
-											<value/>
-										</Condition>
-										<Flags classname='Num'>
-											<value>8192</value>
-										</Flags>
-										<CheckedState classname='Num'>
-											<value>2</value>
-										</CheckedState>
-										<Type classname='PropertyObjectType'>
-											<subprops>
-												<ValueType classname='Num'>
-													<value>3</value>
-												</ValueType>
-												<IsObject classname='Bool'>
-													<value>true</value>
-												</IsObject>
-												<TypeName classname='Str'>
-													<value/>
-												</TypeName>
-												<ElementType classname='Objs'>
-													<value lbound='[0]' ubound='[]'/>
-												</ElementType>
-												<ArrayDimensions classname='ArrayDimensions'>
-													<subprops>
-														<LowerBounds classname='Nums'>
-															<value lbound='[0]' ubound='[]'/>
-														</LowerBounds>
-														<UpperBounds classname='Nums'>
-															<value lbound='[0]' ubound='[]'/>
-														</UpperBounds>
-													</subprops>
-												</ArrayDimensions>
-												<Representation classname='Num'>
-													<value>1</value>
-												</Representation>
-												<ClassName classname='Str'>
-													<value/>
-												</ClassName>
-											</subprops>
-										</Type>
-										<Elements classname='Objs'>
-											<value lbound='[0]' ubound='[]'/>
-										</Elements>
-										<IsAnyType classname='Bool'>
-											<value>true</value>
-										</IsAnyType>
-									</subprops>
-								</_NAME_IN_ATTRIBUTE_>
-							</elemproto>
-						</value>
-					</AdditionalResultsHints>
-					<TS typename='TEInf' xsi:type='TEInf' classname='Obj' flagsforinstances='262168' instanceoverrideflags='4456472'>
-						<subprops>
-							<Id classname='Str'>
-								<value/>
-							</Id>
-							<Icon classname='Str'>
-								<value/>
-							</Icon>
-							<SData classname='Obj' flagsforinstances='2097152' instanceoverrideflags='7143448' structureflags='2097152'/>
-							<PreCond classname='ExprValue'>
-								<value/>
-							</PreCond>
-							<LoadOpt classname='Str'>
-								<value>PreloadWhenExecuted</value>
-							</LoadOpt>
-							<UnloadOpt classname='Str'>
-								<value>UnloadWithFile</value>
-							</UnloadOpt>
-							<Mode classname='Str'>
-								<value>Normal</value>
-							</Mode>
-							<WindowActivation classname='Str'>
-								<value>None</value>
-							</WindowActivation>
-							<ResultOption classname='Num'>
-								<value>1</value>
-							</ResultOption>
-							<StepFCSeqF classname='Bool'>
-								<value>true</value>
-							</StepFCSeqF>
-							<IgnoreRTE classname='Bool'>
-								<value>false</value>
-							</IgnoreRTE>
-							<UseMutex classname='Bool'>
-								<value>false</value>
-							</UseMutex>
-							<MutexNameOrRef classname='ExprValue'>
-								<value/>
-							</MutexNameOrRef>
-							<BatchSyncOpt classname='Num'>
-								<value>0</value>
-							</BatchSyncOpt>
-							<SwitchEnabled classname='Bool'>
-								<value>false</value>
-							</SwitchEnabled>
-							<VirtualDeviceName classname='ExprValue'>
-								<value/>
-							</VirtualDeviceName>
-							<SwitchOperation classname='Num'>
-								<value>1</value>
-							</SwitchOperation>
-							<RouteGroupConnect classname='ExprValue'>
-								<value/>
-							</RouteGroupConnect>
-							<RouteGroupDisconnect classname='ExprValue'>
-								<value/>
-							</RouteGroupDisconnect>
-							<MulticonnectMode classname='Num'>
-								<value>1</value>
-							</MulticonnectMode>
-							<OperationOrder classname='Num'>
-								<value>2</value>
-							</OperationOrder>
-							<ConnectionLifetime classname='Num'>
-								<value>0</value>
-							</ConnectionLifetime>
-							<WaitForDebounce classname='Bool'>
-								<value>true</value>
-							</WaitForDebounce>
-							<PassAct classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
-								<value>Next</value>
-							</PassAct>
-							<FailAct classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
-								<value>Next</value>
-							</FailAct>
-							<PassActTarget classname='ExprValue' flagsforinstances='1' instanceoverrideflags='5046297'>
-								<value/>
-							</PassActTarget>
-							<FailActTarget classname='ExprValue' flagsforinstances='1' instanceoverrideflags='5046297'>
-								<value/>
-							</FailActTarget>
-							<CustExpr classname='ExprValue'>
-								<value/>
-							</CustExpr>
-							<CustTrueAct classname='Str'>
-								<value>Next</value>
-							</CustTrueAct>
-							<CustFalseAct classname='Str'>
-								<value>Next</value>
-							</CustFalseAct>
-							<CustTrueActTarget classname='ExprValue'>
-								<value/>
-							</CustTrueActTarget>
-							<CustFalseActTarget classname='ExprValue'>
-								<value/>
-							</CustFalseActTarget>
-							<LoopType classname='Str'>
-								<value>NoLooping</value>
-							</LoopType>
-							<LoopWhile classname='ExprValue'>
-								<value/>
-							</LoopWhile>
-							<LoopStatus classname='ExprValue'>
-								<value/>
-							</LoopStatus>
-							<LoopIncrement classname='ExprValue'>
-								<value>RunState.LoopIndex += 1</value>
-							</LoopIncrement>
-							<LoopInitialize classname='ExprValue'>
-								<value>RunState.LoopIndex = 0</value>
-							</LoopInitialize>
-							<LoopOpt classname='Num'>
-								<value>0</value>
-							</LoopOpt>
-							<PreExpr classname='ExprValue'>
-								<value/>
-							</PreExpr>
-							<PostExpr classname='ExprValue'>
-								<value/>
-							</PostExpr>
-							<StatusExpr classname='ExprValue'>
-								<value/>
-							</StatusExpr>
-							<CanSpecifyModule classname='Bool'>
-								<value>true</value>
-							</CanSpecifyModule>
-							<CanEditCode classname='Bool'>
-								<value>true</value>
-							</CanEditCode>
-							<CanEditModulePrototype classname='Bool'>
-								<value>true</value>
-							</CanEditModulePrototype>
-							<CanEditParameterAdditionalResults classname='Bool'>
-								<value>true</value>
-							</CanEditParameterAdditionalResults>
-							<PrecondIntExe classname='Num'>
-								<value>0</value>
-							</PrecondIntExe>
-							<Requirements classname='Obj' flagsforinstances='1' valueflags='1' structureflags='2097152'>
-								<subprops>
-									<Links classname='Strs' flagsforinstances='71303168' instanceoverrideflags='72286233' valueflags='71303168'>
-										<value lbound='[0]' ubound='[]'/>
-									</Links>
-								</subprops>
-							</Requirements>
-							<CustomResults classname='Objs'>
-								<value lbound='[0]' ubound='[]'>
-									<elemproto>
-										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-											<subprops>
-												<Name classname='ExprValue'>
-													<value/>
-												</Name>
-												<ValueToLog classname='ExprValue'>
-													<value/>
-												</ValueToLog>
-												<Condition classname='ExprValue'>
-													<value/>
-												</Condition>
-												<Flags classname='Num'>
-													<value>8192</value>
-												</Flags>
-												<CheckedState classname='Num'>
-													<value>2</value>
-												</CheckedState>
-												<Type classname='PropertyObjectType'>
-													<subprops>
-														<ValueType classname='Num'>
-															<value>3</value>
-														</ValueType>
-														<IsObject classname='Bool'>
-															<value>true</value>
-														</IsObject>
-														<TypeName classname='Str'>
-															<value/>
-														</TypeName>
-														<ElementType classname='Objs'>
-															<value lbound='[0]' ubound='[]'/>
-														</ElementType>
-														<ArrayDimensions classname='ArrayDimensions'>
-															<subprops>
-																<LowerBounds classname='Nums'>
-																	<value lbound='[0]' ubound='[]'/>
-																</LowerBounds>
-																<UpperBounds classname='Nums'>
-																	<value lbound='[0]' ubound='[]'/>
-																</UpperBounds>
-															</subprops>
-														</ArrayDimensions>
-														<Representation classname='Num'>
-															<value>1</value>
-														</Representation>
-														<ClassName classname='Str'>
-															<value/>
-														</ClassName>
-													</subprops>
-												</Type>
-												<Elements classname='Objs'>
-													<value lbound='[0]' ubound='[]'/>
-												</Elements>
-												<IsAnyType classname='Bool'>
-													<value>true</value>
-												</IsAnyType>
-											</subprops>
-										</_NAME_IN_ATTRIBUTE_>
-									</elemproto>
-								</value>
-							</CustomResults>
-							<AdditionalResultsHints classname='Objs'>
-								<value lbound='[0]' ubound='[]'>
-									<elemproto>
-										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-											<subprops>
-												<Name classname='ExprValue'>
-													<value/>
-												</Name>
-												<ValueToLog classname='ExprValue'>
-													<value/>
-												</ValueToLog>
-												<Condition classname='ExprValue'>
-													<value/>
-												</Condition>
-												<Flags classname='Num'>
-													<value>8192</value>
-												</Flags>
-												<CheckedState classname='Num'>
-													<value>2</value>
-												</CheckedState>
-												<Type classname='PropertyObjectType'>
-													<subprops>
-														<ValueType classname='Num'>
-															<value>3</value>
-														</ValueType>
-														<IsObject classname='Bool'>
-															<value>true</value>
-														</IsObject>
-														<TypeName classname='Str'>
-															<value/>
-														</TypeName>
-														<ElementType classname='Objs'>
-															<value lbound='[0]' ubound='[]'/>
-														</ElementType>
-														<ArrayDimensions classname='ArrayDimensions'>
-															<subprops>
-																<LowerBounds classname='Nums'>
-																	<value lbound='[0]' ubound='[]'/>
-																</LowerBounds>
-																<UpperBounds classname='Nums'>
-																	<value lbound='[0]' ubound='[]'/>
-																</UpperBounds>
-															</subprops>
-														</ArrayDimensions>
-														<Representation classname='Num'>
-															<value>1</value>
-														</Representation>
-														<ClassName classname='Str'>
-															<value/>
-														</ClassName>
-													</subprops>
-												</Type>
-												<Elements classname='Objs'>
-													<value lbound='[0]' ubound='[]'/>
-												</Elements>
-												<IsAnyType classname='Bool'>
-													<value>true</value>
-												</IsAnyType>
-											</subprops>
-										</_NAME_IN_ATTRIBUTE_>
-									</elemproto>
-								</value>
-							</AdditionalResultsHints>
-						</subprops>
-					</TS>
-					<NI_Data typename='StepTypeNIData' xsi:type='StepTypeNIData' classname='Obj'>
-						<subprops>
-							<EditPanels classname='Strs'>
-								<value lbound='[0]' ubound='[]'/>
-							</EditPanels>
-						</subprops>
-					</NI_Data>
-					<Result classname='Obj' flagsforinstances='4194304' valueflags='4194304'>
-						<subprops>
-							<Error typename='Error' xsi:type='Error' classname='Obj' flagsforinstances='4194304' instanceoverrideflags='4194304' valueflags='4194304'>
-								<subprops>
-									<Code classname='Num'>
-										<value>0</value>
-									</Code>
-									<Msg classname='Str'>
-										<value/>
-									</Msg>
-									<Occurred classname='Bool'>
-										<value>false</value>
-									</Occurred>
-								</subprops>
-							</Error>
-							<Status classname='Str' flagsforinstances='4194304' valueflags='4194304'>
-								<value/>
-							</Status>
-							<ReportText classname='Str' flagsforinstances='4194304' valueflags='4194304'>
-								<value/>
-							</ReportText>
-							<Common typename='CommonResults' xsi:type='CommonResults' classname='Obj' instanceoverrideflags='4194304'/>
-						</subprops>
-					</Result>
-					<CodeTemplates classname='Str' valueflags='4194328' structureflags='524288'>
-						<value>DefaultLabVIEW|DefaultLabVIEWNXG|DefaultCVI|DefaultVB.NET|DefaultCSharp.NET|DefaultC++.NET|DefaultVC++_Template|DefaultHTB72_Template|DefaultHTB80_Template|Default_Template</value>
-					</CodeTemplates>
-					<BlockStartTypes classname='Str' valueflags='4194328' structureflags='524288'>
-						<value/>
-					</BlockStartTypes>
-					<BlockEndTypes classname='Str' valueflags='4194328' structureflags='524288'>
-						<value/>
-					</BlockEndTypes>
-					<AppliesToBlockStructure classname='Bool' valueflags='4194328' structureflags='524288'>
-						<value>false</value>
-					</AppliesToBlockStructure>
-					<CanEncapsulate classname='Bool' valueflags='4194328' structureflags='524288'>
-						<value>false</value>
-					</CanEncapsulate>
-					<Category classname='Str' valueflags='24' structureflags='524288'>
-						<value>Action</value>
-					</Category>
-				</subprops>
-			</Action>
-		</typedef>
-		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='29'>
-			<NI_PythonParameterResult classname='PythonParameterResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
-				<subprops>
-					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
-						<value/>
-					</Condition>
-					<Flags classname='Num'>
-						<value>8192</value>
-						<numericfmt>%#x</numericfmt>
-					</Flags>
-					<CheckedState classname='Num'>
-						<value>1</value>
-					</CheckedState>
-				</subprops>
-			</NI_PythonParameterResult>
-		</typedef>
-		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='28'>
-			<NI_PythonParameter classname='CPythonParameter' isroottypedef='true' typecategory='3' timestamp='1650060872' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
-				<subprops>
-					<Name classname='Str'>
-						<value>_notNamed</value>
-					</Name>
-					<Type classname='Num'>
-						<value>7</value>
-					</Type>
-					<ArgumentValue typename='Expression' xsi:type='Expression' classname='ExprValue'>
-						<value/>
-					</ArgumentValue>
-					<ArgumentDisplayValue typename='Expression' xsi:type='Expression' classname='ExprValue'>
-						<value/>
-					</ArgumentDisplayValue>
-					<AdditionalResults classname='Obj'>
-						<subprops>
-							<Input typename='NI_PythonParameterResult' xsi:type='NI_PythonParameterResult' classname='PythonParameterResult'>
-								<subprops>
-									<Condition classname='ExprValue'>
-										<value/>
-									</Condition>
-									<Flags classname='Num'>
-										<value>8192</value>
-									</Flags>
-									<CheckedState classname='Num'>
-										<value>1</value>
-									</CheckedState>
-								</subprops>
-							</Input>
-							<Output typename='NI_PythonParameterResult' xsi:type='NI_PythonParameterResult' classname='PythonParameterResult'>
-								<subprops>
-									<Condition classname='ExprValue'>
-										<value/>
-									</Condition>
-									<Flags classname='Num'>
-										<value>8192</value>
-									</Flags>
-									<CheckedState classname='Num'>
-										<value>1</value>
-									</CheckedState>
-								</subprops>
-							</Output>
-						</subprops>
-					</AdditionalResults>
-				</subprops>
-			</NI_PythonParameter>
-		</typedef>
-		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='27'>
-			<PythonStepAdditions classname='CPythonModule' isroottypedef='true' typecategory='3' timestamp='1650060872' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
-				<subprops>
-					<PythonCall classname='CPythonCall'>
-						<subprops>
-							<UseAdapterSettingsForInterpreterSession classname='Bool'>
-								<value>true</value>
-							</UseAdapterSettingsForInterpreterSession>
-							<InterpreterSessionScope classname='Num'>
-								<value>3</value>
-							</InterpreterSessionScope>
-							<PythonVersion classname='Str'>
-								<value/>
-							</PythonVersion>
-							<PythonVirtualEnvironmentPath classname='Str'>
-								<value/>
-							</PythonVirtualEnvironmentPath>
-							<InterpreterLocation typename='Expression' xsi:type='Expression' classname='ExprValue'>
-								<value/>
-							</InterpreterLocation>
-							<CreateIfInterpreterDoesNotExist classname='Bool'>
-								<value>true</value>
-							</CreateIfInterpreterDoesNotExist>
-							<ModulePath typename='Path' xsi:type='Path' classname='PathValue'>
-								<value/>
-							</ModulePath>
-							<OperationType classname='Num'>
-								<value>1</value>
-							</OperationType>
-							<OperationScope classname='Num'>
-								<value>0</value>
-							</OperationScope>
-							<ClassName classname='Str'>
-								<value/>
-							</ClassName>
-							<ClassInstanceLocation typename='Expression' xsi:type='Expression' classname='ExprValue'>
-								<value/>
-							</ClassInstanceLocation>
-							<FunctionOrAttributeName classname='Str'>
-								<value/>
-							</FunctionOrAttributeName>
-							<Parameters classname='Objs'>
-								<value lbound='[0]' ubound='[0]'>
-									<elemproto>
-										<_NAME_IN_ATTRIBUTE_ typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name='' classname='CPythonParameter' structureflags='131072'>
-											<subprops>
-												<Name classname='Str'>
-													<value>_notNamed</value>
-												</Name>
-												<Type classname='Num'>
-													<value>7</value>
-												</Type>
-												<ArgumentValue classname='ExprValue'>
-													<value/>
-												</ArgumentValue>
-												<ArgumentDisplayValue classname='ExprValue'>
-													<value/>
-												</ArgumentDisplayValue>
-												<AdditionalResults classname='Obj'>
-													<subprops>
-														<Input classname='PythonParameterResult'>
-															<subprops>
-																<Condition classname='ExprValue'>
-																	<value/>
-																</Condition>
-																<Flags classname='Num'>
-																	<value>8192</value>
-																</Flags>
-																<CheckedState classname='Num'>
-																	<value>1</value>
-																</CheckedState>
-															</subprops>
-														</Input>
-														<Output classname='PythonParameterResult'>
-															<subprops>
-																<Condition classname='ExprValue'>
-																	<value/>
-																</Condition>
-																<Flags classname='Num'>
-																	<value>8192</value>
-																</Flags>
-																<CheckedState classname='Num'>
-																	<value>1</value>
-																</CheckedState>
-															</subprops>
-														</Output>
-													</subprops>
-												</AdditionalResults>
-											</subprops>
-										</_NAME_IN_ATTRIBUTE_>
-									</elemproto>
-									<value>
-										<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
-											<subprops>
-												<Name classname='Str'>
-													<value>Return Value</value>
-												</Name>
-												<Type classname='Num'>
-													<value>7</value>
-												</Type>
-												<ArgumentValue classname='ExprValue'>
-													<value/>
-												</ArgumentValue>
-												<ArgumentDisplayValue classname='ExprValue'>
-													<value/>
-												</ArgumentDisplayValue>
-												<AdditionalResults classname='Obj'>
-													<subprops>
-														<Input classname='PythonParameterResult'>
-															<subprops>
-																<Condition classname='ExprValue'>
-																	<value/>
-																</Condition>
-																<Flags classname='Num'>
-																	<value>8192</value>
-																</Flags>
-																<CheckedState classname='Num'>
-																	<value>1</value>
-																</CheckedState>
-															</subprops>
-														</Input>
-														<Output classname='PythonParameterResult'>
-															<subprops>
-																<Condition classname='ExprValue'>
-																	<value/>
-																</Condition>
-																<Flags classname='Num'>
-																	<value>8192</value>
-																</Flags>
-																<CheckedState classname='Num'>
-																	<value>1</value>
-																</CheckedState>
-															</subprops>
-														</Output>
-													</subprops>
-												</AdditionalResults>
-											</subprops>
-										</CPythonParameter>
-									</value>
-								</value>
-							</Parameters>
-							<DefaultParamCategoryForArray classname='Num'>
-								<value>5</value>
-							</DefaultParamCategoryForArray>
-						</subprops>
-					</PythonCall>
-				</subprops>
-			</PythonStepAdditions>
-		</typedef>
 	</typelist>
 	<Data classname='SequenceFileData' valueflags='4194304'>
 		<subprops>
 			<Seq classname='Objs' valueflags='4194304'>
-				<value lbound='[0]' ubound='[2]'>
+				<value lbound='[0]' ubound='[0]'>
 					<value>
 						<Sequence name='MainSequence'>
 							<subprops>
@@ -5071,302 +5071,7 @@
 									</value>
 								</Main>
 								<Setup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[3]'>
-										<value>
-											<Step typename='Statement' xsi:type='Statement' name='Get absolute path to pinmap file'>
-												<subprops>
-													<TS classname='Obj'>
-														<subprops>
-															<Id classname='Str'>
-																<value>ID#:CHEZyO1w7RGuNrjdh1OqZD</value>
-															</Id>
-															<Icon classname='Str'>
-																<value>StatementStep.ico</value>
-															</Icon>
-															<PreCond classname='ExprValue'>
-																<value/>
-															</PreCond>
-															<LoadOpt classname='Str'>
-																<value>PreloadWhenExecuted</value>
-															</LoadOpt>
-															<UnloadOpt classname='Str'>
-																<value>UnloadWithFile</value>
-															</UnloadOpt>
-															<Mode classname='Str'>
-																<value>Normal</value>
-															</Mode>
-															<WindowActivation classname='Str'>
-																<value>None</value>
-															</WindowActivation>
-															<ResultOption classname='Num'>
-																<value>1</value>
-															</ResultOption>
-															<StepFCSeqF classname='Bool'>
-																<value>true</value>
-															</StepFCSeqF>
-															<IgnoreRTE classname='Bool'>
-																<value>false</value>
-															</IgnoreRTE>
-															<UseMutex classname='Bool'>
-																<value>false</value>
-															</UseMutex>
-															<MutexNameOrRef classname='ExprValue'>
-																<value/>
-															</MutexNameOrRef>
-															<BatchSyncOpt classname='Num'>
-																<value>0</value>
-															</BatchSyncOpt>
-															<SwitchEnabled classname='Bool'>
-																<value>false</value>
-															</SwitchEnabled>
-															<VirtualDeviceName classname='ExprValue'>
-																<value/>
-															</VirtualDeviceName>
-															<SwitchOperation classname='Num'>
-																<value>1</value>
-															</SwitchOperation>
-															<RouteGroupConnect classname='ExprValue'>
-																<value/>
-															</RouteGroupConnect>
-															<RouteGroupDisconnect classname='ExprValue'>
-																<value/>
-															</RouteGroupDisconnect>
-															<MulticonnectMode classname='Num'>
-																<value>1</value>
-															</MulticonnectMode>
-															<OperationOrder classname='Num'>
-																<value>2</value>
-															</OperationOrder>
-															<ConnectionLifetime classname='Num'>
-																<value>0</value>
-															</ConnectionLifetime>
-															<WaitForDebounce classname='Bool'>
-																<value>true</value>
-															</WaitForDebounce>
-															<PassAct classname='Str'>
-																<value>Next</value>
-															</PassAct>
-															<FailAct classname='Str'>
-																<value>Next</value>
-															</FailAct>
-															<PassActTarget classname='ExprValue'>
-																<value/>
-															</PassActTarget>
-															<FailActTarget classname='ExprValue'>
-																<value/>
-															</FailActTarget>
-															<CustExpr classname='ExprValue'>
-																<value/>
-															</CustExpr>
-															<CustTrueAct classname='Str'>
-																<value>Next</value>
-															</CustTrueAct>
-															<CustFalseAct classname='Str'>
-																<value>Next</value>
-															</CustFalseAct>
-															<CustTrueActTarget classname='ExprValue'>
-																<value/>
-															</CustTrueActTarget>
-															<CustFalseActTarget classname='ExprValue'>
-																<value/>
-															</CustFalseActTarget>
-															<LoopType classname='Str'>
-																<value>NoLooping</value>
-															</LoopType>
-															<LoopWhile classname='ExprValue'>
-																<value/>
-															</LoopWhile>
-															<LoopStatus classname='ExprValue'>
-																<value/>
-															</LoopStatus>
-															<LoopIncrement classname='ExprValue'>
-																<value>RunState.LoopIndex += 1</value>
-															</LoopIncrement>
-															<LoopInitialize classname='ExprValue'>
-																<value>RunState.LoopIndex = 0</value>
-															</LoopInitialize>
-															<LoopOpt classname='Num'>
-																<value>0</value>
-															</LoopOpt>
-															<PreExpr classname='ExprValue'>
-																<value/>
-															</PreExpr>
-															<PostExpr classname='ExprValue'>
-																<value>FindFile(FileGlobals.MeasurementLink.PinMapFileName,True,FileGlobals.MeasurementLink.PinMapPath)</value>
-															</PostExpr>
-															<StatusExpr classname='ExprValue'>
-																<value/>
-															</StatusExpr>
-															<CanSpecifyModule classname='Bool'>
-																<value>false</value>
-															</CanSpecifyModule>
-															<CanEditCode classname='Bool'>
-																<value>true</value>
-															</CanEditCode>
-															<CanEditModulePrototype classname='Bool'>
-																<value>true</value>
-															</CanEditModulePrototype>
-															<CanEditParameterAdditionalResults classname='Bool'>
-																<value>true</value>
-															</CanEditParameterAdditionalResults>
-															<PrecondIntExe classname='Num'>
-																<value>0</value>
-															</PrecondIntExe>
-															<CustomResults classname='Objs'>
-																<value lbound='[0]' ubound='[]'>
-																	<elemproto>
-																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-																			<subprops>
-																				<Name classname='ExprValue'>
-																					<value/>
-																				</Name>
-																				<ValueToLog classname='ExprValue'>
-																					<value/>
-																				</ValueToLog>
-																				<Condition classname='ExprValue'>
-																					<value/>
-																				</Condition>
-																				<Flags classname='Num'>
-																					<value>8192</value>
-																				</Flags>
-																				<CheckedState classname='Num'>
-																					<value>2</value>
-																				</CheckedState>
-																				<Type classname='PropertyObjectType'>
-																					<subprops>
-																						<ValueType classname='Num'>
-																							<value>3</value>
-																						</ValueType>
-																						<IsObject classname='Bool'>
-																							<value>true</value>
-																						</IsObject>
-																						<TypeName classname='Str'>
-																							<value/>
-																						</TypeName>
-																						<ElementType classname='Objs'>
-																							<value lbound='[0]' ubound='[]'/>
-																						</ElementType>
-																						<ArrayDimensions classname='ArrayDimensions'>
-																							<subprops>
-																								<LowerBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</LowerBounds>
-																								<UpperBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</UpperBounds>
-																							</subprops>
-																						</ArrayDimensions>
-																						<Representation classname='Num'>
-																							<value>1</value>
-																						</Representation>
-																						<ClassName classname='Str'>
-																							<value/>
-																						</ClassName>
-																					</subprops>
-																				</Type>
-																				<Elements classname='Objs'>
-																					<value lbound='[0]' ubound='[]'/>
-																				</Elements>
-																				<IsAnyType classname='Bool'>
-																					<value>true</value>
-																				</IsAnyType>
-																			</subprops>
-																		</_NAME_IN_ATTRIBUTE_>
-																	</elemproto>
-																</value>
-															</CustomResults>
-															<AdditionalResultsHints classname='Objs'>
-																<value lbound='[0]' ubound='[]'>
-																	<elemproto>
-																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-																			<subprops>
-																				<Name classname='ExprValue'>
-																					<value/>
-																				</Name>
-																				<ValueToLog classname='ExprValue'>
-																					<value/>
-																				</ValueToLog>
-																				<Condition classname='ExprValue'>
-																					<value/>
-																				</Condition>
-																				<Flags classname='Num'>
-																					<value>8192</value>
-																				</Flags>
-																				<CheckedState classname='Num'>
-																					<value>2</value>
-																				</CheckedState>
-																				<Type classname='PropertyObjectType'>
-																					<subprops>
-																						<ValueType classname='Num'>
-																							<value>3</value>
-																						</ValueType>
-																						<IsObject classname='Bool'>
-																							<value>true</value>
-																						</IsObject>
-																						<TypeName classname='Str'>
-																							<value/>
-																						</TypeName>
-																						<ElementType classname='Objs'>
-																							<value lbound='[0]' ubound='[]'/>
-																						</ElementType>
-																						<ArrayDimensions classname='ArrayDimensions'>
-																							<subprops>
-																								<LowerBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</LowerBounds>
-																								<UpperBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</UpperBounds>
-																							</subprops>
-																						</ArrayDimensions>
-																						<Representation classname='Num'>
-																							<value>1</value>
-																						</Representation>
-																						<ClassName classname='Str'>
-																							<value/>
-																						</ClassName>
-																					</subprops>
-																				</Type>
-																				<Elements classname='Objs'>
-																					<value lbound='[0]' ubound='[]'/>
-																				</Elements>
-																				<IsAnyType classname='Bool'>
-																					<value>true</value>
-																				</IsAnyType>
-																			</subprops>
-																		</_NAME_IN_ATTRIBUTE_>
-																	</elemproto>
-																</value>
-															</AdditionalResultsHints>
-														</subprops>
-													</TS>
-													<Result classname='Obj'>
-														<subprops>
-															<Error classname='Obj'>
-																<subprops>
-																	<Code classname='Num'>
-																		<value>0</value>
-																	</Code>
-																	<Msg classname='Str'>
-																		<value/>
-																	</Msg>
-																	<Occurred classname='Bool'>
-																		<value>false</value>
-																	</Occurred>
-																</subprops>
-															</Error>
-															<Status classname='Str'>
-																<value/>
-															</Status>
-															<ReportText classname='Str'>
-																<value/>
-															</ReportText>
-															<Common classname='Obj'/>
-														</subprops>
-													</Result>
-												</subprops>
-											</Step>
-										</value>
+									<value lbound='[0]' ubound='[1]'>
 										<value>
 											<Step typename='Action' xsi:type='Action' name='Update pin map'>
 												<subprops>
@@ -6305,301 +6010,6 @@
 												</subprops>
 											</Step>
 										</value>
-										<value>
-											<Step typename='Statement' xsi:type='Statement' name='Register active PinMapId'>
-												<subprops>
-													<TS classname='Obj'>
-														<subprops>
-															<Id classname='Str'>
-																<value>ID#:7xzPK+Rw7RGuNrjdh1OqZD</value>
-															</Id>
-															<Icon classname='Str'>
-																<value>StatementStep.ico</value>
-															</Icon>
-															<PreCond classname='ExprValue'>
-																<value/>
-															</PreCond>
-															<LoadOpt classname='Str'>
-																<value>PreloadWhenExecuted</value>
-															</LoadOpt>
-															<UnloadOpt classname='Str'>
-																<value>UnloadWithFile</value>
-															</UnloadOpt>
-															<Mode classname='Str'>
-																<value>Normal</value>
-															</Mode>
-															<WindowActivation classname='Str'>
-																<value>None</value>
-															</WindowActivation>
-															<ResultOption classname='Num'>
-																<value>1</value>
-															</ResultOption>
-															<StepFCSeqF classname='Bool'>
-																<value>true</value>
-															</StepFCSeqF>
-															<IgnoreRTE classname='Bool'>
-																<value>false</value>
-															</IgnoreRTE>
-															<UseMutex classname='Bool'>
-																<value>false</value>
-															</UseMutex>
-															<MutexNameOrRef classname='ExprValue'>
-																<value/>
-															</MutexNameOrRef>
-															<BatchSyncOpt classname='Num'>
-																<value>0</value>
-															</BatchSyncOpt>
-															<SwitchEnabled classname='Bool'>
-																<value>false</value>
-															</SwitchEnabled>
-															<VirtualDeviceName classname='ExprValue'>
-																<value/>
-															</VirtualDeviceName>
-															<SwitchOperation classname='Num'>
-																<value>1</value>
-															</SwitchOperation>
-															<RouteGroupConnect classname='ExprValue'>
-																<value/>
-															</RouteGroupConnect>
-															<RouteGroupDisconnect classname='ExprValue'>
-																<value/>
-															</RouteGroupDisconnect>
-															<MulticonnectMode classname='Num'>
-																<value>1</value>
-															</MulticonnectMode>
-															<OperationOrder classname='Num'>
-																<value>2</value>
-															</OperationOrder>
-															<ConnectionLifetime classname='Num'>
-																<value>0</value>
-															</ConnectionLifetime>
-															<WaitForDebounce classname='Bool'>
-																<value>true</value>
-															</WaitForDebounce>
-															<PassAct classname='Str'>
-																<value>Next</value>
-															</PassAct>
-															<FailAct classname='Str'>
-																<value>Next</value>
-															</FailAct>
-															<PassActTarget classname='ExprValue'>
-																<value/>
-															</PassActTarget>
-															<FailActTarget classname='ExprValue'>
-																<value/>
-															</FailActTarget>
-															<CustExpr classname='ExprValue'>
-																<value/>
-															</CustExpr>
-															<CustTrueAct classname='Str'>
-																<value>Next</value>
-															</CustTrueAct>
-															<CustFalseAct classname='Str'>
-																<value>Next</value>
-															</CustFalseAct>
-															<CustTrueActTarget classname='ExprValue'>
-																<value/>
-															</CustTrueActTarget>
-															<CustFalseActTarget classname='ExprValue'>
-																<value/>
-															</CustFalseActTarget>
-															<LoopType classname='Str'>
-																<value>NoLooping</value>
-															</LoopType>
-															<LoopWhile classname='ExprValue'>
-																<value/>
-															</LoopWhile>
-															<LoopStatus classname='ExprValue'>
-																<value/>
-															</LoopStatus>
-															<LoopIncrement classname='ExprValue'>
-																<value>RunState.LoopIndex += 1</value>
-															</LoopIncrement>
-															<LoopInitialize classname='ExprValue'>
-																<value>RunState.LoopIndex = 0</value>
-															</LoopInitialize>
-															<LoopOpt classname='Num'>
-																<value>0</value>
-															</LoopOpt>
-															<PreExpr classname='ExprValue'>
-																<value/>
-															</PreExpr>
-															<PostExpr classname='ExprValue'>
-																<value>RunState.Engine.TemporaryGlobals.SetValString("NI.MeasurementLink.PinMapId", 0x1, FileGlobals.MeasurementLink.PinMapPath)</value>
-															</PostExpr>
-															<StatusExpr classname='ExprValue'>
-																<value/>
-															</StatusExpr>
-															<CanSpecifyModule classname='Bool'>
-																<value>false</value>
-															</CanSpecifyModule>
-															<CanEditCode classname='Bool'>
-																<value>true</value>
-															</CanEditCode>
-															<CanEditModulePrototype classname='Bool'>
-																<value>true</value>
-															</CanEditModulePrototype>
-															<CanEditParameterAdditionalResults classname='Bool'>
-																<value>true</value>
-															</CanEditParameterAdditionalResults>
-															<PrecondIntExe classname='Num'>
-																<value>0</value>
-															</PrecondIntExe>
-															<CustomResults classname='Objs'>
-																<value lbound='[0]' ubound='[]'>
-																	<elemproto>
-																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-																			<subprops>
-																				<Name classname='ExprValue'>
-																					<value/>
-																				</Name>
-																				<ValueToLog classname='ExprValue'>
-																					<value/>
-																				</ValueToLog>
-																				<Condition classname='ExprValue'>
-																					<value/>
-																				</Condition>
-																				<Flags classname='Num'>
-																					<value>8192</value>
-																				</Flags>
-																				<CheckedState classname='Num'>
-																					<value>2</value>
-																				</CheckedState>
-																				<Type classname='PropertyObjectType'>
-																					<subprops>
-																						<ValueType classname='Num'>
-																							<value>3</value>
-																						</ValueType>
-																						<IsObject classname='Bool'>
-																							<value>true</value>
-																						</IsObject>
-																						<TypeName classname='Str'>
-																							<value/>
-																						</TypeName>
-																						<ElementType classname='Objs'>
-																							<value lbound='[0]' ubound='[]'/>
-																						</ElementType>
-																						<ArrayDimensions classname='ArrayDimensions'>
-																							<subprops>
-																								<LowerBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</LowerBounds>
-																								<UpperBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</UpperBounds>
-																							</subprops>
-																						</ArrayDimensions>
-																						<Representation classname='Num'>
-																							<value>1</value>
-																						</Representation>
-																						<ClassName classname='Str'>
-																							<value/>
-																						</ClassName>
-																					</subprops>
-																				</Type>
-																				<Elements classname='Objs'>
-																					<value lbound='[0]' ubound='[]'/>
-																				</Elements>
-																				<IsAnyType classname='Bool'>
-																					<value>true</value>
-																				</IsAnyType>
-																			</subprops>
-																		</_NAME_IN_ATTRIBUTE_>
-																	</elemproto>
-																</value>
-															</CustomResults>
-															<AdditionalResultsHints classname='Objs'>
-																<value lbound='[0]' ubound='[]'>
-																	<elemproto>
-																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-																			<subprops>
-																				<Name classname='ExprValue'>
-																					<value/>
-																				</Name>
-																				<ValueToLog classname='ExprValue'>
-																					<value/>
-																				</ValueToLog>
-																				<Condition classname='ExprValue'>
-																					<value/>
-																				</Condition>
-																				<Flags classname='Num'>
-																					<value>8192</value>
-																				</Flags>
-																				<CheckedState classname='Num'>
-																					<value>2</value>
-																				</CheckedState>
-																				<Type classname='PropertyObjectType'>
-																					<subprops>
-																						<ValueType classname='Num'>
-																							<value>3</value>
-																						</ValueType>
-																						<IsObject classname='Bool'>
-																							<value>true</value>
-																						</IsObject>
-																						<TypeName classname='Str'>
-																							<value/>
-																						</TypeName>
-																						<ElementType classname='Objs'>
-																							<value lbound='[0]' ubound='[]'/>
-																						</ElementType>
-																						<ArrayDimensions classname='ArrayDimensions'>
-																							<subprops>
-																								<LowerBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</LowerBounds>
-																								<UpperBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</UpperBounds>
-																							</subprops>
-																						</ArrayDimensions>
-																						<Representation classname='Num'>
-																							<value>1</value>
-																						</Representation>
-																						<ClassName classname='Str'>
-																							<value/>
-																						</ClassName>
-																					</subprops>
-																				</Type>
-																				<Elements classname='Objs'>
-																					<value lbound='[0]' ubound='[]'/>
-																				</Elements>
-																				<IsAnyType classname='Bool'>
-																					<value>true</value>
-																				</IsAnyType>
-																			</subprops>
-																		</_NAME_IN_ATTRIBUTE_>
-																	</elemproto>
-																</value>
-															</AdditionalResultsHints>
-														</subprops>
-													</TS>
-													<Result classname='Obj'>
-														<subprops>
-															<Error classname='Obj'>
-																<subprops>
-																	<Code classname='Num'>
-																		<value>0</value>
-																	</Code>
-																	<Msg classname='Str'>
-																		<value/>
-																	</Msg>
-																	<Occurred classname='Bool'>
-																		<value>false</value>
-																	</Occurred>
-																</subprops>
-															</Error>
-															<Status classname='Str'>
-																<value/>
-															</Status>
-															<ReportText classname='Str'>
-																<value/>
-															</ReportText>
-															<Common classname='Obj'/>
-														</subprops>
-													</Result>
-												</subprops>
-											</Step>
-										</value>
 									</value>
 								</Setup>
 								<Cleanup classname='Objs' valueflags='4194304'>
@@ -7363,186 +6773,6 @@
 							</subprops>
 						</Sequence>
 					</value>
-					<value>
-						<Sequence name='ProcessSetup'>
-							<comment>Test UUTs and Single Pass call this callback in their setup step group. It is empty in the model file.  Override this in the client file to perform an action before any code in the model executes.</comment>
-							<subprops>
-								<Parameters classname='Obj' valueflags='4456448'/>
-								<Locals classname='Obj' valueflags='4194304'>
-									<subprops>
-										<ResultList classname='Objs'>
-											<value lbound='[0]' ubound='[]'>
-												<elemproto>
-													<_NAME_IN_ATTRIBUTE_ name='' classname='TEResult'/>
-												</elemproto>
-											</value>
-										</ResultList>
-									</subprops>
-								</Locals>
-								<Main classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
-								</Main>
-								<Setup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
-								</Setup>
-								<Cleanup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
-								</Cleanup>
-								<RecordResults classname='Bool' valueflags='4194312'>
-									<value>false</value>
-								</RecordResults>
-								<RTS classname='Obj' valueflags='4456456'>
-									<subprops>
-										<Type classname='Num' valueflags='4194304'>
-											<value>0</value>
-										</Type>
-										<OptimizeNonReentrantCalls classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</OptimizeNonReentrantCalls>
-										<EPNameExpr classname='Str' valueflags='4194304'>
-											<value>"Unnamed Entry Point"</value>
-										</EPNameExpr>
-										<EPEnabledExpr classname='Str' valueflags='4194304'>
-											<value>True</value>
-										</EPEnabledExpr>
-										<EPMenuHint classname='Str' valueflags='4194304'>
-											<value/>
-										</EPMenuHint>
-										<EPIgnoreClient classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</EPIgnoreClient>
-										<EPInitiallyHidden classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</EPInitiallyHidden>
-										<EPCheckToSaveTitledFile classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</EPCheckToSaveTitledFile>
-										<ShowEPAlways classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPAlways>
-										<ShowEPForFileWin classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</ShowEPForFileWin>
-										<ShowEPForExeWin classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPForExeWin>
-										<ShowEPForEditorOnly classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPForEditorOnly>
-										<CopyStepsOnOverriding classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</CopyStepsOnOverriding>
-										<Priority classname='Num' valueflags='4194304'>
-											<value>2953567917</value>
-										</Priority>
-										<AllowIntExeOfEP classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</AllowIntExeOfEP>
-									</subprops>
-								</RTS>
-								<Requirements classname='Obj' valueflags='4456456'>
-									<subprops>
-										<Links classname='Strs' valueflags='71303168'>
-											<value lbound='[0]' ubound='[]'/>
-										</Links>
-									</subprops>
-								</Requirements>
-								<FailureAction classname='Num' valueflags='4194312'>
-									<value>2</value>
-								</FailureAction>
-							</subprops>
-						</Sequence>
-					</value>
-					<value>
-						<Sequence name='ProcessCleanup'>
-							<comment>Test UUTs and Single Pass call this callback in their cleanup step group. It is empty in the model file.  Override this in the client file to perform an action after all code in the model executes and just before the execution completes.</comment>
-							<subprops>
-								<Parameters classname='Obj' valueflags='4456448'/>
-								<Locals classname='Obj' valueflags='4194304'>
-									<subprops>
-										<ResultList classname='Objs'>
-											<value lbound='[0]' ubound='[]'>
-												<elemproto>
-													<_NAME_IN_ATTRIBUTE_ name='' classname='TEResult'/>
-												</elemproto>
-											</value>
-										</ResultList>
-									</subprops>
-								</Locals>
-								<Main classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
-								</Main>
-								<Setup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
-								</Setup>
-								<Cleanup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
-								</Cleanup>
-								<RecordResults classname='Bool' valueflags='4194312'>
-									<value>false</value>
-								</RecordResults>
-								<RTS classname='Obj' valueflags='4456456'>
-									<subprops>
-										<Type classname='Num' valueflags='4194304'>
-											<value>0</value>
-										</Type>
-										<OptimizeNonReentrantCalls classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</OptimizeNonReentrantCalls>
-										<EPNameExpr classname='Str' valueflags='4194304'>
-											<value>"Unnamed Entry Point"</value>
-										</EPNameExpr>
-										<EPEnabledExpr classname='Str' valueflags='4194304'>
-											<value>True</value>
-										</EPEnabledExpr>
-										<EPMenuHint classname='Str' valueflags='4194304'>
-											<value/>
-										</EPMenuHint>
-										<EPIgnoreClient classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</EPIgnoreClient>
-										<EPInitiallyHidden classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</EPInitiallyHidden>
-										<EPCheckToSaveTitledFile classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</EPCheckToSaveTitledFile>
-										<ShowEPAlways classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPAlways>
-										<ShowEPForFileWin classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</ShowEPForFileWin>
-										<ShowEPForExeWin classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPForExeWin>
-										<ShowEPForEditorOnly classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPForEditorOnly>
-										<CopyStepsOnOverriding classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</CopyStepsOnOverriding>
-										<Priority classname='Num' valueflags='4194304'>
-											<value>2953567917</value>
-										</Priority>
-										<AllowIntExeOfEP classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</AllowIntExeOfEP>
-									</subprops>
-								</RTS>
-								<Requirements classname='Obj' valueflags='4456456'>
-									<subprops>
-										<Links classname='Strs' valueflags='71303168'>
-											<value lbound='[0]' ubound='[]'/>
-										</Links>
-									</subprops>
-								</Requirements>
-								<FailureAction classname='Num' valueflags='4194312'>
-									<value>2</value>
-								</FailureAction>
-							</subprops>
-						</Sequence>
-					</value>
 				</value>
 			</Seq>
 			<FileGlobalDefaults classname='Obj' valueflags='4194304'>
@@ -7552,11 +6782,8 @@
 							<EnableMonitoring classname='Bool'>
 								<value>false</value>
 							</EnableMonitoring>
-							<PinMapFileName classname='Str'>
-								<value>NIScopeAcquireWaveform.pinmap</value>
-							</PinMapFileName>
 							<PinMapPath typename='Path' xsi:type='Path' classname='PathValue'>
-								<value/>
+								<value>NIScopeAcquireWaveform.pinmap</value>
 							</PinMapPath>
 						</subprops>
 					</MeasurementLink>

--- a/examples/niscope_acquire_waveform/README.md
+++ b/examples/niscope_acquire_waveform/README.md
@@ -12,7 +12,10 @@ This is a MeasurementLink example that acquires a waveform using an NI oscillosc
 - Includes InstrumentStudio and MeasurementLink UI Editor project files
 - Includes a TestStand sequence showing how to configure the pin map, register
   instrument sessions with the session management service, and run a measurement
-  - For the sake of simplicity, the TestStand sequence handles pin map and session registration and unregistration in the `Setup` and `Cleanup` sections of the main sequence. For **Test UUTs** and batch process model use cases, these steps should be moved to the `ProcessSetup` and `ProcessCleanup` callbacks.
+  - For the sake of simplicity, the TestStand sequence handles pin map and session
+    registration and unregistration in the `Setup` and `Cleanup` sections of the main 
+    sequence. For **Test UUTs** and batch process model use cases, these steps should 
+    be moved to the `ProcessSetup` and `ProcessCleanup` callbacks.
 - Uses the NI gRPC Device Server to allow sharing instrument sessions with other
   measurement services when running measurements from TestStand
 

--- a/examples/niscope_acquire_waveform/README.md
+++ b/examples/niscope_acquire_waveform/README.md
@@ -12,6 +12,7 @@ This is a MeasurementLink example that acquires a waveform using an NI oscillosc
 - Includes InstrumentStudio and MeasurementLink UI Editor project files
 - Includes a TestStand sequence showing how to configure the pin map, register
   instrument sessions with the session management service, and run a measurement
+  - For the sake of simplicity, the TestStand sequence handles pin map and session registration and unregistration in the `Setup` and `Cleanup` sections of the main sequence. For **Test UUTs** and batch process model use cases, these steps should be moved to the `ProcessSetup` and `ProcessCleanup` callbacks.
 - Uses the NI gRPC Device Server to allow sharing instrument sessions with other
   measurement services when running measurements from TestStand
 

--- a/examples/niscope_acquire_waveform/teststand_fixture.py
+++ b/examples/niscope_acquire_waveform/teststand_fixture.py
@@ -1,33 +1,50 @@
 """Functions to set up and tear down sessions of NI-Scope devices in NI TestStand."""
+from typing import Any
 
 import niscope
-from _helpers import GrpcChannelPoolHelper, PinMapClient
+from _helpers import GrpcChannelPoolHelper, PinMapClient, TestStandSupport
 
 import ni_measurementlink_service as nims
 
 
-def update_pin_map(pin_map_id: str) -> None:
+def update_pin_map(pin_map_path: str, sequence_context: Any) -> None:
     """Update registered pin map contents.
 
     Create and register a pin map if a pin map resource for the specified pin map id is not found.
 
     Args:
-        pin_map_id (str): The resource id of the pin map to register as a pin map resource. By
-            convention, the pin_map_id is the .pinmap file path.
-
+        pin_map_path:
+            An absolute or relative path to the pin map file.
+        sequence_context:
+            The SequenceContext COM object from the TestStand sequence execution.
+            (Dynamically typed.)
     """
+    teststand_support = TestStandSupport(sequence_context)
+    pin_map_abs_path = teststand_support.resolve_file_path(pin_map_path)
+
     with GrpcChannelPoolHelper() as grpc_channel_pool:
         pin_map_client = PinMapClient(grpc_channel=grpc_channel_pool.pin_map_channel)
-        pin_map_client.update_pin_map(pin_map_id)
+        pin_map_id = pin_map_client.update_pin_map(pin_map_abs_path)
+
+    teststand_support.set_active_pin_map_id(pin_map_id)
 
 
-def create_niscope_sessions(pin_map_id: str) -> None:
-    """Create and register all NI-Scope sessions."""
+def create_niscope_sessions(sequence_context: Any) -> None:
+    """Create and register all NI-Scope sessions.
+
+    Args:
+        sequence_context:
+            The SequenceContext COM object from the TestStand sequence execution.
+            (Dynamically typed.)
+    """
     with GrpcChannelPoolHelper() as grpc_channel_pool:
         session_management_client = nims.session_management.Client(
             grpc_channel=grpc_channel_pool.session_management_channel
         )
 
+        teststand_support = TestStandSupport(sequence_context)
+        pin_map_id = teststand_support.get_active_pin_map_id()
+        
         pin_map_context = nims.session_management.PinMapContext(pin_map_id=pin_map_id, sites=None)
         with session_management_client.reserve_sessions(
             context=pin_map_context,

--- a/examples/niscope_acquire_waveform/teststand_fixture.py
+++ b/examples/niscope_acquire_waveform/teststand_fixture.py
@@ -44,7 +44,7 @@ def create_niscope_sessions(sequence_context: Any) -> None:
 
         teststand_support = TestStandSupport(sequence_context)
         pin_map_id = teststand_support.get_active_pin_map_id()
-        
+
         pin_map_context = nims.session_management.PinMapContext(pin_map_id=pin_map_id, sites=None)
         with session_management_client.reserve_sessions(
             context=pin_map_context,

--- a/examples/niswitch_control_relays/NISwitchControlRelays.seq
+++ b/examples/niswitch_control_relays/NISwitchControlRelays.seq
@@ -6469,7 +6469,7 @@
 	<Data classname='SequenceFileData' valueflags='4194304'>
 		<subprops>
 			<Seq classname='Objs' valueflags='4194304'>
-				<value lbound='[0]' ubound='[2]'>
+				<value lbound='[0]' ubound='[0]'>
 					<value>
 						<Sequence name='MainSequence'>
 							<subprops>
@@ -7636,93 +7636,6 @@
 									</value>
 								</Main>
 								<Setup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
-								</Setup>
-								<Cleanup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
-								</Cleanup>
-								<RecordResults classname='Bool' valueflags='4194312'>
-									<value>true</value>
-								</RecordResults>
-								<RTS classname='Obj' valueflags='4456456'>
-									<subprops>
-										<Type classname='Num' valueflags='4194304'>
-											<value>0</value>
-										</Type>
-										<OptimizeNonReentrantCalls classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</OptimizeNonReentrantCalls>
-										<EPNameExpr classname='Str' valueflags='4194304'>
-											<value>"Unnamed Entry Point"</value>
-										</EPNameExpr>
-										<EPEnabledExpr classname='Str' valueflags='4194304'>
-											<value>True</value>
-										</EPEnabledExpr>
-										<EPMenuHint classname='Str' valueflags='4194304'>
-											<value/>
-										</EPMenuHint>
-										<EPIgnoreClient classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</EPIgnoreClient>
-										<EPInitiallyHidden classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</EPInitiallyHidden>
-										<EPCheckToSaveTitledFile classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</EPCheckToSaveTitledFile>
-										<ShowEPAlways classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPAlways>
-										<ShowEPForFileWin classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</ShowEPForFileWin>
-										<ShowEPForExeWin classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPForExeWin>
-										<ShowEPForEditorOnly classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPForEditorOnly>
-										<AllowIntExeOfEP classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</AllowIntExeOfEP>
-										<CopyStepsOnOverriding classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</CopyStepsOnOverriding>
-										<Priority classname='Num' valueflags='4194304'>
-											<value>2953567917</value>
-										</Priority>
-									</subprops>
-								</RTS>
-								<Requirements classname='Obj' valueflags='4456456'>
-									<subprops>
-										<Links classname='Strs' valueflags='71303168'>
-											<value lbound='[0]' ubound='[]'/>
-										</Links>
-									</subprops>
-								</Requirements>
-								<FailureAction classname='Num' valueflags='4194312'>
-									<value>2</value>
-								</FailureAction>
-							</subprops>
-						</Sequence>
-					</value>
-					<value>
-						<Sequence name='ProcessSetup'>
-							<comment>Test UUTs and Single Pass call this callback in their setup step group. It is empty in the model file.  Override this in the client file to perform an action before any code in the model executes.</comment>
-							<subprops>
-								<Parameters classname='Obj' valueflags='4456448'/>
-								<Locals classname='Obj' valueflags='4194304'>
-									<subprops>
-										<ResultList classname='Objs'>
-											<value lbound='[0]' ubound='[]'>
-												<elemproto>
-													<_NAME_IN_ATTRIBUTE_ name='' classname='TEResult'/>
-												</elemproto>
-											</value>
-										</ResultList>
-									</subprops>
-								</Locals>
-								<Main classname='Objs' valueflags='4194304'>
 									<value lbound='[0]' ubound='[3]'>
 										<value>
 											<Step typename='Statement' xsi:type='Statement' name='Get absolute path to pinmap file'>
@@ -8071,7 +7984,7 @@
 																				<value>update_pin_map</value>
 																			</FunctionOrAttributeName>
 																			<Parameters classname='Objs'>
-																				<value lbound='[0]' ubound='[1]'>
+																				<value lbound='[0]' ubound='[2]'>
 																					<elemproto>
 																						<_NAME_IN_ATTRIBUTE_ name='' classname='CPythonParameter' structureflags='0'/>
 																					</elemproto>
@@ -8127,7 +8040,7 @@
 																						<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
 																							<subprops>
 																								<Name classname='Str'>
-																									<value>pin_map_id</value>
+																									<value>pin_map_path</value>
 																								</Name>
 																								<Type classname='Num'>
 																									<value>7</value>
@@ -8149,7 +8062,55 @@
 																													<value>8192</value>
 																												</Flags>
 																												<CheckedState classname='Num'>
+																													<value>2</value>
+																												</CheckedState>
+																											</subprops>
+																										</Input>
+																										<Output classname='PythonParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
 																													<value>1</value>
+																												</CheckedState>
+																											</subprops>
+																										</Output>
+																									</subprops>
+																								</AdditionalResults>
+																							</subprops>
+																						</CPythonParameter>
+																					</value>
+																					<value>
+																						<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
+																							<subprops>
+																								<Name classname='Str'>
+																									<value>sequence_context</value>
+																								</Name>
+																								<Type classname='Num'>
+																									<value>7</value>
+																								</Type>
+																								<ArgumentValue classname='ExprValue'>
+																									<value>ThisContext</value>
+																								</ArgumentValue>
+																								<ArgumentDisplayValue classname='ExprValue'>
+																									<value/>
+																								</ArgumentDisplayValue>
+																								<AdditionalResults classname='Obj'>
+																									<subprops>
+																										<Input classname='PythonParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
+																													<value>2</value>
 																												</CheckedState>
 																											</subprops>
 																										</Input>
@@ -8572,13 +8533,13 @@
 																						<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
 																							<subprops>
 																								<Name classname='Str'>
-																									<value>pin_map_id</value>
+																									<value>sequence_context</value>
 																								</Name>
 																								<Type classname='Num'>
 																									<value>7</value>
 																								</Type>
 																								<ArgumentValue classname='ExprValue'>
-																									<value>FileGlobals.MeasurementLink.PinMapPath</value>
+																									<value>ThisContext</value>
 																								</ArgumentValue>
 																								<ArgumentDisplayValue classname='ExprValue'>
 																									<value/>
@@ -8594,7 +8555,7 @@
 																													<value>8192</value>
 																												</Flags>
 																												<CheckedState classname='Num'>
-																													<value>1</value>
+																													<value>2</value>
 																												</CheckedState>
 																											</subprops>
 																										</Input>
@@ -9205,95 +9166,8 @@
 											</Step>
 										</value>
 									</value>
-								</Main>
-								<Setup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
 								</Setup>
 								<Cleanup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
-								</Cleanup>
-								<RecordResults classname='Bool' valueflags='4194312'>
-									<value>false</value>
-								</RecordResults>
-								<RTS classname='Obj' valueflags='4456456'>
-									<subprops>
-										<Type classname='Num' valueflags='4194304'>
-											<value>0</value>
-										</Type>
-										<OptimizeNonReentrantCalls classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</OptimizeNonReentrantCalls>
-										<EPNameExpr classname='Str' valueflags='4194304'>
-											<value>"Unnamed Entry Point"</value>
-										</EPNameExpr>
-										<EPEnabledExpr classname='Str' valueflags='4194304'>
-											<value>True</value>
-										</EPEnabledExpr>
-										<EPMenuHint classname='Str' valueflags='4194304'>
-											<value/>
-										</EPMenuHint>
-										<EPIgnoreClient classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</EPIgnoreClient>
-										<EPInitiallyHidden classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</EPInitiallyHidden>
-										<EPCheckToSaveTitledFile classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</EPCheckToSaveTitledFile>
-										<ShowEPAlways classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPAlways>
-										<ShowEPForFileWin classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</ShowEPForFileWin>
-										<ShowEPForExeWin classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPForExeWin>
-										<ShowEPForEditorOnly classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPForEditorOnly>
-										<CopyStepsOnOverriding classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</CopyStepsOnOverriding>
-										<Priority classname='Num' valueflags='4194304'>
-											<value>2953567917</value>
-										</Priority>
-										<AllowIntExeOfEP classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</AllowIntExeOfEP>
-									</subprops>
-								</RTS>
-								<Requirements classname='Obj' valueflags='4456456'>
-									<subprops>
-										<Links classname='Strs' valueflags='71303168'>
-											<value lbound='[0]' ubound='[]'/>
-										</Links>
-									</subprops>
-								</Requirements>
-								<FailureAction classname='Num' valueflags='4194312'>
-									<value>2</value>
-								</FailureAction>
-							</subprops>
-						</Sequence>
-					</value>
-					<value>
-						<Sequence name='ProcessCleanup'>
-							<comment>Test UUTs and Single Pass call this callback in their cleanup step group. It is empty in the model file.  Override this in the client file to perform an action after all code in the model executes and just before the execution completes.</comment>
-							<subprops>
-								<Parameters classname='Obj' valueflags='4456448'/>
-								<Locals classname='Obj' valueflags='4194304'>
-									<subprops>
-										<ResultList classname='Objs'>
-											<value lbound='[0]' ubound='[]'>
-												<elemproto>
-													<_NAME_IN_ATTRIBUTE_ name='' classname='TEResult'/>
-												</elemproto>
-											</value>
-										</ResultList>
-									</subprops>
-								</Locals>
-								<Main classname='Objs' valueflags='4194304'>
 									<value lbound='[0]' ubound='[1]'>
 										<value>
 											<Step typename='Statement' xsi:type='Statement' name='Unregister active PinMapId'>
@@ -9988,15 +9862,9 @@
 											</Step>
 										</value>
 									</value>
-								</Main>
-								<Setup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
-								</Setup>
-								<Cleanup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
 								</Cleanup>
 								<RecordResults classname='Bool' valueflags='4194312'>
-									<value>false</value>
+									<value>true</value>
 								</RecordResults>
 								<RTS classname='Obj' valueflags='4456456'>
 									<subprops>
@@ -10036,15 +9904,15 @@
 										<ShowEPForEditorOnly classname='Bool' valueflags='4194304'>
 											<value>false</value>
 										</ShowEPForEditorOnly>
+										<AllowIntExeOfEP classname='Bool' valueflags='4194304'>
+											<value>false</value>
+										</AllowIntExeOfEP>
 										<CopyStepsOnOverriding classname='Bool' valueflags='4194304'>
 											<value>true</value>
 										</CopyStepsOnOverriding>
 										<Priority classname='Num' valueflags='4194304'>
 											<value>2953567917</value>
 										</Priority>
-										<AllowIntExeOfEP classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</AllowIntExeOfEP>
 									</subprops>
 								</RTS>
 								<Requirements classname='Obj' valueflags='4456456'>

--- a/examples/niswitch_control_relays/NISwitchControlRelays.seq
+++ b/examples/niswitch_control_relays/NISwitchControlRelays.seq
@@ -4649,6 +4649,647 @@
 				</subprops>
 			</NI_Wait>
 		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='21'>
+			<Action classname='StepType' isroottypedef='true' typecategory='1' timestamp='1618215606' typeversion='21.0.0.2' typelastmodversion='21.0.0.0' typeminprodversion='21.0.0.0' typeflags='33554446'>
+				<subprops>
+					<Substeps typename='StepTypeSubstepsArray' xsi:type='StepTypeSubstepsArray' classname='Objs' flagsforinstances='524312' instanceoverrideflags='655384'>
+						<value lbound='[0]' ubound='[]'/>
+					</Substeps>
+					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
+						<value>ResStr("NI_STEPTYPES", "ACTION_DESCRIPTION_NAME") + (("%ModuleDescription" == "") ? "" : ",  %ModuleDescription")</value>
+					</DescriptionFormat>
+					<DefaultNameFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
+						<value>ResStr("NI_STEPTYPES", "ACTION_DEF_STEP_NAME")</value>
+					</DefaultNameFormat>
+					<Menu typename='StepTypeMenu' xsi:type='StepTypeMenu' classname='Obj' flagsforinstances='524312' instanceoverrideflags='524312'>
+						<subprops>
+							<CanBeSubstepType classname='Bool'>
+								<value>false</value>
+							</CanBeSubstepType>
+							<CanOnlyBeSubstepType classname='Bool'>
+								<value>false</value>
+							</CanOnlyBeSubstepType>
+							<Category classname='Str'>
+								<value>""</value>
+							</Category>
+							<ItemName classname='ExprValue'>
+								<value>ResStr("NI_STEPTYPES", "ACTION_MENU_ITEM_NAME")</value>
+							</ItemName>
+							<SingularItemName classname='Str'>
+								<value>""</value>
+							</SingularItemName>
+							<SeparatorBeforeCategory classname='Bool'>
+								<value>false</value>
+							</SeparatorBeforeCategory>
+							<SeparatorBeforeItemName classname='Bool'>
+								<value>false</value>
+							</SeparatorBeforeItemName>
+							<Group classname='Str'>
+								<value>Action</value>
+							</Group>
+						</subprops>
+					</Menu>
+					<AdditionalResultsHints classname='Objs' valueflags='4194328' structureflags='524288'>
+						<value lbound='[0]' ubound='[]'>
+							<elemproto>
+								<_NAME_IN_ATTRIBUTE_ typename='NI_CustomResult' xsi:type='NI_CustomResult' name='' classname='CustomResult'>
+									<subprops>
+										<Name classname='ExprValue'>
+											<value/>
+										</Name>
+										<ValueToLog classname='ExprValue'>
+											<value/>
+										</ValueToLog>
+										<Condition classname='ExprValue'>
+											<value/>
+										</Condition>
+										<Flags classname='Num'>
+											<value>8192</value>
+										</Flags>
+										<CheckedState classname='Num'>
+											<value>2</value>
+										</CheckedState>
+										<Type classname='PropertyObjectType'>
+											<subprops>
+												<ValueType classname='Num'>
+													<value>3</value>
+												</ValueType>
+												<IsObject classname='Bool'>
+													<value>true</value>
+												</IsObject>
+												<TypeName classname='Str'>
+													<value/>
+												</TypeName>
+												<ElementType classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</ElementType>
+												<ArrayDimensions classname='ArrayDimensions'>
+													<subprops>
+														<LowerBounds classname='Nums'>
+															<value lbound='[0]' ubound='[]'/>
+														</LowerBounds>
+														<UpperBounds classname='Nums'>
+															<value lbound='[0]' ubound='[]'/>
+														</UpperBounds>
+													</subprops>
+												</ArrayDimensions>
+												<Representation classname='Num'>
+													<value>1</value>
+												</Representation>
+												<ClassName classname='Str'>
+													<value/>
+												</ClassName>
+											</subprops>
+										</Type>
+										<Elements classname='Objs'>
+											<value lbound='[0]' ubound='[]'/>
+										</Elements>
+										<IsAnyType classname='Bool'>
+											<value>true</value>
+										</IsAnyType>
+									</subprops>
+								</_NAME_IN_ATTRIBUTE_>
+							</elemproto>
+						</value>
+					</AdditionalResultsHints>
+					<TS typename='TEInf' xsi:type='TEInf' classname='Obj' flagsforinstances='262168' instanceoverrideflags='4456472'>
+						<subprops>
+							<Id classname='Str'>
+								<value/>
+							</Id>
+							<Icon classname='Str'>
+								<value/>
+							</Icon>
+							<SData classname='Obj' flagsforinstances='2097152' instanceoverrideflags='7143448' structureflags='2097152'/>
+							<PreCond classname='ExprValue'>
+								<value/>
+							</PreCond>
+							<LoadOpt classname='Str'>
+								<value>PreloadWhenExecuted</value>
+							</LoadOpt>
+							<UnloadOpt classname='Str'>
+								<value>UnloadWithFile</value>
+							</UnloadOpt>
+							<Mode classname='Str'>
+								<value>Normal</value>
+							</Mode>
+							<WindowActivation classname='Str'>
+								<value>None</value>
+							</WindowActivation>
+							<ResultOption classname='Num'>
+								<value>1</value>
+							</ResultOption>
+							<StepFCSeqF classname='Bool'>
+								<value>true</value>
+							</StepFCSeqF>
+							<IgnoreRTE classname='Bool'>
+								<value>false</value>
+							</IgnoreRTE>
+							<UseMutex classname='Bool'>
+								<value>false</value>
+							</UseMutex>
+							<MutexNameOrRef classname='ExprValue'>
+								<value/>
+							</MutexNameOrRef>
+							<BatchSyncOpt classname='Num'>
+								<value>0</value>
+							</BatchSyncOpt>
+							<SwitchEnabled classname='Bool'>
+								<value>false</value>
+							</SwitchEnabled>
+							<VirtualDeviceName classname='ExprValue'>
+								<value/>
+							</VirtualDeviceName>
+							<SwitchOperation classname='Num'>
+								<value>1</value>
+							</SwitchOperation>
+							<RouteGroupConnect classname='ExprValue'>
+								<value/>
+							</RouteGroupConnect>
+							<RouteGroupDisconnect classname='ExprValue'>
+								<value/>
+							</RouteGroupDisconnect>
+							<MulticonnectMode classname='Num'>
+								<value>1</value>
+							</MulticonnectMode>
+							<OperationOrder classname='Num'>
+								<value>2</value>
+							</OperationOrder>
+							<ConnectionLifetime classname='Num'>
+								<value>0</value>
+							</ConnectionLifetime>
+							<WaitForDebounce classname='Bool'>
+								<value>true</value>
+							</WaitForDebounce>
+							<PassAct classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
+								<value>Next</value>
+							</PassAct>
+							<FailAct classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
+								<value>Next</value>
+							</FailAct>
+							<PassActTarget classname='ExprValue' flagsforinstances='1' instanceoverrideflags='5046297'>
+								<value/>
+							</PassActTarget>
+							<FailActTarget classname='ExprValue' flagsforinstances='1' instanceoverrideflags='5046297'>
+								<value/>
+							</FailActTarget>
+							<CustExpr classname='ExprValue'>
+								<value/>
+							</CustExpr>
+							<CustTrueAct classname='Str'>
+								<value>Next</value>
+							</CustTrueAct>
+							<CustFalseAct classname='Str'>
+								<value>Next</value>
+							</CustFalseAct>
+							<CustTrueActTarget classname='ExprValue'>
+								<value/>
+							</CustTrueActTarget>
+							<CustFalseActTarget classname='ExprValue'>
+								<value/>
+							</CustFalseActTarget>
+							<LoopType classname='Str'>
+								<value>NoLooping</value>
+							</LoopType>
+							<LoopWhile classname='ExprValue'>
+								<value/>
+							</LoopWhile>
+							<LoopStatus classname='ExprValue'>
+								<value/>
+							</LoopStatus>
+							<LoopIncrement classname='ExprValue'>
+								<value>RunState.LoopIndex += 1</value>
+							</LoopIncrement>
+							<LoopInitialize classname='ExprValue'>
+								<value>RunState.LoopIndex = 0</value>
+							</LoopInitialize>
+							<LoopOpt classname='Num'>
+								<value>0</value>
+							</LoopOpt>
+							<PreExpr classname='ExprValue'>
+								<value/>
+							</PreExpr>
+							<PostExpr classname='ExprValue'>
+								<value/>
+							</PostExpr>
+							<StatusExpr classname='ExprValue'>
+								<value/>
+							</StatusExpr>
+							<CanSpecifyModule classname='Bool'>
+								<value>true</value>
+							</CanSpecifyModule>
+							<CanEditCode classname='Bool'>
+								<value>true</value>
+							</CanEditCode>
+							<CanEditModulePrototype classname='Bool'>
+								<value>true</value>
+							</CanEditModulePrototype>
+							<CanEditParameterAdditionalResults classname='Bool'>
+								<value>true</value>
+							</CanEditParameterAdditionalResults>
+							<PrecondIntExe classname='Num'>
+								<value>0</value>
+							</PrecondIntExe>
+							<Requirements classname='Obj' flagsforinstances='1' valueflags='1' structureflags='2097152'>
+								<subprops>
+									<Links classname='Strs' flagsforinstances='71303168' instanceoverrideflags='72286233' valueflags='71303168'>
+										<value lbound='[0]' ubound='[]'/>
+									</Links>
+								</subprops>
+							</Requirements>
+							<CustomResults classname='Objs'>
+								<value lbound='[0]' ubound='[]'>
+									<elemproto>
+										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+											<subprops>
+												<Name classname='ExprValue'>
+													<value/>
+												</Name>
+												<ValueToLog classname='ExprValue'>
+													<value/>
+												</ValueToLog>
+												<Condition classname='ExprValue'>
+													<value/>
+												</Condition>
+												<Flags classname='Num'>
+													<value>8192</value>
+												</Flags>
+												<CheckedState classname='Num'>
+													<value>2</value>
+												</CheckedState>
+												<Type classname='PropertyObjectType'>
+													<subprops>
+														<ValueType classname='Num'>
+															<value>3</value>
+														</ValueType>
+														<IsObject classname='Bool'>
+															<value>true</value>
+														</IsObject>
+														<TypeName classname='Str'>
+															<value/>
+														</TypeName>
+														<ElementType classname='Objs'>
+															<value lbound='[0]' ubound='[]'/>
+														</ElementType>
+														<ArrayDimensions classname='ArrayDimensions'>
+															<subprops>
+																<LowerBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</LowerBounds>
+																<UpperBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</UpperBounds>
+															</subprops>
+														</ArrayDimensions>
+														<Representation classname='Num'>
+															<value>1</value>
+														</Representation>
+														<ClassName classname='Str'>
+															<value/>
+														</ClassName>
+													</subprops>
+												</Type>
+												<Elements classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</Elements>
+												<IsAnyType classname='Bool'>
+													<value>true</value>
+												</IsAnyType>
+											</subprops>
+										</_NAME_IN_ATTRIBUTE_>
+									</elemproto>
+								</value>
+							</CustomResults>
+							<AdditionalResultsHints classname='Objs'>
+								<value lbound='[0]' ubound='[]'>
+									<elemproto>
+										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+											<subprops>
+												<Name classname='ExprValue'>
+													<value/>
+												</Name>
+												<ValueToLog classname='ExprValue'>
+													<value/>
+												</ValueToLog>
+												<Condition classname='ExprValue'>
+													<value/>
+												</Condition>
+												<Flags classname='Num'>
+													<value>8192</value>
+												</Flags>
+												<CheckedState classname='Num'>
+													<value>2</value>
+												</CheckedState>
+												<Type classname='PropertyObjectType'>
+													<subprops>
+														<ValueType classname='Num'>
+															<value>3</value>
+														</ValueType>
+														<IsObject classname='Bool'>
+															<value>true</value>
+														</IsObject>
+														<TypeName classname='Str'>
+															<value/>
+														</TypeName>
+														<ElementType classname='Objs'>
+															<value lbound='[0]' ubound='[]'/>
+														</ElementType>
+														<ArrayDimensions classname='ArrayDimensions'>
+															<subprops>
+																<LowerBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</LowerBounds>
+																<UpperBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</UpperBounds>
+															</subprops>
+														</ArrayDimensions>
+														<Representation classname='Num'>
+															<value>1</value>
+														</Representation>
+														<ClassName classname='Str'>
+															<value/>
+														</ClassName>
+													</subprops>
+												</Type>
+												<Elements classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</Elements>
+												<IsAnyType classname='Bool'>
+													<value>true</value>
+												</IsAnyType>
+											</subprops>
+										</_NAME_IN_ATTRIBUTE_>
+									</elemproto>
+								</value>
+							</AdditionalResultsHints>
+						</subprops>
+					</TS>
+					<NI_Data typename='StepTypeNIData' xsi:type='StepTypeNIData' classname='Obj'>
+						<subprops>
+							<EditPanels classname='Strs'>
+								<value lbound='[0]' ubound='[]'/>
+							</EditPanels>
+						</subprops>
+					</NI_Data>
+					<Result classname='Obj' flagsforinstances='4194304' valueflags='4194304'>
+						<subprops>
+							<Error typename='Error' xsi:type='Error' classname='Obj' flagsforinstances='4194304' instanceoverrideflags='4194304' valueflags='4194304'>
+								<subprops>
+									<Code classname='Num'>
+										<value>0</value>
+									</Code>
+									<Msg classname='Str'>
+										<value/>
+									</Msg>
+									<Occurred classname='Bool'>
+										<value>false</value>
+									</Occurred>
+								</subprops>
+							</Error>
+							<Status classname='Str' flagsforinstances='4194304' valueflags='4194304'>
+								<value/>
+							</Status>
+							<ReportText classname='Str' flagsforinstances='4194304' valueflags='4194304'>
+								<value/>
+							</ReportText>
+							<Common typename='CommonResults' xsi:type='CommonResults' classname='Obj' instanceoverrideflags='4194304'/>
+						</subprops>
+					</Result>
+					<CodeTemplates classname='Str' valueflags='4194328' structureflags='524288'>
+						<value>DefaultLabVIEW|DefaultLabVIEWNXG|DefaultCVI|DefaultVB.NET|DefaultCSharp.NET|DefaultC++.NET|DefaultVC++_Template|DefaultHTB72_Template|DefaultHTB80_Template|Default_Template</value>
+					</CodeTemplates>
+					<BlockStartTypes classname='Str' valueflags='4194328' structureflags='524288'>
+						<value/>
+					</BlockStartTypes>
+					<BlockEndTypes classname='Str' valueflags='4194328' structureflags='524288'>
+						<value/>
+					</BlockEndTypes>
+					<AppliesToBlockStructure classname='Bool' valueflags='4194328' structureflags='524288'>
+						<value>false</value>
+					</AppliesToBlockStructure>
+					<CanEncapsulate classname='Bool' valueflags='4194328' structureflags='524288'>
+						<value>false</value>
+					</CanEncapsulate>
+					<Category classname='Str' valueflags='24' structureflags='524288'>
+						<value>Action</value>
+					</Category>
+				</subprops>
+			</Action>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='29'>
+			<NI_PythonParameterResult classname='PythonParameterResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+				<subprops>
+					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</Condition>
+					<Flags classname='Num'>
+						<value>8192</value>
+						<numericfmt>%#x</numericfmt>
+					</Flags>
+					<CheckedState classname='Num'>
+						<value>1</value>
+					</CheckedState>
+				</subprops>
+			</NI_PythonParameterResult>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='28'>
+			<NI_PythonParameter classname='CPythonParameter' isroottypedef='true' typecategory='3' timestamp='1650060872' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+				<subprops>
+					<Name classname='Str'>
+						<value>_notNamed</value>
+					</Name>
+					<Type classname='Num'>
+						<value>7</value>
+					</Type>
+					<ArgumentValue typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</ArgumentValue>
+					<ArgumentDisplayValue typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</ArgumentDisplayValue>
+					<AdditionalResults classname='Obj'>
+						<subprops>
+							<Input typename='NI_PythonParameterResult' xsi:type='NI_PythonParameterResult' classname='PythonParameterResult'>
+								<subprops>
+									<Condition classname='ExprValue'>
+										<value/>
+									</Condition>
+									<Flags classname='Num'>
+										<value>8192</value>
+									</Flags>
+									<CheckedState classname='Num'>
+										<value>1</value>
+									</CheckedState>
+								</subprops>
+							</Input>
+							<Output typename='NI_PythonParameterResult' xsi:type='NI_PythonParameterResult' classname='PythonParameterResult'>
+								<subprops>
+									<Condition classname='ExprValue'>
+										<value/>
+									</Condition>
+									<Flags classname='Num'>
+										<value>8192</value>
+									</Flags>
+									<CheckedState classname='Num'>
+										<value>1</value>
+									</CheckedState>
+								</subprops>
+							</Output>
+						</subprops>
+					</AdditionalResults>
+				</subprops>
+			</NI_PythonParameter>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='27'>
+			<PythonStepAdditions classname='CPythonModule' isroottypedef='true' typecategory='3' timestamp='1650060872' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+				<subprops>
+					<PythonCall classname='CPythonCall'>
+						<subprops>
+							<UseAdapterSettingsForInterpreterSession classname='Bool'>
+								<value>true</value>
+							</UseAdapterSettingsForInterpreterSession>
+							<InterpreterSessionScope classname='Num'>
+								<value>3</value>
+							</InterpreterSessionScope>
+							<PythonVersion classname='Str'>
+								<value/>
+							</PythonVersion>
+							<PythonVirtualEnvironmentPath classname='Str'>
+								<value/>
+							</PythonVirtualEnvironmentPath>
+							<InterpreterLocation typename='Expression' xsi:type='Expression' classname='ExprValue'>
+								<value/>
+							</InterpreterLocation>
+							<CreateIfInterpreterDoesNotExist classname='Bool'>
+								<value>true</value>
+							</CreateIfInterpreterDoesNotExist>
+							<ModulePath typename='Path' xsi:type='Path' classname='PathValue'>
+								<value/>
+							</ModulePath>
+							<OperationType classname='Num'>
+								<value>1</value>
+							</OperationType>
+							<OperationScope classname='Num'>
+								<value>0</value>
+							</OperationScope>
+							<ClassName classname='Str'>
+								<value/>
+							</ClassName>
+							<ClassInstanceLocation typename='Expression' xsi:type='Expression' classname='ExprValue'>
+								<value/>
+							</ClassInstanceLocation>
+							<FunctionOrAttributeName classname='Str'>
+								<value/>
+							</FunctionOrAttributeName>
+							<Parameters classname='Objs'>
+								<value lbound='[0]' ubound='[0]'>
+									<elemproto>
+										<_NAME_IN_ATTRIBUTE_ typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name='' classname='CPythonParameter' structureflags='131072'>
+											<subprops>
+												<Name classname='Str'>
+													<value>_notNamed</value>
+												</Name>
+												<Type classname='Num'>
+													<value>7</value>
+												</Type>
+												<ArgumentValue classname='ExprValue'>
+													<value/>
+												</ArgumentValue>
+												<ArgumentDisplayValue classname='ExprValue'>
+													<value/>
+												</ArgumentDisplayValue>
+												<AdditionalResults classname='Obj'>
+													<subprops>
+														<Input classname='PythonParameterResult'>
+															<subprops>
+																<Condition classname='ExprValue'>
+																	<value/>
+																</Condition>
+																<Flags classname='Num'>
+																	<value>8192</value>
+																</Flags>
+																<CheckedState classname='Num'>
+																	<value>1</value>
+																</CheckedState>
+															</subprops>
+														</Input>
+														<Output classname='PythonParameterResult'>
+															<subprops>
+																<Condition classname='ExprValue'>
+																	<value/>
+																</Condition>
+																<Flags classname='Num'>
+																	<value>8192</value>
+																</Flags>
+																<CheckedState classname='Num'>
+																	<value>1</value>
+																</CheckedState>
+															</subprops>
+														</Output>
+													</subprops>
+												</AdditionalResults>
+											</subprops>
+										</_NAME_IN_ATTRIBUTE_>
+									</elemproto>
+									<value>
+										<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
+											<subprops>
+												<Name classname='Str'>
+													<value>Return Value</value>
+												</Name>
+												<Type classname='Num'>
+													<value>7</value>
+												</Type>
+												<ArgumentValue classname='ExprValue'>
+													<value/>
+												</ArgumentValue>
+												<ArgumentDisplayValue classname='ExprValue'>
+													<value/>
+												</ArgumentDisplayValue>
+												<AdditionalResults classname='Obj'>
+													<subprops>
+														<Input classname='PythonParameterResult'>
+															<subprops>
+																<Condition classname='ExprValue'>
+																	<value/>
+																</Condition>
+																<Flags classname='Num'>
+																	<value>8192</value>
+																</Flags>
+																<CheckedState classname='Num'>
+																	<value>1</value>
+																</CheckedState>
+															</subprops>
+														</Input>
+														<Output classname='PythonParameterResult'>
+															<subprops>
+																<Condition classname='ExprValue'>
+																	<value/>
+																</Condition>
+																<Flags classname='Num'>
+																	<value>8192</value>
+																</Flags>
+																<CheckedState classname='Num'>
+																	<value>1</value>
+																</CheckedState>
+															</subprops>
+														</Output>
+													</subprops>
+												</AdditionalResults>
+											</subprops>
+										</CPythonParameter>
+									</value>
+								</value>
+							</Parameters>
+							<DefaultParamCategoryForArray classname='Num'>
+								<value>5</value>
+							</DefaultParamCategoryForArray>
+						</subprops>
+					</PythonCall>
+				</subprops>
+			</PythonStepAdditions>
+		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='26'>
 			<Statement classname='StepType' isroottypedef='true' typecategory='1' timestamp='1618215676' typeversion='21.0.0.2' typelastmodversion='21.0.0.0' typeminprodversion='21.0.0.0' typeflags='33554446'>
 				<subprops>
@@ -5824,647 +6465,6 @@
 				</subprops>
 			</Statement>
 		</typedef>
-		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='21'>
-			<Action classname='StepType' isroottypedef='true' typecategory='1' timestamp='1618215606' typeversion='21.0.0.2' typelastmodversion='21.0.0.0' typeminprodversion='21.0.0.0' typeflags='33554446'>
-				<subprops>
-					<Substeps typename='StepTypeSubstepsArray' xsi:type='StepTypeSubstepsArray' classname='Objs' flagsforinstances='524312' instanceoverrideflags='655384'>
-						<value lbound='[0]' ubound='[]'/>
-					</Substeps>
-					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
-						<value>ResStr("NI_STEPTYPES", "ACTION_DESCRIPTION_NAME") + (("%ModuleDescription" == "") ? "" : ",  %ModuleDescription")</value>
-					</DescriptionFormat>
-					<DefaultNameFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
-						<value>ResStr("NI_STEPTYPES", "ACTION_DEF_STEP_NAME")</value>
-					</DefaultNameFormat>
-					<Menu typename='StepTypeMenu' xsi:type='StepTypeMenu' classname='Obj' flagsforinstances='524312' instanceoverrideflags='524312'>
-						<subprops>
-							<CanBeSubstepType classname='Bool'>
-								<value>false</value>
-							</CanBeSubstepType>
-							<CanOnlyBeSubstepType classname='Bool'>
-								<value>false</value>
-							</CanOnlyBeSubstepType>
-							<Category classname='Str'>
-								<value>""</value>
-							</Category>
-							<ItemName classname='ExprValue'>
-								<value>ResStr("NI_STEPTYPES", "ACTION_MENU_ITEM_NAME")</value>
-							</ItemName>
-							<SingularItemName classname='Str'>
-								<value>""</value>
-							</SingularItemName>
-							<SeparatorBeforeCategory classname='Bool'>
-								<value>false</value>
-							</SeparatorBeforeCategory>
-							<SeparatorBeforeItemName classname='Bool'>
-								<value>false</value>
-							</SeparatorBeforeItemName>
-							<Group classname='Str'>
-								<value>Action</value>
-							</Group>
-						</subprops>
-					</Menu>
-					<AdditionalResultsHints classname='Objs' valueflags='4194328' structureflags='524288'>
-						<value lbound='[0]' ubound='[]'>
-							<elemproto>
-								<_NAME_IN_ATTRIBUTE_ typename='NI_CustomResult' xsi:type='NI_CustomResult' name='' classname='CustomResult'>
-									<subprops>
-										<Name classname='ExprValue'>
-											<value/>
-										</Name>
-										<ValueToLog classname='ExprValue'>
-											<value/>
-										</ValueToLog>
-										<Condition classname='ExprValue'>
-											<value/>
-										</Condition>
-										<Flags classname='Num'>
-											<value>8192</value>
-										</Flags>
-										<CheckedState classname='Num'>
-											<value>2</value>
-										</CheckedState>
-										<Type classname='PropertyObjectType'>
-											<subprops>
-												<ValueType classname='Num'>
-													<value>3</value>
-												</ValueType>
-												<IsObject classname='Bool'>
-													<value>true</value>
-												</IsObject>
-												<TypeName classname='Str'>
-													<value/>
-												</TypeName>
-												<ElementType classname='Objs'>
-													<value lbound='[0]' ubound='[]'/>
-												</ElementType>
-												<ArrayDimensions classname='ArrayDimensions'>
-													<subprops>
-														<LowerBounds classname='Nums'>
-															<value lbound='[0]' ubound='[]'/>
-														</LowerBounds>
-														<UpperBounds classname='Nums'>
-															<value lbound='[0]' ubound='[]'/>
-														</UpperBounds>
-													</subprops>
-												</ArrayDimensions>
-												<Representation classname='Num'>
-													<value>1</value>
-												</Representation>
-												<ClassName classname='Str'>
-													<value/>
-												</ClassName>
-											</subprops>
-										</Type>
-										<Elements classname='Objs'>
-											<value lbound='[0]' ubound='[]'/>
-										</Elements>
-										<IsAnyType classname='Bool'>
-											<value>true</value>
-										</IsAnyType>
-									</subprops>
-								</_NAME_IN_ATTRIBUTE_>
-							</elemproto>
-						</value>
-					</AdditionalResultsHints>
-					<TS typename='TEInf' xsi:type='TEInf' classname='Obj' flagsforinstances='262168' instanceoverrideflags='4456472'>
-						<subprops>
-							<Id classname='Str'>
-								<value/>
-							</Id>
-							<Icon classname='Str'>
-								<value/>
-							</Icon>
-							<SData classname='Obj' flagsforinstances='2097152' instanceoverrideflags='7143448' structureflags='2097152'/>
-							<PreCond classname='ExprValue'>
-								<value/>
-							</PreCond>
-							<LoadOpt classname='Str'>
-								<value>PreloadWhenExecuted</value>
-							</LoadOpt>
-							<UnloadOpt classname='Str'>
-								<value>UnloadWithFile</value>
-							</UnloadOpt>
-							<Mode classname='Str'>
-								<value>Normal</value>
-							</Mode>
-							<WindowActivation classname='Str'>
-								<value>None</value>
-							</WindowActivation>
-							<ResultOption classname='Num'>
-								<value>1</value>
-							</ResultOption>
-							<StepFCSeqF classname='Bool'>
-								<value>true</value>
-							</StepFCSeqF>
-							<IgnoreRTE classname='Bool'>
-								<value>false</value>
-							</IgnoreRTE>
-							<UseMutex classname='Bool'>
-								<value>false</value>
-							</UseMutex>
-							<MutexNameOrRef classname='ExprValue'>
-								<value/>
-							</MutexNameOrRef>
-							<BatchSyncOpt classname='Num'>
-								<value>0</value>
-							</BatchSyncOpt>
-							<SwitchEnabled classname='Bool'>
-								<value>false</value>
-							</SwitchEnabled>
-							<VirtualDeviceName classname='ExprValue'>
-								<value/>
-							</VirtualDeviceName>
-							<SwitchOperation classname='Num'>
-								<value>1</value>
-							</SwitchOperation>
-							<RouteGroupConnect classname='ExprValue'>
-								<value/>
-							</RouteGroupConnect>
-							<RouteGroupDisconnect classname='ExprValue'>
-								<value/>
-							</RouteGroupDisconnect>
-							<MulticonnectMode classname='Num'>
-								<value>1</value>
-							</MulticonnectMode>
-							<OperationOrder classname='Num'>
-								<value>2</value>
-							</OperationOrder>
-							<ConnectionLifetime classname='Num'>
-								<value>0</value>
-							</ConnectionLifetime>
-							<WaitForDebounce classname='Bool'>
-								<value>true</value>
-							</WaitForDebounce>
-							<PassAct classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
-								<value>Next</value>
-							</PassAct>
-							<FailAct classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
-								<value>Next</value>
-							</FailAct>
-							<PassActTarget classname='ExprValue' flagsforinstances='1' instanceoverrideflags='5046297'>
-								<value/>
-							</PassActTarget>
-							<FailActTarget classname='ExprValue' flagsforinstances='1' instanceoverrideflags='5046297'>
-								<value/>
-							</FailActTarget>
-							<CustExpr classname='ExprValue'>
-								<value/>
-							</CustExpr>
-							<CustTrueAct classname='Str'>
-								<value>Next</value>
-							</CustTrueAct>
-							<CustFalseAct classname='Str'>
-								<value>Next</value>
-							</CustFalseAct>
-							<CustTrueActTarget classname='ExprValue'>
-								<value/>
-							</CustTrueActTarget>
-							<CustFalseActTarget classname='ExprValue'>
-								<value/>
-							</CustFalseActTarget>
-							<LoopType classname='Str'>
-								<value>NoLooping</value>
-							</LoopType>
-							<LoopWhile classname='ExprValue'>
-								<value/>
-							</LoopWhile>
-							<LoopStatus classname='ExprValue'>
-								<value/>
-							</LoopStatus>
-							<LoopIncrement classname='ExprValue'>
-								<value>RunState.LoopIndex += 1</value>
-							</LoopIncrement>
-							<LoopInitialize classname='ExprValue'>
-								<value>RunState.LoopIndex = 0</value>
-							</LoopInitialize>
-							<LoopOpt classname='Num'>
-								<value>0</value>
-							</LoopOpt>
-							<PreExpr classname='ExprValue'>
-								<value/>
-							</PreExpr>
-							<PostExpr classname='ExprValue'>
-								<value/>
-							</PostExpr>
-							<StatusExpr classname='ExprValue'>
-								<value/>
-							</StatusExpr>
-							<CanSpecifyModule classname='Bool'>
-								<value>true</value>
-							</CanSpecifyModule>
-							<CanEditCode classname='Bool'>
-								<value>true</value>
-							</CanEditCode>
-							<CanEditModulePrototype classname='Bool'>
-								<value>true</value>
-							</CanEditModulePrototype>
-							<CanEditParameterAdditionalResults classname='Bool'>
-								<value>true</value>
-							</CanEditParameterAdditionalResults>
-							<PrecondIntExe classname='Num'>
-								<value>0</value>
-							</PrecondIntExe>
-							<Requirements classname='Obj' flagsforinstances='1' valueflags='1' structureflags='2097152'>
-								<subprops>
-									<Links classname='Strs' flagsforinstances='71303168' instanceoverrideflags='72286233' valueflags='71303168'>
-										<value lbound='[0]' ubound='[]'/>
-									</Links>
-								</subprops>
-							</Requirements>
-							<CustomResults classname='Objs'>
-								<value lbound='[0]' ubound='[]'>
-									<elemproto>
-										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-											<subprops>
-												<Name classname='ExprValue'>
-													<value/>
-												</Name>
-												<ValueToLog classname='ExprValue'>
-													<value/>
-												</ValueToLog>
-												<Condition classname='ExprValue'>
-													<value/>
-												</Condition>
-												<Flags classname='Num'>
-													<value>8192</value>
-												</Flags>
-												<CheckedState classname='Num'>
-													<value>2</value>
-												</CheckedState>
-												<Type classname='PropertyObjectType'>
-													<subprops>
-														<ValueType classname='Num'>
-															<value>3</value>
-														</ValueType>
-														<IsObject classname='Bool'>
-															<value>true</value>
-														</IsObject>
-														<TypeName classname='Str'>
-															<value/>
-														</TypeName>
-														<ElementType classname='Objs'>
-															<value lbound='[0]' ubound='[]'/>
-														</ElementType>
-														<ArrayDimensions classname='ArrayDimensions'>
-															<subprops>
-																<LowerBounds classname='Nums'>
-																	<value lbound='[0]' ubound='[]'/>
-																</LowerBounds>
-																<UpperBounds classname='Nums'>
-																	<value lbound='[0]' ubound='[]'/>
-																</UpperBounds>
-															</subprops>
-														</ArrayDimensions>
-														<Representation classname='Num'>
-															<value>1</value>
-														</Representation>
-														<ClassName classname='Str'>
-															<value/>
-														</ClassName>
-													</subprops>
-												</Type>
-												<Elements classname='Objs'>
-													<value lbound='[0]' ubound='[]'/>
-												</Elements>
-												<IsAnyType classname='Bool'>
-													<value>true</value>
-												</IsAnyType>
-											</subprops>
-										</_NAME_IN_ATTRIBUTE_>
-									</elemproto>
-								</value>
-							</CustomResults>
-							<AdditionalResultsHints classname='Objs'>
-								<value lbound='[0]' ubound='[]'>
-									<elemproto>
-										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-											<subprops>
-												<Name classname='ExprValue'>
-													<value/>
-												</Name>
-												<ValueToLog classname='ExprValue'>
-													<value/>
-												</ValueToLog>
-												<Condition classname='ExprValue'>
-													<value/>
-												</Condition>
-												<Flags classname='Num'>
-													<value>8192</value>
-												</Flags>
-												<CheckedState classname='Num'>
-													<value>2</value>
-												</CheckedState>
-												<Type classname='PropertyObjectType'>
-													<subprops>
-														<ValueType classname='Num'>
-															<value>3</value>
-														</ValueType>
-														<IsObject classname='Bool'>
-															<value>true</value>
-														</IsObject>
-														<TypeName classname='Str'>
-															<value/>
-														</TypeName>
-														<ElementType classname='Objs'>
-															<value lbound='[0]' ubound='[]'/>
-														</ElementType>
-														<ArrayDimensions classname='ArrayDimensions'>
-															<subprops>
-																<LowerBounds classname='Nums'>
-																	<value lbound='[0]' ubound='[]'/>
-																</LowerBounds>
-																<UpperBounds classname='Nums'>
-																	<value lbound='[0]' ubound='[]'/>
-																</UpperBounds>
-															</subprops>
-														</ArrayDimensions>
-														<Representation classname='Num'>
-															<value>1</value>
-														</Representation>
-														<ClassName classname='Str'>
-															<value/>
-														</ClassName>
-													</subprops>
-												</Type>
-												<Elements classname='Objs'>
-													<value lbound='[0]' ubound='[]'/>
-												</Elements>
-												<IsAnyType classname='Bool'>
-													<value>true</value>
-												</IsAnyType>
-											</subprops>
-										</_NAME_IN_ATTRIBUTE_>
-									</elemproto>
-								</value>
-							</AdditionalResultsHints>
-						</subprops>
-					</TS>
-					<NI_Data typename='StepTypeNIData' xsi:type='StepTypeNIData' classname='Obj'>
-						<subprops>
-							<EditPanels classname='Strs'>
-								<value lbound='[0]' ubound='[]'/>
-							</EditPanels>
-						</subprops>
-					</NI_Data>
-					<Result classname='Obj' flagsforinstances='4194304' valueflags='4194304'>
-						<subprops>
-							<Error typename='Error' xsi:type='Error' classname='Obj' flagsforinstances='4194304' instanceoverrideflags='4194304' valueflags='4194304'>
-								<subprops>
-									<Code classname='Num'>
-										<value>0</value>
-									</Code>
-									<Msg classname='Str'>
-										<value/>
-									</Msg>
-									<Occurred classname='Bool'>
-										<value>false</value>
-									</Occurred>
-								</subprops>
-							</Error>
-							<Status classname='Str' flagsforinstances='4194304' valueflags='4194304'>
-								<value/>
-							</Status>
-							<ReportText classname='Str' flagsforinstances='4194304' valueflags='4194304'>
-								<value/>
-							</ReportText>
-							<Common typename='CommonResults' xsi:type='CommonResults' classname='Obj' instanceoverrideflags='4194304'/>
-						</subprops>
-					</Result>
-					<CodeTemplates classname='Str' valueflags='4194328' structureflags='524288'>
-						<value>DefaultLabVIEW|DefaultLabVIEWNXG|DefaultCVI|DefaultVB.NET|DefaultCSharp.NET|DefaultC++.NET|DefaultVC++_Template|DefaultHTB72_Template|DefaultHTB80_Template|Default_Template</value>
-					</CodeTemplates>
-					<BlockStartTypes classname='Str' valueflags='4194328' structureflags='524288'>
-						<value/>
-					</BlockStartTypes>
-					<BlockEndTypes classname='Str' valueflags='4194328' structureflags='524288'>
-						<value/>
-					</BlockEndTypes>
-					<AppliesToBlockStructure classname='Bool' valueflags='4194328' structureflags='524288'>
-						<value>false</value>
-					</AppliesToBlockStructure>
-					<CanEncapsulate classname='Bool' valueflags='4194328' structureflags='524288'>
-						<value>false</value>
-					</CanEncapsulate>
-					<Category classname='Str' valueflags='24' structureflags='524288'>
-						<value>Action</value>
-					</Category>
-				</subprops>
-			</Action>
-		</typedef>
-		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='29'>
-			<NI_PythonParameterResult classname='PythonParameterResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
-				<subprops>
-					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
-						<value/>
-					</Condition>
-					<Flags classname='Num'>
-						<value>8192</value>
-						<numericfmt>%#x</numericfmt>
-					</Flags>
-					<CheckedState classname='Num'>
-						<value>1</value>
-					</CheckedState>
-				</subprops>
-			</NI_PythonParameterResult>
-		</typedef>
-		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='28'>
-			<NI_PythonParameter classname='CPythonParameter' isroottypedef='true' typecategory='3' timestamp='1650060872' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
-				<subprops>
-					<Name classname='Str'>
-						<value>_notNamed</value>
-					</Name>
-					<Type classname='Num'>
-						<value>7</value>
-					</Type>
-					<ArgumentValue typename='Expression' xsi:type='Expression' classname='ExprValue'>
-						<value/>
-					</ArgumentValue>
-					<ArgumentDisplayValue typename='Expression' xsi:type='Expression' classname='ExprValue'>
-						<value/>
-					</ArgumentDisplayValue>
-					<AdditionalResults classname='Obj'>
-						<subprops>
-							<Input typename='NI_PythonParameterResult' xsi:type='NI_PythonParameterResult' classname='PythonParameterResult'>
-								<subprops>
-									<Condition classname='ExprValue'>
-										<value/>
-									</Condition>
-									<Flags classname='Num'>
-										<value>8192</value>
-									</Flags>
-									<CheckedState classname='Num'>
-										<value>1</value>
-									</CheckedState>
-								</subprops>
-							</Input>
-							<Output typename='NI_PythonParameterResult' xsi:type='NI_PythonParameterResult' classname='PythonParameterResult'>
-								<subprops>
-									<Condition classname='ExprValue'>
-										<value/>
-									</Condition>
-									<Flags classname='Num'>
-										<value>8192</value>
-									</Flags>
-									<CheckedState classname='Num'>
-										<value>1</value>
-									</CheckedState>
-								</subprops>
-							</Output>
-						</subprops>
-					</AdditionalResults>
-				</subprops>
-			</NI_PythonParameter>
-		</typedef>
-		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='27'>
-			<PythonStepAdditions classname='CPythonModule' isroottypedef='true' typecategory='3' timestamp='1650060872' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
-				<subprops>
-					<PythonCall classname='CPythonCall'>
-						<subprops>
-							<UseAdapterSettingsForInterpreterSession classname='Bool'>
-								<value>true</value>
-							</UseAdapterSettingsForInterpreterSession>
-							<InterpreterSessionScope classname='Num'>
-								<value>3</value>
-							</InterpreterSessionScope>
-							<PythonVersion classname='Str'>
-								<value/>
-							</PythonVersion>
-							<PythonVirtualEnvironmentPath classname='Str'>
-								<value/>
-							</PythonVirtualEnvironmentPath>
-							<InterpreterLocation typename='Expression' xsi:type='Expression' classname='ExprValue'>
-								<value/>
-							</InterpreterLocation>
-							<CreateIfInterpreterDoesNotExist classname='Bool'>
-								<value>true</value>
-							</CreateIfInterpreterDoesNotExist>
-							<ModulePath typename='Path' xsi:type='Path' classname='PathValue'>
-								<value/>
-							</ModulePath>
-							<OperationType classname='Num'>
-								<value>1</value>
-							</OperationType>
-							<OperationScope classname='Num'>
-								<value>0</value>
-							</OperationScope>
-							<ClassName classname='Str'>
-								<value/>
-							</ClassName>
-							<ClassInstanceLocation typename='Expression' xsi:type='Expression' classname='ExprValue'>
-								<value/>
-							</ClassInstanceLocation>
-							<FunctionOrAttributeName classname='Str'>
-								<value/>
-							</FunctionOrAttributeName>
-							<Parameters classname='Objs'>
-								<value lbound='[0]' ubound='[0]'>
-									<elemproto>
-										<_NAME_IN_ATTRIBUTE_ typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name='' classname='CPythonParameter' structureflags='131072'>
-											<subprops>
-												<Name classname='Str'>
-													<value>_notNamed</value>
-												</Name>
-												<Type classname='Num'>
-													<value>7</value>
-												</Type>
-												<ArgumentValue classname='ExprValue'>
-													<value/>
-												</ArgumentValue>
-												<ArgumentDisplayValue classname='ExprValue'>
-													<value/>
-												</ArgumentDisplayValue>
-												<AdditionalResults classname='Obj'>
-													<subprops>
-														<Input classname='PythonParameterResult'>
-															<subprops>
-																<Condition classname='ExprValue'>
-																	<value/>
-																</Condition>
-																<Flags classname='Num'>
-																	<value>8192</value>
-																</Flags>
-																<CheckedState classname='Num'>
-																	<value>1</value>
-																</CheckedState>
-															</subprops>
-														</Input>
-														<Output classname='PythonParameterResult'>
-															<subprops>
-																<Condition classname='ExprValue'>
-																	<value/>
-																</Condition>
-																<Flags classname='Num'>
-																	<value>8192</value>
-																</Flags>
-																<CheckedState classname='Num'>
-																	<value>1</value>
-																</CheckedState>
-															</subprops>
-														</Output>
-													</subprops>
-												</AdditionalResults>
-											</subprops>
-										</_NAME_IN_ATTRIBUTE_>
-									</elemproto>
-									<value>
-										<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
-											<subprops>
-												<Name classname='Str'>
-													<value>Return Value</value>
-												</Name>
-												<Type classname='Num'>
-													<value>7</value>
-												</Type>
-												<ArgumentValue classname='ExprValue'>
-													<value/>
-												</ArgumentValue>
-												<ArgumentDisplayValue classname='ExprValue'>
-													<value/>
-												</ArgumentDisplayValue>
-												<AdditionalResults classname='Obj'>
-													<subprops>
-														<Input classname='PythonParameterResult'>
-															<subprops>
-																<Condition classname='ExprValue'>
-																	<value/>
-																</Condition>
-																<Flags classname='Num'>
-																	<value>8192</value>
-																</Flags>
-																<CheckedState classname='Num'>
-																	<value>1</value>
-																</CheckedState>
-															</subprops>
-														</Input>
-														<Output classname='PythonParameterResult'>
-															<subprops>
-																<Condition classname='ExprValue'>
-																	<value/>
-																</Condition>
-																<Flags classname='Num'>
-																	<value>8192</value>
-																</Flags>
-																<CheckedState classname='Num'>
-																	<value>1</value>
-																</CheckedState>
-															</subprops>
-														</Output>
-													</subprops>
-												</AdditionalResults>
-											</subprops>
-										</CPythonParameter>
-									</value>
-								</value>
-							</Parameters>
-							<DefaultParamCategoryForArray classname='Num'>
-								<value>5</value>
-							</DefaultParamCategoryForArray>
-						</subprops>
-					</PythonCall>
-				</subprops>
-			</PythonStepAdditions>
-		</typedef>
 	</typelist>
 	<Data classname='SequenceFileData' valueflags='4194304'>
 		<subprops>
@@ -7636,302 +7636,7 @@
 									</value>
 								</Main>
 								<Setup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[3]'>
-										<value>
-											<Step typename='Statement' xsi:type='Statement' name='Get absolute path to pinmap file'>
-												<subprops>
-													<TS classname='Obj'>
-														<subprops>
-															<Id classname='Str'>
-																<value>ID#:CHEZyO1w7RGuNrjdh1OqZD</value>
-															</Id>
-															<Icon classname='Str'>
-																<value>StatementStep.ico</value>
-															</Icon>
-															<PreCond classname='ExprValue'>
-																<value/>
-															</PreCond>
-															<LoadOpt classname='Str'>
-																<value>PreloadWhenExecuted</value>
-															</LoadOpt>
-															<UnloadOpt classname='Str'>
-																<value>UnloadWithFile</value>
-															</UnloadOpt>
-															<Mode classname='Str'>
-																<value>Normal</value>
-															</Mode>
-															<WindowActivation classname='Str'>
-																<value>None</value>
-															</WindowActivation>
-															<ResultOption classname='Num'>
-																<value>1</value>
-															</ResultOption>
-															<StepFCSeqF classname='Bool'>
-																<value>true</value>
-															</StepFCSeqF>
-															<IgnoreRTE classname='Bool'>
-																<value>false</value>
-															</IgnoreRTE>
-															<UseMutex classname='Bool'>
-																<value>false</value>
-															</UseMutex>
-															<MutexNameOrRef classname='ExprValue'>
-																<value/>
-															</MutexNameOrRef>
-															<BatchSyncOpt classname='Num'>
-																<value>0</value>
-															</BatchSyncOpt>
-															<SwitchEnabled classname='Bool'>
-																<value>false</value>
-															</SwitchEnabled>
-															<VirtualDeviceName classname='ExprValue'>
-																<value/>
-															</VirtualDeviceName>
-															<SwitchOperation classname='Num'>
-																<value>1</value>
-															</SwitchOperation>
-															<RouteGroupConnect classname='ExprValue'>
-																<value/>
-															</RouteGroupConnect>
-															<RouteGroupDisconnect classname='ExprValue'>
-																<value/>
-															</RouteGroupDisconnect>
-															<MulticonnectMode classname='Num'>
-																<value>1</value>
-															</MulticonnectMode>
-															<OperationOrder classname='Num'>
-																<value>2</value>
-															</OperationOrder>
-															<ConnectionLifetime classname='Num'>
-																<value>0</value>
-															</ConnectionLifetime>
-															<WaitForDebounce classname='Bool'>
-																<value>true</value>
-															</WaitForDebounce>
-															<PassAct classname='Str'>
-																<value>Next</value>
-															</PassAct>
-															<FailAct classname='Str'>
-																<value>Next</value>
-															</FailAct>
-															<PassActTarget classname='ExprValue'>
-																<value/>
-															</PassActTarget>
-															<FailActTarget classname='ExprValue'>
-																<value/>
-															</FailActTarget>
-															<CustExpr classname='ExprValue'>
-																<value/>
-															</CustExpr>
-															<CustTrueAct classname='Str'>
-																<value>Next</value>
-															</CustTrueAct>
-															<CustFalseAct classname='Str'>
-																<value>Next</value>
-															</CustFalseAct>
-															<CustTrueActTarget classname='ExprValue'>
-																<value/>
-															</CustTrueActTarget>
-															<CustFalseActTarget classname='ExprValue'>
-																<value/>
-															</CustFalseActTarget>
-															<LoopType classname='Str'>
-																<value>NoLooping</value>
-															</LoopType>
-															<LoopWhile classname='ExprValue'>
-																<value/>
-															</LoopWhile>
-															<LoopStatus classname='ExprValue'>
-																<value/>
-															</LoopStatus>
-															<LoopIncrement classname='ExprValue'>
-																<value>RunState.LoopIndex += 1</value>
-															</LoopIncrement>
-															<LoopInitialize classname='ExprValue'>
-																<value>RunState.LoopIndex = 0</value>
-															</LoopInitialize>
-															<LoopOpt classname='Num'>
-																<value>0</value>
-															</LoopOpt>
-															<PreExpr classname='ExprValue'>
-																<value/>
-															</PreExpr>
-															<PostExpr classname='ExprValue'>
-																<value>FindFile(FileGlobals.MeasurementLink.PinMapFileName,True,FileGlobals.MeasurementLink.PinMapPath)</value>
-															</PostExpr>
-															<StatusExpr classname='ExprValue'>
-																<value/>
-															</StatusExpr>
-															<CanSpecifyModule classname='Bool'>
-																<value>false</value>
-															</CanSpecifyModule>
-															<CanEditCode classname='Bool'>
-																<value>true</value>
-															</CanEditCode>
-															<CanEditModulePrototype classname='Bool'>
-																<value>true</value>
-															</CanEditModulePrototype>
-															<CanEditParameterAdditionalResults classname='Bool'>
-																<value>true</value>
-															</CanEditParameterAdditionalResults>
-															<PrecondIntExe classname='Num'>
-																<value>0</value>
-															</PrecondIntExe>
-															<CustomResults classname='Objs'>
-																<value lbound='[0]' ubound='[]'>
-																	<elemproto>
-																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-																			<subprops>
-																				<Name classname='ExprValue'>
-																					<value/>
-																				</Name>
-																				<ValueToLog classname='ExprValue'>
-																					<value/>
-																				</ValueToLog>
-																				<Condition classname='ExprValue'>
-																					<value/>
-																				</Condition>
-																				<Flags classname='Num'>
-																					<value>8192</value>
-																				</Flags>
-																				<CheckedState classname='Num'>
-																					<value>2</value>
-																				</CheckedState>
-																				<Type classname='PropertyObjectType'>
-																					<subprops>
-																						<ValueType classname='Num'>
-																							<value>3</value>
-																						</ValueType>
-																						<IsObject classname='Bool'>
-																							<value>true</value>
-																						</IsObject>
-																						<TypeName classname='Str'>
-																							<value/>
-																						</TypeName>
-																						<ElementType classname='Objs'>
-																							<value lbound='[0]' ubound='[]'/>
-																						</ElementType>
-																						<ArrayDimensions classname='ArrayDimensions'>
-																							<subprops>
-																								<LowerBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</LowerBounds>
-																								<UpperBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</UpperBounds>
-																							</subprops>
-																						</ArrayDimensions>
-																						<Representation classname='Num'>
-																							<value>1</value>
-																						</Representation>
-																						<ClassName classname='Str'>
-																							<value/>
-																						</ClassName>
-																					</subprops>
-																				</Type>
-																				<Elements classname='Objs'>
-																					<value lbound='[0]' ubound='[]'/>
-																				</Elements>
-																				<IsAnyType classname='Bool'>
-																					<value>true</value>
-																				</IsAnyType>
-																			</subprops>
-																		</_NAME_IN_ATTRIBUTE_>
-																	</elemproto>
-																</value>
-															</CustomResults>
-															<AdditionalResultsHints classname='Objs'>
-																<value lbound='[0]' ubound='[]'>
-																	<elemproto>
-																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-																			<subprops>
-																				<Name classname='ExprValue'>
-																					<value/>
-																				</Name>
-																				<ValueToLog classname='ExprValue'>
-																					<value/>
-																				</ValueToLog>
-																				<Condition classname='ExprValue'>
-																					<value/>
-																				</Condition>
-																				<Flags classname='Num'>
-																					<value>8192</value>
-																				</Flags>
-																				<CheckedState classname='Num'>
-																					<value>2</value>
-																				</CheckedState>
-																				<Type classname='PropertyObjectType'>
-																					<subprops>
-																						<ValueType classname='Num'>
-																							<value>3</value>
-																						</ValueType>
-																						<IsObject classname='Bool'>
-																							<value>true</value>
-																						</IsObject>
-																						<TypeName classname='Str'>
-																							<value/>
-																						</TypeName>
-																						<ElementType classname='Objs'>
-																							<value lbound='[0]' ubound='[]'/>
-																						</ElementType>
-																						<ArrayDimensions classname='ArrayDimensions'>
-																							<subprops>
-																								<LowerBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</LowerBounds>
-																								<UpperBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</UpperBounds>
-																							</subprops>
-																						</ArrayDimensions>
-																						<Representation classname='Num'>
-																							<value>1</value>
-																						</Representation>
-																						<ClassName classname='Str'>
-																							<value/>
-																						</ClassName>
-																					</subprops>
-																				</Type>
-																				<Elements classname='Objs'>
-																					<value lbound='[0]' ubound='[]'/>
-																				</Elements>
-																				<IsAnyType classname='Bool'>
-																					<value>true</value>
-																				</IsAnyType>
-																			</subprops>
-																		</_NAME_IN_ATTRIBUTE_>
-																	</elemproto>
-																</value>
-															</AdditionalResultsHints>
-														</subprops>
-													</TS>
-													<Result classname='Obj'>
-														<subprops>
-															<Error classname='Obj'>
-																<subprops>
-																	<Code classname='Num'>
-																		<value>0</value>
-																	</Code>
-																	<Msg classname='Str'>
-																		<value/>
-																	</Msg>
-																	<Occurred classname='Bool'>
-																		<value>false</value>
-																	</Occurred>
-																</subprops>
-															</Error>
-															<Status classname='Str'>
-																<value/>
-															</Status>
-															<ReportText classname='Str'>
-																<value/>
-															</ReportText>
-															<Common classname='Obj'/>
-														</subprops>
-													</Result>
-												</subprops>
-											</Step>
-										</value>
+									<value lbound='[0]' ubound='[1]'>
 										<value>
 											<Step typename='Action' xsi:type='Action' name='Update pin map'>
 												<subprops>
@@ -8702,301 +8407,6 @@
 															</StatusExpr>
 															<CanSpecifyModule classname='Bool'>
 																<value>true</value>
-															</CanSpecifyModule>
-															<CanEditCode classname='Bool'>
-																<value>true</value>
-															</CanEditCode>
-															<CanEditModulePrototype classname='Bool'>
-																<value>true</value>
-															</CanEditModulePrototype>
-															<CanEditParameterAdditionalResults classname='Bool'>
-																<value>true</value>
-															</CanEditParameterAdditionalResults>
-															<PrecondIntExe classname='Num'>
-																<value>0</value>
-															</PrecondIntExe>
-															<CustomResults classname='Objs'>
-																<value lbound='[0]' ubound='[]'>
-																	<elemproto>
-																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-																			<subprops>
-																				<Name classname='ExprValue'>
-																					<value/>
-																				</Name>
-																				<ValueToLog classname='ExprValue'>
-																					<value/>
-																				</ValueToLog>
-																				<Condition classname='ExprValue'>
-																					<value/>
-																				</Condition>
-																				<Flags classname='Num'>
-																					<value>8192</value>
-																				</Flags>
-																				<CheckedState classname='Num'>
-																					<value>2</value>
-																				</CheckedState>
-																				<Type classname='PropertyObjectType'>
-																					<subprops>
-																						<ValueType classname='Num'>
-																							<value>3</value>
-																						</ValueType>
-																						<IsObject classname='Bool'>
-																							<value>true</value>
-																						</IsObject>
-																						<TypeName classname='Str'>
-																							<value/>
-																						</TypeName>
-																						<ElementType classname='Objs'>
-																							<value lbound='[0]' ubound='[]'/>
-																						</ElementType>
-																						<ArrayDimensions classname='ArrayDimensions'>
-																							<subprops>
-																								<LowerBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</LowerBounds>
-																								<UpperBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</UpperBounds>
-																							</subprops>
-																						</ArrayDimensions>
-																						<Representation classname='Num'>
-																							<value>1</value>
-																						</Representation>
-																						<ClassName classname='Str'>
-																							<value/>
-																						</ClassName>
-																					</subprops>
-																				</Type>
-																				<Elements classname='Objs'>
-																					<value lbound='[0]' ubound='[]'/>
-																				</Elements>
-																				<IsAnyType classname='Bool'>
-																					<value>true</value>
-																				</IsAnyType>
-																			</subprops>
-																		</_NAME_IN_ATTRIBUTE_>
-																	</elemproto>
-																</value>
-															</CustomResults>
-															<AdditionalResultsHints classname='Objs'>
-																<value lbound='[0]' ubound='[]'>
-																	<elemproto>
-																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-																			<subprops>
-																				<Name classname='ExprValue'>
-																					<value/>
-																				</Name>
-																				<ValueToLog classname='ExprValue'>
-																					<value/>
-																				</ValueToLog>
-																				<Condition classname='ExprValue'>
-																					<value/>
-																				</Condition>
-																				<Flags classname='Num'>
-																					<value>8192</value>
-																				</Flags>
-																				<CheckedState classname='Num'>
-																					<value>2</value>
-																				</CheckedState>
-																				<Type classname='PropertyObjectType'>
-																					<subprops>
-																						<ValueType classname='Num'>
-																							<value>3</value>
-																						</ValueType>
-																						<IsObject classname='Bool'>
-																							<value>true</value>
-																						</IsObject>
-																						<TypeName classname='Str'>
-																							<value/>
-																						</TypeName>
-																						<ElementType classname='Objs'>
-																							<value lbound='[0]' ubound='[]'/>
-																						</ElementType>
-																						<ArrayDimensions classname='ArrayDimensions'>
-																							<subprops>
-																								<LowerBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</LowerBounds>
-																								<UpperBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</UpperBounds>
-																							</subprops>
-																						</ArrayDimensions>
-																						<Representation classname='Num'>
-																							<value>1</value>
-																						</Representation>
-																						<ClassName classname='Str'>
-																							<value/>
-																						</ClassName>
-																					</subprops>
-																				</Type>
-																				<Elements classname='Objs'>
-																					<value lbound='[0]' ubound='[]'/>
-																				</Elements>
-																				<IsAnyType classname='Bool'>
-																					<value>true</value>
-																				</IsAnyType>
-																			</subprops>
-																		</_NAME_IN_ATTRIBUTE_>
-																	</elemproto>
-																</value>
-															</AdditionalResultsHints>
-														</subprops>
-													</TS>
-													<Result classname='Obj'>
-														<subprops>
-															<Error classname='Obj'>
-																<subprops>
-																	<Code classname='Num'>
-																		<value>0</value>
-																	</Code>
-																	<Msg classname='Str'>
-																		<value/>
-																	</Msg>
-																	<Occurred classname='Bool'>
-																		<value>false</value>
-																	</Occurred>
-																</subprops>
-															</Error>
-															<Status classname='Str'>
-																<value/>
-															</Status>
-															<ReportText classname='Str'>
-																<value/>
-															</ReportText>
-															<Common classname='Obj'/>
-														</subprops>
-													</Result>
-												</subprops>
-											</Step>
-										</value>
-										<value>
-											<Step typename='Statement' xsi:type='Statement' name='Register active PinMapId'>
-												<subprops>
-													<TS classname='Obj'>
-														<subprops>
-															<Id classname='Str'>
-																<value>ID#:7xzPK+Rw7RGuNrjdh1OqZD</value>
-															</Id>
-															<Icon classname='Str'>
-																<value>StatementStep.ico</value>
-															</Icon>
-															<PreCond classname='ExprValue'>
-																<value/>
-															</PreCond>
-															<LoadOpt classname='Str'>
-																<value>PreloadWhenExecuted</value>
-															</LoadOpt>
-															<UnloadOpt classname='Str'>
-																<value>UnloadWithFile</value>
-															</UnloadOpt>
-															<Mode classname='Str'>
-																<value>Normal</value>
-															</Mode>
-															<WindowActivation classname='Str'>
-																<value>None</value>
-															</WindowActivation>
-															<ResultOption classname='Num'>
-																<value>1</value>
-															</ResultOption>
-															<StepFCSeqF classname='Bool'>
-																<value>true</value>
-															</StepFCSeqF>
-															<IgnoreRTE classname='Bool'>
-																<value>false</value>
-															</IgnoreRTE>
-															<UseMutex classname='Bool'>
-																<value>false</value>
-															</UseMutex>
-															<MutexNameOrRef classname='ExprValue'>
-																<value/>
-															</MutexNameOrRef>
-															<BatchSyncOpt classname='Num'>
-																<value>0</value>
-															</BatchSyncOpt>
-															<SwitchEnabled classname='Bool'>
-																<value>false</value>
-															</SwitchEnabled>
-															<VirtualDeviceName classname='ExprValue'>
-																<value/>
-															</VirtualDeviceName>
-															<SwitchOperation classname='Num'>
-																<value>1</value>
-															</SwitchOperation>
-															<RouteGroupConnect classname='ExprValue'>
-																<value/>
-															</RouteGroupConnect>
-															<RouteGroupDisconnect classname='ExprValue'>
-																<value/>
-															</RouteGroupDisconnect>
-															<MulticonnectMode classname='Num'>
-																<value>1</value>
-															</MulticonnectMode>
-															<OperationOrder classname='Num'>
-																<value>2</value>
-															</OperationOrder>
-															<ConnectionLifetime classname='Num'>
-																<value>0</value>
-															</ConnectionLifetime>
-															<WaitForDebounce classname='Bool'>
-																<value>true</value>
-															</WaitForDebounce>
-															<PassAct classname='Str'>
-																<value>Next</value>
-															</PassAct>
-															<FailAct classname='Str'>
-																<value>Next</value>
-															</FailAct>
-															<PassActTarget classname='ExprValue'>
-																<value/>
-															</PassActTarget>
-															<FailActTarget classname='ExprValue'>
-																<value/>
-															</FailActTarget>
-															<CustExpr classname='ExprValue'>
-																<value/>
-															</CustExpr>
-															<CustTrueAct classname='Str'>
-																<value>Next</value>
-															</CustTrueAct>
-															<CustFalseAct classname='Str'>
-																<value>Next</value>
-															</CustFalseAct>
-															<CustTrueActTarget classname='ExprValue'>
-																<value/>
-															</CustTrueActTarget>
-															<CustFalseActTarget classname='ExprValue'>
-																<value/>
-															</CustFalseActTarget>
-															<LoopType classname='Str'>
-																<value>NoLooping</value>
-															</LoopType>
-															<LoopWhile classname='ExprValue'>
-																<value/>
-															</LoopWhile>
-															<LoopStatus classname='ExprValue'>
-																<value/>
-															</LoopStatus>
-															<LoopIncrement classname='ExprValue'>
-																<value>RunState.LoopIndex += 1</value>
-															</LoopIncrement>
-															<LoopInitialize classname='ExprValue'>
-																<value>RunState.LoopIndex = 0</value>
-															</LoopInitialize>
-															<LoopOpt classname='Num'>
-																<value>0</value>
-															</LoopOpt>
-															<PreExpr classname='ExprValue'>
-																<value/>
-															</PreExpr>
-															<PostExpr classname='ExprValue'>
-																<value>RunState.Engine.TemporaryGlobals.SetValString("NI.MeasurementLink.PinMapId", 0x1, FileGlobals.MeasurementLink.PinMapPath)</value>
-															</PostExpr>
-															<StatusExpr classname='ExprValue'>
-																<value/>
-															</StatusExpr>
-															<CanSpecifyModule classname='Bool'>
-																<value>false</value>
 															</CanSpecifyModule>
 															<CanEditCode classname='Bool'>
 																<value>true</value>
@@ -9937,11 +9347,8 @@
 							<EnableMonitoring classname='Bool'>
 								<value>false</value>
 							</EnableMonitoring>
-							<PinMapFileName classname='Str'>
-								<value>NISwitchControlRelays.pinmap</value>
-							</PinMapFileName>
 							<PinMapPath typename='Path' xsi:type='Path' classname='PathValue'>
-								<value/>
+								<value>NISwitchControlRelays.pinmap</value>
 							</PinMapPath>
 						</subprops>
 					</MeasurementLink>

--- a/examples/niswitch_control_relays/README.md
+++ b/examples/niswitch_control_relays/README.md
@@ -11,6 +11,7 @@ This is a MeasurementLink example that controls relays using an NI relay driver
 - Includes InstrumentStudio and MeasurementLink UI Editor project files
 - Includes a TestStand sequence showing how to configure the pin map, register
   instrument sessions with the session management service, and run a measurement
+  - For the sake of simplicity, the TestStand sequence handles pin map and session registration and unregistration in the `Setup` and `Cleanup` sections of the main sequence. For **Test UUTs** and batch process model use cases, these steps should be moved to the `ProcessSetup` and `ProcessCleanup` callbacks.
 - Uses the NI gRPC Device Server to allow sharing instrument sessions with other
   measurement services when running measurements from TestStand
 

--- a/examples/niswitch_control_relays/README.md
+++ b/examples/niswitch_control_relays/README.md
@@ -11,7 +11,10 @@ This is a MeasurementLink example that controls relays using an NI relay driver
 - Includes InstrumentStudio and MeasurementLink UI Editor project files
 - Includes a TestStand sequence showing how to configure the pin map, register
   instrument sessions with the session management service, and run a measurement
-  - For the sake of simplicity, the TestStand sequence handles pin map and session registration and unregistration in the `Setup` and `Cleanup` sections of the main sequence. For **Test UUTs** and batch process model use cases, these steps should be moved to the `ProcessSetup` and `ProcessCleanup` callbacks.
+  - For the sake of simplicity, the TestStand sequence handles pin map and session
+    registration and unregistration in the `Setup` and `Cleanup` sections of the main 
+    sequence. For **Test UUTs** and batch process model use cases, these steps should
+    be moved to the `ProcessSetup` and `ProcessCleanup` callbacks.
 - Uses the NI gRPC Device Server to allow sharing instrument sessions with other
   measurement services when running measurements from TestStand
 

--- a/examples/niswitch_control_relays/teststand_fixture.py
+++ b/examples/niswitch_control_relays/teststand_fixture.py
@@ -44,7 +44,7 @@ def create_niswitch_sessions(sequence_context: Any) -> None:
 
         teststand_support = TestStandSupport(sequence_context)
         pin_map_id = teststand_support.get_active_pin_map_id()
-        
+
         pin_map_context = nims.session_management.PinMapContext(pin_map_id=pin_map_id, sites=None)
         with session_management_client.reserve_sessions(
             context=pin_map_context,

--- a/examples/niswitch_control_relays/teststand_fixture.py
+++ b/examples/niswitch_control_relays/teststand_fixture.py
@@ -1,33 +1,50 @@
 """Functions to set up and tear down sessions of NI-Switch devices in NI TestStand."""
+from typing import Any
 
 import niswitch
-from _helpers import GrpcChannelPoolHelper, PinMapClient
+from _helpers import GrpcChannelPoolHelper, PinMapClient, TestStandSupport
 
 import ni_measurementlink_service as nims
 
 
-def update_pin_map(pin_map_id: str) -> None:
+def update_pin_map(pin_map_path: str, sequence_context: Any) -> None:
     """Update registered pin map contents.
 
     Create and register a pin map if a pin map resource for the specified pin map id is not found.
 
     Args:
-        pin_map_id (str): The resource id of the pin map to register as a pin map resource. By
-            convention, the pin_map_id is the .pinmap file path.
-
+        pin_map_path:
+            An absolute or relative path to the pin map file.
+        sequence_context:
+            The SequenceContext COM object from the TestStand sequence execution.
+            (Dynamically typed.)
     """
+    teststand_support = TestStandSupport(sequence_context)
+    pin_map_abs_path = teststand_support.resolve_file_path(pin_map_path)
+
     with GrpcChannelPoolHelper() as grpc_channel_pool:
         pin_map_client = PinMapClient(grpc_channel=grpc_channel_pool.pin_map_channel)
-        pin_map_client.update_pin_map(pin_map_id)
+        pin_map_id = pin_map_client.update_pin_map(pin_map_abs_path)
+
+    teststand_support.set_active_pin_map_id(pin_map_id)
 
 
-def create_niswitch_sessions(pin_map_id: str) -> None:
-    """Create and register all NI-Switch sessions."""
+def create_niswitch_sessions(sequence_context: Any) -> None:
+    """Create and register all NI-Switch sessions.
+
+    Args:
+        sequence_context:
+            The SequenceContext COM object from the TestStand sequence execution.
+            (Dynamically typed.)
+    """
     with GrpcChannelPoolHelper() as grpc_channel_pool:
         session_management_client = nims.session_management.Client(
             grpc_channel=grpc_channel_pool.session_management_channel
         )
 
+        teststand_support = TestStandSupport(sequence_context)
+        pin_map_id = teststand_support.get_active_pin_map_id()
+        
         pin_map_context = nims.session_management.PinMapContext(pin_map_id=pin_map_id, sites=None)
         with session_management_client.reserve_sessions(
             context=pin_map_context,

--- a/examples/nivisa_dmm_measurement/NIVisaDmmMeasurement.seq
+++ b/examples/nivisa_dmm_measurement/NIVisaDmmMeasurement.seq
@@ -1670,6 +1670,647 @@
 		</typedef>
 		<protected>E@=3DJC4100hYLECF=_K@0@mKCYo_1KN:&lt;Ta239hF9[gHbEVFDfRINZfQ01CkaUMk5=k`[c;[42MMF9aiNliecVfMFCLXi_`f2H7c\G\X50M=Z4S4aT2QI&gt;A^D:d1\PCI`L11RlV5bM5AIZTc9STI5Mkg&lt;bHlle[O=CL_KEgb?8RiVHS7QmPY@S4X^7I58A@kPaKcPWCOC1;DBf61lViY=]`28BC\B_mEf20ZJS@W@GDDRffLe\Ci;aKbN&gt;i5P_4ScVVBTjIIfn0j8l&lt;e6IcMbZHgCI;n8CRlR7&lt;YcK0@cY[8aDHj=GGkNK;C?KC?b=]mMejoc1gGol1&gt;hL6lf5fZ92?Ia@l1;QL024f^NSm2MhNlcFg_YR[l5kclo:einXehbR&gt;98[4?GC:CX[3hm\UMob2aIMT0eJmgI@\;njRK9]fIl_8f=d]n4bQcRXDEl&lt;o=@Yiik\3Md@?k1=0Joj&gt;?Je`&lt;RUd&lt;JYmeOnOgB3G@Ub\FoGFgIQmQli8nGH=QjKD9i`2nf41XEKj;oDB8iZU`@XP^KWoAKEbOf:ViVAl=_I37KJSec7Ea\nJ5]NZj\OnJF;ASQemRIDbbdglb\U&gt;H[O^bDHO?XMLaOoeVCf=a^CC`d8^TX2B</protected>
 		<protected>E@=3@J\4110h]L]Mg[cK3fBoj\Kifo1C[KY_3VgFm3_6n&gt;DfdTDgjaSF_LdVUJaY::FII@T:GB9LaYOo80OP^053LBBVb1G?:50k4;P1c\^`03ffoj9S72=AOm;a2oh?Na\lC7TUOXcNfaSdfIbVCC_ao20aN9bmo_&lt;R_S=&gt;KV;lhbmh89SY[:2UflXcmGIlnngoE]\\ad_6_gW8X9GAXJSPJYin&gt;C71=c74a79JN&lt;`GPK]_\&gt;2`h9IOC]VA5BU4AMW1Qc`j?lJ\aR4__&gt;R4SI_`[_mmnM33ONg`3P[g4N5aSF;ce]^eVffg6&gt;cIRLhI]7CjE^W[jW`kZkGEWHk1=RR;gTe:O[H;k[bAd7UCaTVXgjlho3Af&gt;?oIJdjMo&gt;3=o;aTo\ZZnG9_cgcO7mjV^k&gt;\:gkoOkSn1jkfm@MgLnb&lt;Amg;\Nmj8klk3llhhnW&gt;nn^GCW_fW_&gt;ji]:Va&gt;TNnNQdK5LolNX?M@\6jN2ddlIHh=MT1E^[o4Q7I54R=RlVg[S\KmOe9GM:Qeh9OnUhWTeC^ZM7SAGP1V=LZ4[i\cOmoH[RS6YBL2L\PAg][JQ&lt;Eo?8;D9Mk3M]&gt;N^6&gt;HgJ]KP^a&gt;cfBkkmZ33RdU`]jB_NIOShWL4oDlbn3lNOCL??R7GCmKaTDhekoi_En`9oJKe&lt;e1`lBjmjXJ&lt;^4_^_^&gt;?7O?nEE_WTY:VYEc]3^eJm^cdC7;LcK_]Ei&gt;b&lt;^`9HR6YcO&gt;l@Amg&gt;PLXQbSb^=?FXRUZd&lt;[n&lt;SGjgCQ`mhTl;7NUbgaRQBkXNY4iX5iAJX6C`gdG[d3d&gt;`Uj3DPMF7h71WBBLLR&gt;Tk9dZlFCYSi__fNBBT`C;A&gt;jeP2CdONN52i5^eBEIEI=8EMHBBe^G^1ohD6&gt;LRiJgM\IPYE8Wn`T9W@jf8iEfN:@L3&lt;Ha_l0CCE&lt;HOJjXBRll_NLReo_^K7CQWihL&lt;B1::YXdSaG&lt;XFnCP94dQXb;^6V07F&gt;TkPem&gt;4QI;?9JkF`g80:`G?AULFSY^XW;4XL^_D=GZV9VVODS^[=]dL]b=N;O[ib6]2aLATM7\AcX=JH&lt;\1j8_?I9_VUO]5;PKjdi^o&gt;Kn=FbmhAmF3EXh?dAPF?cWPU;NHFT9YBblF15fj0n]RK9&gt;d;@lD9HXLGTZOAa;gEd6:MElAPOkOoMom`hnaYko^ne_;PeC\`kMYOoCalP3DR_^NADNSV6R1Nk4f?=Lo;VQ&gt;7&gt;fR@=2j8C:;D@3fk&gt;^=YHE^PQ1fU&gt;TFoNH&gt;GnfRGNMNW`[okK`S56RJfM4Zmo^6E9ZYc&gt;FNEO3PO=T9eK0:bgljYdR7WooKS9eTjd@bcImNVZ8UXa:AC_F_WCj]4\6ST&lt;:ie_AbZFIL7UmlIne:BcTQ5T2U]O2goYWXRN5F8oeQT^`HXPD=2LV[h;ibbNNj1kU]lXlnX4ACO5aRA@TfHY77@P?L=_N@4^cJG;Wi2@3M5OQ:^@&gt;2K9_9W:4Vn1LGaRN@WL9AFFVg1oYHdi`54XIa5G[\i&gt;iPT4506XA7h2^c_T`3d[ARdFICaAS2RM:1KgT7B&gt;MhXVaI&lt;kA^@CX2aS^I:B&gt;=W&lt;U?l&lt;DWU&lt;Jd7^cKe2R]EdIBcBQZni_K1JPCEhV&gt;VH]FBZ&lt;5413k[U]MAFA`Ohma2g2NoU0@E;FI93Yi;RjnlScC;`glEaH^X@K[NY9Y1EUZc6V6\3?FKC0APU0^[aP:_GMI=eeWnJ&lt;6e2]@;AXaAE&lt;S[lhAb`XFjPP@dTXNYS=&lt;568je\`W3?@gn9HDaM84^&gt;SDl0&lt;Ba6YNKCeYZ\CUU?WGnR4=m^aN[KTlFG\?VZ[MC:3HfflAagl\jZUG@ScZW:2K\FU9TQa&lt;h;?iYb&lt;RJI66IEg&lt;WHgdkU:\KFIZG\BDU=9W&gt;:\:W7nM3NIjXT;2YV[@dDaY3bhOQY^af&lt;UVo:ZV^^@0d_M5ObRQ2PIHZ9bbbGm;4Z\KEfEYI=M];D@9j1kZ@2@FIkf9:\CYe5KnKANXH7R@eMc2M;Pl]PZG]@4h2Q7OY:=QFh@\Y6]E6X1bL6mjS76a`JS=H=XQReG6Djb7[c&lt;h@S5UCX4`ABLQ4:ZZ7=JF9JejC5\[T:meE5_[:`Qm=DfI0EDQLRH6o]LAPRXlbTgXSbnW7ZTN?N]lH02JKm;Z4hn&lt;A[89:C8lM5hC]Ab^\\WNK7JGS]XainLm:PWFF3EmC15\]YC\D;I6a&lt;NiIhd2GMIG`A9\[]T00fP:UXIXSHk2jI&gt;XFG&gt;I521bbKDA`Xb]h&gt;oAl&gt;IolbRB7j=i9_H89&lt;FR=U572U\LjNhnkeeemHDJJ\GHX\;J51M&lt;?QV2DneREAR3in6&lt;M75M_Re=Ci3gEOQ2VO`4P8_hfhSO\dZ7m]n\hlV6gSlSC@PoZSe8WUaY3d0_;Z=9H:I6Gf2PVG`mf8CC87@DBlT62^h6QFFhZF64BJ46@Dh&lt;T1=C]0_9J?073S@61ADIUT31&lt;mVE&lt;W?R@RBUJP`@;50X2Bh618KM^bf033T033D?NM@P`?0\dBA3A8AXF0]@KnP[5&lt;EDfUICcBF^EZT=:cWKBKYTDKXD=&lt;A:mkNB7LFDHC9b7nG57NFZ1]Ubo]8]0MN]YWJJ&gt;eS42I?===3_n_?J=384=Go8e^0mdmBiTjRaf;F@8M4_gCZSGQ3cUUnF6J_R9WJV0PNaTJDk&lt;RiWS6=&gt;Rf9EmM:WgL4LHg5oH[aMbbOlnI6b`9KZ^Z]oAdeH\@YgaV8ChHTKjEVA]a^YN&lt;;71CAbR\&lt;jAYI\\Y&lt;R\`1AOol`j1&gt;53?d8MV_@kAN_W4nIdKc0gRYHEo`]U?HWN?0&lt;?l2h:ZC\&gt;^D]Ug4FNZl123fNoZ7fLRB[_HR6O&gt;BaoomWl_8YS0Q\8;RB]@j=GIIe]J&lt;AT[;1I&lt;5ZJ\?Va5g?&gt;7hXgcbU4V=lT&gt;nV[28JKeQJ5QX4^WD3MfTBIBPKU57e&gt;[FRd&gt;_EeSHJhDa4hM9S9TUlOR=KWn]eAJ]W5VROh9ak`n5&lt;LV6L9d&lt;0`?fk]J8FW52OlL2i&lt;L1kO=mGBf9e:\`^[_J:F&gt;7o0_9mGc_`=KP@SW_^NU525JcQcEGhR8Da3gf4mJ?R6a2lLPKjL:TlfL8iHOKf:Mjeb\&gt;Xb3&gt;0kM@iNkaifYHDFNIKP\e^;bhg@V&lt;g0Za7F]R=JKPMgdg&gt;nYaMSb8MAV0o05XKjM5&lt;5^V=albT\&lt;868hhl^jHPRa0KcT4i[31chfOeGW&gt;;``&gt;&gt;I;B:YafYW&gt;jW_7D1&gt;9_X14U9VXJ5E_PA2ZPb&gt;n6eBLcN]SU4eSd&lt;IDGD4D5WHMlFCU0DeARScb:h\?EC1&gt;IBWead&gt;7F&gt;FeBea\oCS]jf@kE47ZHcB?TlP6_K[QC2@_N&gt;ilNn0VdgZE&gt;Z98hXCHa4bNUM16M74Q;DhldmcZ&gt;V?_TG1J?NI:F8&lt;aomhdPX5^AEe6BRYle4clf_gSb6D9LaD2h]ij8SAH@[`J@cb2G7ee@iZWl2A&gt;`Ga95FDhJo7Xo&gt;Zd3[jL&lt;DQ4OILX9a;0T\SUDWY:Bh&gt;WGNb:dHQ[S`[8:1L:F@&gt;H[49RQ6_3QV&lt;UT0oIITF^H_\X=:&lt;42`N``YjM75HWEd]5O`&lt;EX89FTP`^oN:QHgED5k:\CaYbA2GbD1;X5:N;?SoLhVhR`R_9lg3hU4n:I`2Gn:IjDHED]5i=2fcTklTK1H6k4HjK;HBM&gt;;c]9;i[MFD?WaY1O]oS293kLd9S3N6He?:_QKEcBGLOc:jB6H@fR]h]HGB5;:&lt;RE&lt;`3K4Ibi29dR;nU&lt;&lt;TKBRnTdK[ZTT6oiOVVXKgaP6&lt;lMTO_JC\0&lt;RY5NkR352&lt;FbcCB&lt;_3?0XjQ`BJP;OJR::8eHFb3&lt;;M\9FOC8T:MkD:Z;C=eb^0:AMSbSY_^Lc=SGbD5WDh@6j]PCDc@;\X1Nb\[`Z0W_Th5&lt;HD4CafYghb`T95Ko571]SZJDHF2eE&lt;7jViL_\8TQ@dFRo]`G[h3&gt;862l:2F[UU6dVbFjU?NI&gt;OHOk&gt;JNcFNU[mXi]iJ[neWQ\mWa]i[e?IkO^Mf]LHTP[G3?43M8g^Wh``lW3kBT7ADM6b_IUCIPO=C8g5@?9R3&lt;hilXNY7_&lt;THNN&lt;KMLm;eGM6_A6AUDB\c5Q;S2POniP9[mdEeIDnO7;T7Nia2nFN\L2XZIP?ZJKW\2cK0U5fb[dLn?[C&gt;YAMXfVFic02OQA\6LHEk0oBd0f;`kR1hImAUl:@I;^:oFJUF?mDgPlLokm]OIgenn9;n5[Oh3g7@W7OWBCk9X1mYDPF9AQ4LOGeM_D_WR?I7QRlVEmN_0QlA9^lO[HjnfngGjkHokO\A35=_4hVU^jKm;\?Y9^B=RkTG1I&lt;6nI`AQ_kJ;of[GmIi[g0]1\UG_FKUnX]ZcGmoI;NUdDFOolHn;NbMLkT`1GEo;j63N_8b_O`PQ[KRjb&lt;NDHW4;\lT[Ila;nMd`56_c\C25fJLUS;9fn@6[[SMIBBMFK\8d;ZIRSI;fJ5_cojWSIfcY2kNd1jkS0f9A3BNfk8W1m4H0gRbfA3J6Q726nmNm4PQYcWZ___NEf_FmmmOm40IZ1mf4PmS?H8k&gt;=J3g&lt;\1K6j;CNTGZ8kY61mk30RLUO`T`_H`Hg&lt;`\K67=HJ3g&lt;\3K6iGRVO9``_1H`L`\K6`f=371ikY61mf30S&lt;W]K86enT`_H`Hg&lt;=fbaLQO`c@&lt;hK;Rmmf&gt;KT=]4\mm;NkW]^mcFgV[_]l=8aHk_j]MgIEYV5XJkiW]l^^CKnYn2OgNJ0g&lt;fR\mWo;?JNcFN^cfL_eWZ[Eff[LeWebL[d?YfWFm3O0neW6m3NP3nGQ@G_M?lS61c3KG?`NUXHYTJ?j1SoC7V&gt;RGj_]d[blRO_M^Qg&gt;f_[0oQJWgg`CkhXXJ\hG;1Ujg`4MNjIg_6l3GG;oohYSNBallm3eZnFmebBeaLSDIS17WJfDBN9nUo^n2oC_;Q\;4O3WWk7mAZI17;2]ChHfZeJ;I\fY;^dB\J;NW@cEDj]HE]B8GSiKJgN9M6f4UIKhV02kFjYnXXBH9lF?3gDC&lt;EC`d=4l&lt;aIYa?]YS&lt;9Zl8]AkXcPg:6L69WWX^8R2;YXfC&lt;Xg6AQg@oOoChH=41ln]AG?J3U0Wn&gt;8[8cdWGUnL2Z&gt;Ll4HaNcI&lt;f]SiWCVXSMeP?^a7:Tf&lt;`L3cKdmDl7?Uj&gt;FnPG5NSQBkHE`Yj&gt;ZNQ^;UbDk0kCT]3]YV&lt;50o&lt;2&lt;aTY7THb5hg;3^hl@GYRZE@mbL?5gdHJNW5`6W8[eho^38?;R459L4WN1Jg[egNX[3[_&gt;lAAY&gt;L9Z_H5YN]9:KZMj\cPGZco]??=ig[hH7YShgPS8:44leI:@9R?fLHKlH6UZ]nlAXHFAFUn7AdT=;FK^oZgocoK[2W_=Aj]T;2mBd8`7h`B0K&gt;IP&lt;04@S6]dA9N`8Q8YBk19T@8RFF4T29OB1V7TX7QM01@hI@3`QJ=4@H\nBkS2d5P1BDgN8?4B230Y8lb8ONC@?IPH0A@OMPD?HZ@1`&gt;mj`5N5c60PN06hNI1c8`@k6b0M9IN3`QM68;M1l5Bl&gt;6cX&gt;XD78V@S2j5Ad;C&lt;0cA7OX0nM8&lt;iaN3K0@0Kil664BNSOe:0@R=6NA66f9@PX0d0dHb:LL\6@1aSJl[5h6I38X&lt;0`;0&lt;Al748MXb84H=@Y&lt;lI\5@GNMD;RJd?DeY0Ac1J230g&gt;d1e00LP8d;&gt;V@59CQA1BG&lt;@2[2A45hE8CX:H0A=a\KRAC&lt;Q0YPRb5D&lt;IR63P1QX&lt;JXCS9a3FQ&gt;daQVRjO4I;1da1URZ;LZ444@R2PX2XAXA9Te@FngkoKI_ea&gt;NZN^m\`1H5CMhX9Bn1?ZYS0WAbR2RD8F3W@XajF1=AXS6&lt;TS4i09PN?`gPUG9G3J26`2GbAW]jGY5&lt;AGn^iZAjM_;W5&lt;g^kKMC]B[X13GZm3mmNffKMhb:cJ]DAT&gt;a?_4H8jZX2PIja6[DFTFC:]l]=1AN=PD`VJ&gt;HX2k?Pj7:bQ`W[XWe0\38&lt;V=I\:]2HOl74S6e0a;ZmCFf:3FnRcED67[hUWZPU7ZZKLUVD\PFX_FVE23Q7WUaWV=U&gt;&lt;ZRLQB8LDd0hS94OC1D?6J9N:\\`US2k:iaJY8jY]eTVWO0KLeICMh3dn\dH86aYA7eY]eZZ3=d6WJLE7IPEWIe=_c4FYLEhdA\b5XoJQE;n[HFdKI7C3oK`RFK6l`B8RhhCXhP8XnP3841548PB6P6B[DKHS41JU&lt;Qne:U\ARQ=B[VDHSOT307XA07Qhn2d8RBoajKU&gt;9P@S2lYle3RId0IIf072nP8&gt;;NUah=0ilGD:G5\RN_\=;5jTD@iTfQNGIfmQJ2oJl[SBFC]DLncWBE4mFZe6d_Ob&gt;3YC4APEA@D_mOFNI8ALek79bT&gt;:a8]EjYToY&lt;]8C`FV4Z``X`1aB@L&lt;?V9ARCQ4c:K71jA4o8X@_N2@;?hf9D0M0]D;:A]?]T5@Y1`&gt;Vi=L5H`I25YCYJTF@F?fd@VbI9Pf6?dDZY8JdAcR`QM5&gt;MT&lt;aOnO7&lt;DiRiB;\k?RRIHVCkC&lt;FWi=5fXF\he2n@Q&gt;2TEkZIo6kBK3\C@]3\oE]=7UY8knVi7O5=^_a6d;G^?DaLI=YY]ARAc7NRDMhAYZlK90=KQlem6G@;;lecBDFecfKNA=H&gt;mJl3I59=NFgn`nf[B1:05f5E[`fiTPQ4EDe1H=4ZRWkf3TWlOP&gt;Ela5hZDn]cQJC=UBXIIJdWiR@KZe]DHRbmfI;]VYoi&gt;o?3K1h=6</protected>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='21'>
+			<Action classname='StepType' isroottypedef='true' typecategory='1' timestamp='1618215606' typeversion='21.0.0.2' typelastmodversion='21.0.0.0' typeminprodversion='21.0.0.0' typeflags='33554446'>
+				<subprops>
+					<Substeps typename='StepTypeSubstepsArray' xsi:type='StepTypeSubstepsArray' classname='Objs' flagsforinstances='524312' instanceoverrideflags='655384'>
+						<value lbound='[0]' ubound='[]'/>
+					</Substeps>
+					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
+						<value>ResStr("NI_STEPTYPES", "ACTION_DESCRIPTION_NAME") + (("%ModuleDescription" == "") ? "" : ",  %ModuleDescription")</value>
+					</DescriptionFormat>
+					<DefaultNameFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
+						<value>ResStr("NI_STEPTYPES", "ACTION_DEF_STEP_NAME")</value>
+					</DefaultNameFormat>
+					<Menu typename='StepTypeMenu' xsi:type='StepTypeMenu' classname='Obj' flagsforinstances='524312' instanceoverrideflags='524312'>
+						<subprops>
+							<CanBeSubstepType classname='Bool'>
+								<value>false</value>
+							</CanBeSubstepType>
+							<CanOnlyBeSubstepType classname='Bool'>
+								<value>false</value>
+							</CanOnlyBeSubstepType>
+							<Category classname='Str'>
+								<value>""</value>
+							</Category>
+							<ItemName classname='ExprValue'>
+								<value>ResStr("NI_STEPTYPES", "ACTION_MENU_ITEM_NAME")</value>
+							</ItemName>
+							<SingularItemName classname='Str'>
+								<value>""</value>
+							</SingularItemName>
+							<SeparatorBeforeCategory classname='Bool'>
+								<value>false</value>
+							</SeparatorBeforeCategory>
+							<SeparatorBeforeItemName classname='Bool'>
+								<value>false</value>
+							</SeparatorBeforeItemName>
+							<Group classname='Str'>
+								<value>Action</value>
+							</Group>
+						</subprops>
+					</Menu>
+					<AdditionalResultsHints classname='Objs' valueflags='4194328' structureflags='524288'>
+						<value lbound='[0]' ubound='[]'>
+							<elemproto>
+								<_NAME_IN_ATTRIBUTE_ typename='NI_CustomResult' xsi:type='NI_CustomResult' name='' classname='CustomResult'>
+									<subprops>
+										<Name classname='ExprValue'>
+											<value/>
+										</Name>
+										<ValueToLog classname='ExprValue'>
+											<value/>
+										</ValueToLog>
+										<Condition classname='ExprValue'>
+											<value/>
+										</Condition>
+										<Flags classname='Num'>
+											<value>8192</value>
+										</Flags>
+										<CheckedState classname='Num'>
+											<value>2</value>
+										</CheckedState>
+										<Type classname='PropertyObjectType'>
+											<subprops>
+												<ValueType classname='Num'>
+													<value>3</value>
+												</ValueType>
+												<IsObject classname='Bool'>
+													<value>true</value>
+												</IsObject>
+												<TypeName classname='Str'>
+													<value/>
+												</TypeName>
+												<ElementType classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</ElementType>
+												<ArrayDimensions classname='ArrayDimensions'>
+													<subprops>
+														<LowerBounds classname='Nums'>
+															<value lbound='[0]' ubound='[]'/>
+														</LowerBounds>
+														<UpperBounds classname='Nums'>
+															<value lbound='[0]' ubound='[]'/>
+														</UpperBounds>
+													</subprops>
+												</ArrayDimensions>
+												<Representation classname='Num'>
+													<value>1</value>
+												</Representation>
+												<ClassName classname='Str'>
+													<value/>
+												</ClassName>
+											</subprops>
+										</Type>
+										<Elements classname='Objs'>
+											<value lbound='[0]' ubound='[]'/>
+										</Elements>
+										<IsAnyType classname='Bool'>
+											<value>true</value>
+										</IsAnyType>
+									</subprops>
+								</_NAME_IN_ATTRIBUTE_>
+							</elemproto>
+						</value>
+					</AdditionalResultsHints>
+					<TS typename='TEInf' xsi:type='TEInf' classname='Obj' flagsforinstances='262168' instanceoverrideflags='4456472'>
+						<subprops>
+							<Id classname='Str'>
+								<value/>
+							</Id>
+							<Icon classname='Str'>
+								<value/>
+							</Icon>
+							<SData classname='Obj' flagsforinstances='2097152' instanceoverrideflags='7143448' structureflags='2097152'/>
+							<PreCond classname='ExprValue'>
+								<value/>
+							</PreCond>
+							<LoadOpt classname='Str'>
+								<value>PreloadWhenExecuted</value>
+							</LoadOpt>
+							<UnloadOpt classname='Str'>
+								<value>UnloadWithFile</value>
+							</UnloadOpt>
+							<Mode classname='Str'>
+								<value>Normal</value>
+							</Mode>
+							<WindowActivation classname='Str'>
+								<value>None</value>
+							</WindowActivation>
+							<ResultOption classname='Num'>
+								<value>1</value>
+							</ResultOption>
+							<StepFCSeqF classname='Bool'>
+								<value>true</value>
+							</StepFCSeqF>
+							<IgnoreRTE classname='Bool'>
+								<value>false</value>
+							</IgnoreRTE>
+							<UseMutex classname='Bool'>
+								<value>false</value>
+							</UseMutex>
+							<MutexNameOrRef classname='ExprValue'>
+								<value/>
+							</MutexNameOrRef>
+							<BatchSyncOpt classname='Num'>
+								<value>0</value>
+							</BatchSyncOpt>
+							<SwitchEnabled classname='Bool'>
+								<value>false</value>
+							</SwitchEnabled>
+							<VirtualDeviceName classname='ExprValue'>
+								<value/>
+							</VirtualDeviceName>
+							<SwitchOperation classname='Num'>
+								<value>1</value>
+							</SwitchOperation>
+							<RouteGroupConnect classname='ExprValue'>
+								<value/>
+							</RouteGroupConnect>
+							<RouteGroupDisconnect classname='ExprValue'>
+								<value/>
+							</RouteGroupDisconnect>
+							<MulticonnectMode classname='Num'>
+								<value>1</value>
+							</MulticonnectMode>
+							<OperationOrder classname='Num'>
+								<value>2</value>
+							</OperationOrder>
+							<ConnectionLifetime classname='Num'>
+								<value>0</value>
+							</ConnectionLifetime>
+							<WaitForDebounce classname='Bool'>
+								<value>true</value>
+							</WaitForDebounce>
+							<PassAct classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
+								<value>Next</value>
+							</PassAct>
+							<FailAct classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
+								<value>Next</value>
+							</FailAct>
+							<PassActTarget classname='ExprValue' flagsforinstances='1' instanceoverrideflags='5046297'>
+								<value/>
+							</PassActTarget>
+							<FailActTarget classname='ExprValue' flagsforinstances='1' instanceoverrideflags='5046297'>
+								<value/>
+							</FailActTarget>
+							<CustExpr classname='ExprValue'>
+								<value/>
+							</CustExpr>
+							<CustTrueAct classname='Str'>
+								<value>Next</value>
+							</CustTrueAct>
+							<CustFalseAct classname='Str'>
+								<value>Next</value>
+							</CustFalseAct>
+							<CustTrueActTarget classname='ExprValue'>
+								<value/>
+							</CustTrueActTarget>
+							<CustFalseActTarget classname='ExprValue'>
+								<value/>
+							</CustFalseActTarget>
+							<LoopType classname='Str'>
+								<value>NoLooping</value>
+							</LoopType>
+							<LoopWhile classname='ExprValue'>
+								<value/>
+							</LoopWhile>
+							<LoopStatus classname='ExprValue'>
+								<value/>
+							</LoopStatus>
+							<LoopIncrement classname='ExprValue'>
+								<value>RunState.LoopIndex += 1</value>
+							</LoopIncrement>
+							<LoopInitialize classname='ExprValue'>
+								<value>RunState.LoopIndex = 0</value>
+							</LoopInitialize>
+							<LoopOpt classname='Num'>
+								<value>0</value>
+							</LoopOpt>
+							<PreExpr classname='ExprValue'>
+								<value/>
+							</PreExpr>
+							<PostExpr classname='ExprValue'>
+								<value/>
+							</PostExpr>
+							<StatusExpr classname='ExprValue'>
+								<value/>
+							</StatusExpr>
+							<CanSpecifyModule classname='Bool'>
+								<value>true</value>
+							</CanSpecifyModule>
+							<CanEditCode classname='Bool'>
+								<value>true</value>
+							</CanEditCode>
+							<CanEditModulePrototype classname='Bool'>
+								<value>true</value>
+							</CanEditModulePrototype>
+							<CanEditParameterAdditionalResults classname='Bool'>
+								<value>true</value>
+							</CanEditParameterAdditionalResults>
+							<PrecondIntExe classname='Num'>
+								<value>0</value>
+							</PrecondIntExe>
+							<Requirements classname='Obj' flagsforinstances='1' valueflags='1' structureflags='2097152'>
+								<subprops>
+									<Links classname='Strs' flagsforinstances='71303168' instanceoverrideflags='72286233' valueflags='71303168'>
+										<value lbound='[0]' ubound='[]'/>
+									</Links>
+								</subprops>
+							</Requirements>
+							<CustomResults classname='Objs'>
+								<value lbound='[0]' ubound='[]'>
+									<elemproto>
+										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+											<subprops>
+												<Name classname='ExprValue'>
+													<value/>
+												</Name>
+												<ValueToLog classname='ExprValue'>
+													<value/>
+												</ValueToLog>
+												<Condition classname='ExprValue'>
+													<value/>
+												</Condition>
+												<Flags classname='Num'>
+													<value>8192</value>
+												</Flags>
+												<CheckedState classname='Num'>
+													<value>2</value>
+												</CheckedState>
+												<Type classname='PropertyObjectType'>
+													<subprops>
+														<ValueType classname='Num'>
+															<value>3</value>
+														</ValueType>
+														<IsObject classname='Bool'>
+															<value>true</value>
+														</IsObject>
+														<TypeName classname='Str'>
+															<value/>
+														</TypeName>
+														<ElementType classname='Objs'>
+															<value lbound='[0]' ubound='[]'/>
+														</ElementType>
+														<ArrayDimensions classname='ArrayDimensions'>
+															<subprops>
+																<LowerBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</LowerBounds>
+																<UpperBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</UpperBounds>
+															</subprops>
+														</ArrayDimensions>
+														<Representation classname='Num'>
+															<value>1</value>
+														</Representation>
+														<ClassName classname='Str'>
+															<value/>
+														</ClassName>
+													</subprops>
+												</Type>
+												<Elements classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</Elements>
+												<IsAnyType classname='Bool'>
+													<value>true</value>
+												</IsAnyType>
+											</subprops>
+										</_NAME_IN_ATTRIBUTE_>
+									</elemproto>
+								</value>
+							</CustomResults>
+							<AdditionalResultsHints classname='Objs'>
+								<value lbound='[0]' ubound='[]'>
+									<elemproto>
+										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+											<subprops>
+												<Name classname='ExprValue'>
+													<value/>
+												</Name>
+												<ValueToLog classname='ExprValue'>
+													<value/>
+												</ValueToLog>
+												<Condition classname='ExprValue'>
+													<value/>
+												</Condition>
+												<Flags classname='Num'>
+													<value>8192</value>
+												</Flags>
+												<CheckedState classname='Num'>
+													<value>2</value>
+												</CheckedState>
+												<Type classname='PropertyObjectType'>
+													<subprops>
+														<ValueType classname='Num'>
+															<value>3</value>
+														</ValueType>
+														<IsObject classname='Bool'>
+															<value>true</value>
+														</IsObject>
+														<TypeName classname='Str'>
+															<value/>
+														</TypeName>
+														<ElementType classname='Objs'>
+															<value lbound='[0]' ubound='[]'/>
+														</ElementType>
+														<ArrayDimensions classname='ArrayDimensions'>
+															<subprops>
+																<LowerBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</LowerBounds>
+																<UpperBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</UpperBounds>
+															</subprops>
+														</ArrayDimensions>
+														<Representation classname='Num'>
+															<value>1</value>
+														</Representation>
+														<ClassName classname='Str'>
+															<value/>
+														</ClassName>
+													</subprops>
+												</Type>
+												<Elements classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</Elements>
+												<IsAnyType classname='Bool'>
+													<value>true</value>
+												</IsAnyType>
+											</subprops>
+										</_NAME_IN_ATTRIBUTE_>
+									</elemproto>
+								</value>
+							</AdditionalResultsHints>
+						</subprops>
+					</TS>
+					<NI_Data typename='StepTypeNIData' xsi:type='StepTypeNIData' classname='Obj'>
+						<subprops>
+							<EditPanels classname='Strs'>
+								<value lbound='[0]' ubound='[]'/>
+							</EditPanels>
+						</subprops>
+					</NI_Data>
+					<Result classname='Obj' flagsforinstances='4194304' valueflags='4194304'>
+						<subprops>
+							<Error typename='Error' xsi:type='Error' classname='Obj' flagsforinstances='4194304' instanceoverrideflags='4194304' valueflags='4194304'>
+								<subprops>
+									<Code classname='Num'>
+										<value>0</value>
+									</Code>
+									<Msg classname='Str'>
+										<value/>
+									</Msg>
+									<Occurred classname='Bool'>
+										<value>false</value>
+									</Occurred>
+								</subprops>
+							</Error>
+							<Status classname='Str' flagsforinstances='4194304' valueflags='4194304'>
+								<value/>
+							</Status>
+							<ReportText classname='Str' flagsforinstances='4194304' valueflags='4194304'>
+								<value/>
+							</ReportText>
+							<Common typename='CommonResults' xsi:type='CommonResults' classname='Obj' instanceoverrideflags='4194304'/>
+						</subprops>
+					</Result>
+					<CodeTemplates classname='Str' valueflags='4194328' structureflags='524288'>
+						<value>DefaultLabVIEW|DefaultLabVIEWNXG|DefaultCVI|DefaultVB.NET|DefaultCSharp.NET|DefaultC++.NET|DefaultVC++_Template|DefaultHTB72_Template|DefaultHTB80_Template|Default_Template</value>
+					</CodeTemplates>
+					<BlockStartTypes classname='Str' valueflags='4194328' structureflags='524288'>
+						<value/>
+					</BlockStartTypes>
+					<BlockEndTypes classname='Str' valueflags='4194328' structureflags='524288'>
+						<value/>
+					</BlockEndTypes>
+					<AppliesToBlockStructure classname='Bool' valueflags='4194328' structureflags='524288'>
+						<value>false</value>
+					</AppliesToBlockStructure>
+					<CanEncapsulate classname='Bool' valueflags='4194328' structureflags='524288'>
+						<value>false</value>
+					</CanEncapsulate>
+					<Category classname='Str' valueflags='24' structureflags='524288'>
+						<value>Action</value>
+					</Category>
+				</subprops>
+			</Action>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='29'>
+			<NI_PythonParameterResult classname='PythonParameterResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+				<subprops>
+					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</Condition>
+					<Flags classname='Num'>
+						<value>8192</value>
+						<numericfmt>%#x</numericfmt>
+					</Flags>
+					<CheckedState classname='Num'>
+						<value>1</value>
+					</CheckedState>
+				</subprops>
+			</NI_PythonParameterResult>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='28'>
+			<NI_PythonParameter classname='CPythonParameter' isroottypedef='true' typecategory='3' timestamp='1650060872' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+				<subprops>
+					<Name classname='Str'>
+						<value>_notNamed</value>
+					</Name>
+					<Type classname='Num'>
+						<value>7</value>
+					</Type>
+					<ArgumentValue typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</ArgumentValue>
+					<ArgumentDisplayValue typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</ArgumentDisplayValue>
+					<AdditionalResults classname='Obj'>
+						<subprops>
+							<Input typename='NI_PythonParameterResult' xsi:type='NI_PythonParameterResult' classname='PythonParameterResult'>
+								<subprops>
+									<Condition classname='ExprValue'>
+										<value/>
+									</Condition>
+									<Flags classname='Num'>
+										<value>8192</value>
+									</Flags>
+									<CheckedState classname='Num'>
+										<value>1</value>
+									</CheckedState>
+								</subprops>
+							</Input>
+							<Output typename='NI_PythonParameterResult' xsi:type='NI_PythonParameterResult' classname='PythonParameterResult'>
+								<subprops>
+									<Condition classname='ExprValue'>
+										<value/>
+									</Condition>
+									<Flags classname='Num'>
+										<value>8192</value>
+									</Flags>
+									<CheckedState classname='Num'>
+										<value>1</value>
+									</CheckedState>
+								</subprops>
+							</Output>
+						</subprops>
+					</AdditionalResults>
+				</subprops>
+			</NI_PythonParameter>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='27'>
+			<PythonStepAdditions classname='CPythonModule' isroottypedef='true' typecategory='3' timestamp='1650060872' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+				<subprops>
+					<PythonCall classname='CPythonCall'>
+						<subprops>
+							<UseAdapterSettingsForInterpreterSession classname='Bool'>
+								<value>true</value>
+							</UseAdapterSettingsForInterpreterSession>
+							<InterpreterSessionScope classname='Num'>
+								<value>3</value>
+							</InterpreterSessionScope>
+							<PythonVersion classname='Str'>
+								<value/>
+							</PythonVersion>
+							<PythonVirtualEnvironmentPath classname='Str'>
+								<value/>
+							</PythonVirtualEnvironmentPath>
+							<InterpreterLocation typename='Expression' xsi:type='Expression' classname='ExprValue'>
+								<value/>
+							</InterpreterLocation>
+							<CreateIfInterpreterDoesNotExist classname='Bool'>
+								<value>true</value>
+							</CreateIfInterpreterDoesNotExist>
+							<ModulePath typename='Path' xsi:type='Path' classname='PathValue'>
+								<value/>
+							</ModulePath>
+							<OperationType classname='Num'>
+								<value>1</value>
+							</OperationType>
+							<OperationScope classname='Num'>
+								<value>0</value>
+							</OperationScope>
+							<ClassName classname='Str'>
+								<value/>
+							</ClassName>
+							<ClassInstanceLocation typename='Expression' xsi:type='Expression' classname='ExprValue'>
+								<value/>
+							</ClassInstanceLocation>
+							<FunctionOrAttributeName classname='Str'>
+								<value/>
+							</FunctionOrAttributeName>
+							<Parameters classname='Objs'>
+								<value lbound='[0]' ubound='[0]'>
+									<elemproto>
+										<_NAME_IN_ATTRIBUTE_ typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name='' classname='CPythonParameter' structureflags='131072'>
+											<subprops>
+												<Name classname='Str'>
+													<value>_notNamed</value>
+												</Name>
+												<Type classname='Num'>
+													<value>7</value>
+												</Type>
+												<ArgumentValue classname='ExprValue'>
+													<value/>
+												</ArgumentValue>
+												<ArgumentDisplayValue classname='ExprValue'>
+													<value/>
+												</ArgumentDisplayValue>
+												<AdditionalResults classname='Obj'>
+													<subprops>
+														<Input classname='PythonParameterResult'>
+															<subprops>
+																<Condition classname='ExprValue'>
+																	<value/>
+																</Condition>
+																<Flags classname='Num'>
+																	<value>8192</value>
+																</Flags>
+																<CheckedState classname='Num'>
+																	<value>1</value>
+																</CheckedState>
+															</subprops>
+														</Input>
+														<Output classname='PythonParameterResult'>
+															<subprops>
+																<Condition classname='ExprValue'>
+																	<value/>
+																</Condition>
+																<Flags classname='Num'>
+																	<value>8192</value>
+																</Flags>
+																<CheckedState classname='Num'>
+																	<value>1</value>
+																</CheckedState>
+															</subprops>
+														</Output>
+													</subprops>
+												</AdditionalResults>
+											</subprops>
+										</_NAME_IN_ATTRIBUTE_>
+									</elemproto>
+									<value>
+										<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
+											<subprops>
+												<Name classname='Str'>
+													<value>Return Value</value>
+												</Name>
+												<Type classname='Num'>
+													<value>7</value>
+												</Type>
+												<ArgumentValue classname='ExprValue'>
+													<value/>
+												</ArgumentValue>
+												<ArgumentDisplayValue classname='ExprValue'>
+													<value/>
+												</ArgumentDisplayValue>
+												<AdditionalResults classname='Obj'>
+													<subprops>
+														<Input classname='PythonParameterResult'>
+															<subprops>
+																<Condition classname='ExprValue'>
+																	<value/>
+																</Condition>
+																<Flags classname='Num'>
+																	<value>8192</value>
+																</Flags>
+																<CheckedState classname='Num'>
+																	<value>1</value>
+																</CheckedState>
+															</subprops>
+														</Input>
+														<Output classname='PythonParameterResult'>
+															<subprops>
+																<Condition classname='ExprValue'>
+																	<value/>
+																</Condition>
+																<Flags classname='Num'>
+																	<value>8192</value>
+																</Flags>
+																<CheckedState classname='Num'>
+																	<value>1</value>
+																</CheckedState>
+															</subprops>
+														</Output>
+													</subprops>
+												</AdditionalResults>
+											</subprops>
+										</CPythonParameter>
+									</value>
+								</value>
+							</Parameters>
+							<DefaultParamCategoryForArray classname='Num'>
+								<value>5</value>
+							</DefaultParamCategoryForArray>
+						</subprops>
+					</PythonCall>
+				</subprops>
+			</PythonStepAdditions>
+		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='22'>
 			<EditSubstep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
 				<subprops>
@@ -3592,652 +4233,11 @@
 				</subprops>
 			</Statement>
 		</typedef>
-		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='21'>
-			<Action classname='StepType' isroottypedef='true' typecategory='1' timestamp='1618215606' typeversion='21.0.0.2' typelastmodversion='21.0.0.0' typeminprodversion='21.0.0.0' typeflags='33554446'>
-				<subprops>
-					<Substeps typename='StepTypeSubstepsArray' xsi:type='StepTypeSubstepsArray' classname='Objs' flagsforinstances='524312' instanceoverrideflags='655384'>
-						<value lbound='[0]' ubound='[]'/>
-					</Substeps>
-					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
-						<value>ResStr("NI_STEPTYPES", "ACTION_DESCRIPTION_NAME") + (("%ModuleDescription" == "") ? "" : ",  %ModuleDescription")</value>
-					</DescriptionFormat>
-					<DefaultNameFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
-						<value>ResStr("NI_STEPTYPES", "ACTION_DEF_STEP_NAME")</value>
-					</DefaultNameFormat>
-					<Menu typename='StepTypeMenu' xsi:type='StepTypeMenu' classname='Obj' flagsforinstances='524312' instanceoverrideflags='524312'>
-						<subprops>
-							<CanBeSubstepType classname='Bool'>
-								<value>false</value>
-							</CanBeSubstepType>
-							<CanOnlyBeSubstepType classname='Bool'>
-								<value>false</value>
-							</CanOnlyBeSubstepType>
-							<Category classname='Str'>
-								<value>""</value>
-							</Category>
-							<ItemName classname='ExprValue'>
-								<value>ResStr("NI_STEPTYPES", "ACTION_MENU_ITEM_NAME")</value>
-							</ItemName>
-							<SingularItemName classname='Str'>
-								<value>""</value>
-							</SingularItemName>
-							<SeparatorBeforeCategory classname='Bool'>
-								<value>false</value>
-							</SeparatorBeforeCategory>
-							<SeparatorBeforeItemName classname='Bool'>
-								<value>false</value>
-							</SeparatorBeforeItemName>
-							<Group classname='Str'>
-								<value>Action</value>
-							</Group>
-						</subprops>
-					</Menu>
-					<AdditionalResultsHints classname='Objs' valueflags='4194328' structureflags='524288'>
-						<value lbound='[0]' ubound='[]'>
-							<elemproto>
-								<_NAME_IN_ATTRIBUTE_ typename='NI_CustomResult' xsi:type='NI_CustomResult' name='' classname='CustomResult'>
-									<subprops>
-										<Name classname='ExprValue'>
-											<value/>
-										</Name>
-										<ValueToLog classname='ExprValue'>
-											<value/>
-										</ValueToLog>
-										<Condition classname='ExprValue'>
-											<value/>
-										</Condition>
-										<Flags classname='Num'>
-											<value>8192</value>
-										</Flags>
-										<CheckedState classname='Num'>
-											<value>2</value>
-										</CheckedState>
-										<Type classname='PropertyObjectType'>
-											<subprops>
-												<ValueType classname='Num'>
-													<value>3</value>
-												</ValueType>
-												<IsObject classname='Bool'>
-													<value>true</value>
-												</IsObject>
-												<TypeName classname='Str'>
-													<value/>
-												</TypeName>
-												<ElementType classname='Objs'>
-													<value lbound='[0]' ubound='[]'/>
-												</ElementType>
-												<ArrayDimensions classname='ArrayDimensions'>
-													<subprops>
-														<LowerBounds classname='Nums'>
-															<value lbound='[0]' ubound='[]'/>
-														</LowerBounds>
-														<UpperBounds classname='Nums'>
-															<value lbound='[0]' ubound='[]'/>
-														</UpperBounds>
-													</subprops>
-												</ArrayDimensions>
-												<Representation classname='Num'>
-													<value>1</value>
-												</Representation>
-												<ClassName classname='Str'>
-													<value/>
-												</ClassName>
-											</subprops>
-										</Type>
-										<Elements classname='Objs'>
-											<value lbound='[0]' ubound='[]'/>
-										</Elements>
-										<IsAnyType classname='Bool'>
-											<value>true</value>
-										</IsAnyType>
-									</subprops>
-								</_NAME_IN_ATTRIBUTE_>
-							</elemproto>
-						</value>
-					</AdditionalResultsHints>
-					<TS typename='TEInf' xsi:type='TEInf' classname='Obj' flagsforinstances='262168' instanceoverrideflags='4456472'>
-						<subprops>
-							<Id classname='Str'>
-								<value/>
-							</Id>
-							<Icon classname='Str'>
-								<value/>
-							</Icon>
-							<SData classname='Obj' flagsforinstances='2097152' instanceoverrideflags='7143448' structureflags='2097152'/>
-							<PreCond classname='ExprValue'>
-								<value/>
-							</PreCond>
-							<LoadOpt classname='Str'>
-								<value>PreloadWhenExecuted</value>
-							</LoadOpt>
-							<UnloadOpt classname='Str'>
-								<value>UnloadWithFile</value>
-							</UnloadOpt>
-							<Mode classname='Str'>
-								<value>Normal</value>
-							</Mode>
-							<WindowActivation classname='Str'>
-								<value>None</value>
-							</WindowActivation>
-							<ResultOption classname='Num'>
-								<value>1</value>
-							</ResultOption>
-							<StepFCSeqF classname='Bool'>
-								<value>true</value>
-							</StepFCSeqF>
-							<IgnoreRTE classname='Bool'>
-								<value>false</value>
-							</IgnoreRTE>
-							<UseMutex classname='Bool'>
-								<value>false</value>
-							</UseMutex>
-							<MutexNameOrRef classname='ExprValue'>
-								<value/>
-							</MutexNameOrRef>
-							<BatchSyncOpt classname='Num'>
-								<value>0</value>
-							</BatchSyncOpt>
-							<SwitchEnabled classname='Bool'>
-								<value>false</value>
-							</SwitchEnabled>
-							<VirtualDeviceName classname='ExprValue'>
-								<value/>
-							</VirtualDeviceName>
-							<SwitchOperation classname='Num'>
-								<value>1</value>
-							</SwitchOperation>
-							<RouteGroupConnect classname='ExprValue'>
-								<value/>
-							</RouteGroupConnect>
-							<RouteGroupDisconnect classname='ExprValue'>
-								<value/>
-							</RouteGroupDisconnect>
-							<MulticonnectMode classname='Num'>
-								<value>1</value>
-							</MulticonnectMode>
-							<OperationOrder classname='Num'>
-								<value>2</value>
-							</OperationOrder>
-							<ConnectionLifetime classname='Num'>
-								<value>0</value>
-							</ConnectionLifetime>
-							<WaitForDebounce classname='Bool'>
-								<value>true</value>
-							</WaitForDebounce>
-							<PassAct classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
-								<value>Next</value>
-							</PassAct>
-							<FailAct classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
-								<value>Next</value>
-							</FailAct>
-							<PassActTarget classname='ExprValue' flagsforinstances='1' instanceoverrideflags='5046297'>
-								<value/>
-							</PassActTarget>
-							<FailActTarget classname='ExprValue' flagsforinstances='1' instanceoverrideflags='5046297'>
-								<value/>
-							</FailActTarget>
-							<CustExpr classname='ExprValue'>
-								<value/>
-							</CustExpr>
-							<CustTrueAct classname='Str'>
-								<value>Next</value>
-							</CustTrueAct>
-							<CustFalseAct classname='Str'>
-								<value>Next</value>
-							</CustFalseAct>
-							<CustTrueActTarget classname='ExprValue'>
-								<value/>
-							</CustTrueActTarget>
-							<CustFalseActTarget classname='ExprValue'>
-								<value/>
-							</CustFalseActTarget>
-							<LoopType classname='Str'>
-								<value>NoLooping</value>
-							</LoopType>
-							<LoopWhile classname='ExprValue'>
-								<value/>
-							</LoopWhile>
-							<LoopStatus classname='ExprValue'>
-								<value/>
-							</LoopStatus>
-							<LoopIncrement classname='ExprValue'>
-								<value>RunState.LoopIndex += 1</value>
-							</LoopIncrement>
-							<LoopInitialize classname='ExprValue'>
-								<value>RunState.LoopIndex = 0</value>
-							</LoopInitialize>
-							<LoopOpt classname='Num'>
-								<value>0</value>
-							</LoopOpt>
-							<PreExpr classname='ExprValue'>
-								<value/>
-							</PreExpr>
-							<PostExpr classname='ExprValue'>
-								<value/>
-							</PostExpr>
-							<StatusExpr classname='ExprValue'>
-								<value/>
-							</StatusExpr>
-							<CanSpecifyModule classname='Bool'>
-								<value>true</value>
-							</CanSpecifyModule>
-							<CanEditCode classname='Bool'>
-								<value>true</value>
-							</CanEditCode>
-							<CanEditModulePrototype classname='Bool'>
-								<value>true</value>
-							</CanEditModulePrototype>
-							<CanEditParameterAdditionalResults classname='Bool'>
-								<value>true</value>
-							</CanEditParameterAdditionalResults>
-							<PrecondIntExe classname='Num'>
-								<value>0</value>
-							</PrecondIntExe>
-							<Requirements classname='Obj' flagsforinstances='1' valueflags='1' structureflags='2097152'>
-								<subprops>
-									<Links classname='Strs' flagsforinstances='71303168' instanceoverrideflags='72286233' valueflags='71303168'>
-										<value lbound='[0]' ubound='[]'/>
-									</Links>
-								</subprops>
-							</Requirements>
-							<CustomResults classname='Objs'>
-								<value lbound='[0]' ubound='[]'>
-									<elemproto>
-										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-											<subprops>
-												<Name classname='ExprValue'>
-													<value/>
-												</Name>
-												<ValueToLog classname='ExprValue'>
-													<value/>
-												</ValueToLog>
-												<Condition classname='ExprValue'>
-													<value/>
-												</Condition>
-												<Flags classname='Num'>
-													<value>8192</value>
-												</Flags>
-												<CheckedState classname='Num'>
-													<value>2</value>
-												</CheckedState>
-												<Type classname='PropertyObjectType'>
-													<subprops>
-														<ValueType classname='Num'>
-															<value>3</value>
-														</ValueType>
-														<IsObject classname='Bool'>
-															<value>true</value>
-														</IsObject>
-														<TypeName classname='Str'>
-															<value/>
-														</TypeName>
-														<ElementType classname='Objs'>
-															<value lbound='[0]' ubound='[]'/>
-														</ElementType>
-														<ArrayDimensions classname='ArrayDimensions'>
-															<subprops>
-																<LowerBounds classname='Nums'>
-																	<value lbound='[0]' ubound='[]'/>
-																</LowerBounds>
-																<UpperBounds classname='Nums'>
-																	<value lbound='[0]' ubound='[]'/>
-																</UpperBounds>
-															</subprops>
-														</ArrayDimensions>
-														<Representation classname='Num'>
-															<value>1</value>
-														</Representation>
-														<ClassName classname='Str'>
-															<value/>
-														</ClassName>
-													</subprops>
-												</Type>
-												<Elements classname='Objs'>
-													<value lbound='[0]' ubound='[]'/>
-												</Elements>
-												<IsAnyType classname='Bool'>
-													<value>true</value>
-												</IsAnyType>
-											</subprops>
-										</_NAME_IN_ATTRIBUTE_>
-									</elemproto>
-								</value>
-							</CustomResults>
-							<AdditionalResultsHints classname='Objs'>
-								<value lbound='[0]' ubound='[]'>
-									<elemproto>
-										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-											<subprops>
-												<Name classname='ExprValue'>
-													<value/>
-												</Name>
-												<ValueToLog classname='ExprValue'>
-													<value/>
-												</ValueToLog>
-												<Condition classname='ExprValue'>
-													<value/>
-												</Condition>
-												<Flags classname='Num'>
-													<value>8192</value>
-												</Flags>
-												<CheckedState classname='Num'>
-													<value>2</value>
-												</CheckedState>
-												<Type classname='PropertyObjectType'>
-													<subprops>
-														<ValueType classname='Num'>
-															<value>3</value>
-														</ValueType>
-														<IsObject classname='Bool'>
-															<value>true</value>
-														</IsObject>
-														<TypeName classname='Str'>
-															<value/>
-														</TypeName>
-														<ElementType classname='Objs'>
-															<value lbound='[0]' ubound='[]'/>
-														</ElementType>
-														<ArrayDimensions classname='ArrayDimensions'>
-															<subprops>
-																<LowerBounds classname='Nums'>
-																	<value lbound='[0]' ubound='[]'/>
-																</LowerBounds>
-																<UpperBounds classname='Nums'>
-																	<value lbound='[0]' ubound='[]'/>
-																</UpperBounds>
-															</subprops>
-														</ArrayDimensions>
-														<Representation classname='Num'>
-															<value>1</value>
-														</Representation>
-														<ClassName classname='Str'>
-															<value/>
-														</ClassName>
-													</subprops>
-												</Type>
-												<Elements classname='Objs'>
-													<value lbound='[0]' ubound='[]'/>
-												</Elements>
-												<IsAnyType classname='Bool'>
-													<value>true</value>
-												</IsAnyType>
-											</subprops>
-										</_NAME_IN_ATTRIBUTE_>
-									</elemproto>
-								</value>
-							</AdditionalResultsHints>
-						</subprops>
-					</TS>
-					<NI_Data typename='StepTypeNIData' xsi:type='StepTypeNIData' classname='Obj'>
-						<subprops>
-							<EditPanels classname='Strs'>
-								<value lbound='[0]' ubound='[]'/>
-							</EditPanels>
-						</subprops>
-					</NI_Data>
-					<Result classname='Obj' flagsforinstances='4194304' valueflags='4194304'>
-						<subprops>
-							<Error typename='Error' xsi:type='Error' classname='Obj' flagsforinstances='4194304' instanceoverrideflags='4194304' valueflags='4194304'>
-								<subprops>
-									<Code classname='Num'>
-										<value>0</value>
-									</Code>
-									<Msg classname='Str'>
-										<value/>
-									</Msg>
-									<Occurred classname='Bool'>
-										<value>false</value>
-									</Occurred>
-								</subprops>
-							</Error>
-							<Status classname='Str' flagsforinstances='4194304' valueflags='4194304'>
-								<value/>
-							</Status>
-							<ReportText classname='Str' flagsforinstances='4194304' valueflags='4194304'>
-								<value/>
-							</ReportText>
-							<Common typename='CommonResults' xsi:type='CommonResults' classname='Obj' instanceoverrideflags='4194304'/>
-						</subprops>
-					</Result>
-					<CodeTemplates classname='Str' valueflags='4194328' structureflags='524288'>
-						<value>DefaultLabVIEW|DefaultLabVIEWNXG|DefaultCVI|DefaultVB.NET|DefaultCSharp.NET|DefaultC++.NET|DefaultVC++_Template|DefaultHTB72_Template|DefaultHTB80_Template|Default_Template</value>
-					</CodeTemplates>
-					<BlockStartTypes classname='Str' valueflags='4194328' structureflags='524288'>
-						<value/>
-					</BlockStartTypes>
-					<BlockEndTypes classname='Str' valueflags='4194328' structureflags='524288'>
-						<value/>
-					</BlockEndTypes>
-					<AppliesToBlockStructure classname='Bool' valueflags='4194328' structureflags='524288'>
-						<value>false</value>
-					</AppliesToBlockStructure>
-					<CanEncapsulate classname='Bool' valueflags='4194328' structureflags='524288'>
-						<value>false</value>
-					</CanEncapsulate>
-					<Category classname='Str' valueflags='24' structureflags='524288'>
-						<value>Action</value>
-					</Category>
-				</subprops>
-			</Action>
-		</typedef>
-		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='29'>
-			<NI_PythonParameterResult classname='PythonParameterResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
-				<subprops>
-					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
-						<value/>
-					</Condition>
-					<Flags classname='Num'>
-						<value>8192</value>
-						<numericfmt>%#x</numericfmt>
-					</Flags>
-					<CheckedState classname='Num'>
-						<value>1</value>
-					</CheckedState>
-				</subprops>
-			</NI_PythonParameterResult>
-		</typedef>
-		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='28'>
-			<NI_PythonParameter classname='CPythonParameter' isroottypedef='true' typecategory='3' timestamp='1650060872' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
-				<subprops>
-					<Name classname='Str'>
-						<value>_notNamed</value>
-					</Name>
-					<Type classname='Num'>
-						<value>7</value>
-					</Type>
-					<ArgumentValue typename='Expression' xsi:type='Expression' classname='ExprValue'>
-						<value/>
-					</ArgumentValue>
-					<ArgumentDisplayValue typename='Expression' xsi:type='Expression' classname='ExprValue'>
-						<value/>
-					</ArgumentDisplayValue>
-					<AdditionalResults classname='Obj'>
-						<subprops>
-							<Input typename='NI_PythonParameterResult' xsi:type='NI_PythonParameterResult' classname='PythonParameterResult'>
-								<subprops>
-									<Condition classname='ExprValue'>
-										<value/>
-									</Condition>
-									<Flags classname='Num'>
-										<value>8192</value>
-									</Flags>
-									<CheckedState classname='Num'>
-										<value>1</value>
-									</CheckedState>
-								</subprops>
-							</Input>
-							<Output typename='NI_PythonParameterResult' xsi:type='NI_PythonParameterResult' classname='PythonParameterResult'>
-								<subprops>
-									<Condition classname='ExprValue'>
-										<value/>
-									</Condition>
-									<Flags classname='Num'>
-										<value>8192</value>
-									</Flags>
-									<CheckedState classname='Num'>
-										<value>1</value>
-									</CheckedState>
-								</subprops>
-							</Output>
-						</subprops>
-					</AdditionalResults>
-				</subprops>
-			</NI_PythonParameter>
-		</typedef>
-		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='27'>
-			<PythonStepAdditions classname='CPythonModule' isroottypedef='true' typecategory='3' timestamp='1650060872' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
-				<subprops>
-					<PythonCall classname='CPythonCall'>
-						<subprops>
-							<UseAdapterSettingsForInterpreterSession classname='Bool'>
-								<value>true</value>
-							</UseAdapterSettingsForInterpreterSession>
-							<InterpreterSessionScope classname='Num'>
-								<value>3</value>
-							</InterpreterSessionScope>
-							<PythonVersion classname='Str'>
-								<value/>
-							</PythonVersion>
-							<PythonVirtualEnvironmentPath classname='Str'>
-								<value/>
-							</PythonVirtualEnvironmentPath>
-							<InterpreterLocation typename='Expression' xsi:type='Expression' classname='ExprValue'>
-								<value/>
-							</InterpreterLocation>
-							<CreateIfInterpreterDoesNotExist classname='Bool'>
-								<value>true</value>
-							</CreateIfInterpreterDoesNotExist>
-							<ModulePath typename='Path' xsi:type='Path' classname='PathValue'>
-								<value/>
-							</ModulePath>
-							<OperationType classname='Num'>
-								<value>1</value>
-							</OperationType>
-							<OperationScope classname='Num'>
-								<value>0</value>
-							</OperationScope>
-							<ClassName classname='Str'>
-								<value/>
-							</ClassName>
-							<ClassInstanceLocation typename='Expression' xsi:type='Expression' classname='ExprValue'>
-								<value/>
-							</ClassInstanceLocation>
-							<FunctionOrAttributeName classname='Str'>
-								<value/>
-							</FunctionOrAttributeName>
-							<Parameters classname='Objs'>
-								<value lbound='[0]' ubound='[0]'>
-									<elemproto>
-										<_NAME_IN_ATTRIBUTE_ typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name='' classname='CPythonParameter' structureflags='131072'>
-											<subprops>
-												<Name classname='Str'>
-													<value>_notNamed</value>
-												</Name>
-												<Type classname='Num'>
-													<value>7</value>
-												</Type>
-												<ArgumentValue classname='ExprValue'>
-													<value/>
-												</ArgumentValue>
-												<ArgumentDisplayValue classname='ExprValue'>
-													<value/>
-												</ArgumentDisplayValue>
-												<AdditionalResults classname='Obj'>
-													<subprops>
-														<Input classname='PythonParameterResult'>
-															<subprops>
-																<Condition classname='ExprValue'>
-																	<value/>
-																</Condition>
-																<Flags classname='Num'>
-																	<value>8192</value>
-																</Flags>
-																<CheckedState classname='Num'>
-																	<value>1</value>
-																</CheckedState>
-															</subprops>
-														</Input>
-														<Output classname='PythonParameterResult'>
-															<subprops>
-																<Condition classname='ExprValue'>
-																	<value/>
-																</Condition>
-																<Flags classname='Num'>
-																	<value>8192</value>
-																</Flags>
-																<CheckedState classname='Num'>
-																	<value>1</value>
-																</CheckedState>
-															</subprops>
-														</Output>
-													</subprops>
-												</AdditionalResults>
-											</subprops>
-										</_NAME_IN_ATTRIBUTE_>
-									</elemproto>
-									<value>
-										<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
-											<subprops>
-												<Name classname='Str'>
-													<value>Return Value</value>
-												</Name>
-												<Type classname='Num'>
-													<value>7</value>
-												</Type>
-												<ArgumentValue classname='ExprValue'>
-													<value/>
-												</ArgumentValue>
-												<ArgumentDisplayValue classname='ExprValue'>
-													<value/>
-												</ArgumentDisplayValue>
-												<AdditionalResults classname='Obj'>
-													<subprops>
-														<Input classname='PythonParameterResult'>
-															<subprops>
-																<Condition classname='ExprValue'>
-																	<value/>
-																</Condition>
-																<Flags classname='Num'>
-																	<value>8192</value>
-																</Flags>
-																<CheckedState classname='Num'>
-																	<value>1</value>
-																</CheckedState>
-															</subprops>
-														</Input>
-														<Output classname='PythonParameterResult'>
-															<subprops>
-																<Condition classname='ExprValue'>
-																	<value/>
-																</Condition>
-																<Flags classname='Num'>
-																	<value>8192</value>
-																</Flags>
-																<CheckedState classname='Num'>
-																	<value>1</value>
-																</CheckedState>
-															</subprops>
-														</Output>
-													</subprops>
-												</AdditionalResults>
-											</subprops>
-										</CPythonParameter>
-									</value>
-								</value>
-							</Parameters>
-							<DefaultParamCategoryForArray classname='Num'>
-								<value>5</value>
-							</DefaultParamCategoryForArray>
-						</subprops>
-					</PythonCall>
-				</subprops>
-			</PythonStepAdditions>
-		</typedef>
 	</typelist>
 	<Data classname='SequenceFileData' valueflags='4194304'>
 		<subprops>
 			<Seq classname='Objs' valueflags='4194304'>
-				<value lbound='[0]' ubound='[2]'>
+				<value lbound='[0]' ubound='[0]'>
 					<value>
 						<Sequence name='MainSequence'>
 							<subprops>
@@ -4741,389 +4741,7 @@
 									</value>
 								</Main>
 								<Setup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
-								</Setup>
-								<Cleanup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
-								</Cleanup>
-								<RecordResults classname='Bool' valueflags='4194312'>
-									<value>true</value>
-								</RecordResults>
-								<RTS classname='Obj' valueflags='4456456'>
-									<subprops>
-										<Type classname='Num' valueflags='4194304'>
-											<value>0</value>
-										</Type>
-										<OptimizeNonReentrantCalls classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</OptimizeNonReentrantCalls>
-										<EPNameExpr classname='Str' valueflags='4194304'>
-											<value>"Unnamed Entry Point"</value>
-										</EPNameExpr>
-										<EPEnabledExpr classname='Str' valueflags='4194304'>
-											<value>True</value>
-										</EPEnabledExpr>
-										<EPMenuHint classname='Str' valueflags='4194304'>
-											<value/>
-										</EPMenuHint>
-										<EPIgnoreClient classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</EPIgnoreClient>
-										<EPInitiallyHidden classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</EPInitiallyHidden>
-										<EPCheckToSaveTitledFile classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</EPCheckToSaveTitledFile>
-										<ShowEPAlways classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPAlways>
-										<ShowEPForFileWin classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</ShowEPForFileWin>
-										<ShowEPForExeWin classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPForExeWin>
-										<ShowEPForEditorOnly classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPForEditorOnly>
-										<AllowIntExeOfEP classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</AllowIntExeOfEP>
-										<CopyStepsOnOverriding classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</CopyStepsOnOverriding>
-										<Priority classname='Num' valueflags='4194304'>
-											<value>2953567917</value>
-										</Priority>
-									</subprops>
-								</RTS>
-								<Requirements classname='Obj' valueflags='4456456'>
-									<subprops>
-										<Links classname='Strs' valueflags='71303168'>
-											<value lbound='[0]' ubound='[]'/>
-										</Links>
-									</subprops>
-								</Requirements>
-								<FailureAction classname='Num' valueflags='4194312'>
-									<value>2</value>
-								</FailureAction>
-							</subprops>
-						</Sequence>
-					</value>
-					<value>
-						<Sequence name='ProcessSetup'>
-							<comment>Test UUTs and Single Pass call this callback in their setup step group. It is empty in the model file.  Override this in the client file to perform an action before any code in the model executes.</comment>
-							<subprops>
-								<Parameters classname='Obj' valueflags='4456448'/>
-								<Locals classname='Obj' valueflags='4194304'>
-									<subprops>
-										<ResultList classname='Objs'>
-											<value lbound='[0]' ubound='[]'>
-												<elemproto>
-													<_NAME_IN_ATTRIBUTE_ name='' classname='TEResult'/>
-												</elemproto>
-											</value>
-										</ResultList>
-									</subprops>
-								</Locals>
-								<Main classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[3]'>
-										<value>
-											<Step typename='Statement' xsi:type='Statement' name='Get absolute path to pinmap file'>
-												<subprops>
-													<TS classname='Obj'>
-														<subprops>
-															<Id classname='Str'>
-																<value>ID#:CHEZyO1w7RGuNrjdh1OqZD</value>
-															</Id>
-															<Icon classname='Str'>
-																<value>StatementStep.ico</value>
-															</Icon>
-															<PreCond classname='ExprValue'>
-																<value/>
-															</PreCond>
-															<LoadOpt classname='Str'>
-																<value>PreloadWhenExecuted</value>
-															</LoadOpt>
-															<UnloadOpt classname='Str'>
-																<value>UnloadWithFile</value>
-															</UnloadOpt>
-															<Mode classname='Str'>
-																<value>Normal</value>
-															</Mode>
-															<WindowActivation classname='Str'>
-																<value>None</value>
-															</WindowActivation>
-															<ResultOption classname='Num'>
-																<value>1</value>
-															</ResultOption>
-															<StepFCSeqF classname='Bool'>
-																<value>true</value>
-															</StepFCSeqF>
-															<IgnoreRTE classname='Bool'>
-																<value>false</value>
-															</IgnoreRTE>
-															<UseMutex classname='Bool'>
-																<value>false</value>
-															</UseMutex>
-															<MutexNameOrRef classname='ExprValue'>
-																<value/>
-															</MutexNameOrRef>
-															<BatchSyncOpt classname='Num'>
-																<value>0</value>
-															</BatchSyncOpt>
-															<SwitchEnabled classname='Bool'>
-																<value>false</value>
-															</SwitchEnabled>
-															<VirtualDeviceName classname='ExprValue'>
-																<value/>
-															</VirtualDeviceName>
-															<SwitchOperation classname='Num'>
-																<value>1</value>
-															</SwitchOperation>
-															<RouteGroupConnect classname='ExprValue'>
-																<value/>
-															</RouteGroupConnect>
-															<RouteGroupDisconnect classname='ExprValue'>
-																<value/>
-															</RouteGroupDisconnect>
-															<MulticonnectMode classname='Num'>
-																<value>1</value>
-															</MulticonnectMode>
-															<OperationOrder classname='Num'>
-																<value>2</value>
-															</OperationOrder>
-															<ConnectionLifetime classname='Num'>
-																<value>0</value>
-															</ConnectionLifetime>
-															<WaitForDebounce classname='Bool'>
-																<value>true</value>
-															</WaitForDebounce>
-															<PassAct classname='Str'>
-																<value>Next</value>
-															</PassAct>
-															<FailAct classname='Str'>
-																<value>Next</value>
-															</FailAct>
-															<PassActTarget classname='ExprValue'>
-																<value/>
-															</PassActTarget>
-															<FailActTarget classname='ExprValue'>
-																<value/>
-															</FailActTarget>
-															<CustExpr classname='ExprValue'>
-																<value/>
-															</CustExpr>
-															<CustTrueAct classname='Str'>
-																<value>Next</value>
-															</CustTrueAct>
-															<CustFalseAct classname='Str'>
-																<value>Next</value>
-															</CustFalseAct>
-															<CustTrueActTarget classname='ExprValue'>
-																<value/>
-															</CustTrueActTarget>
-															<CustFalseActTarget classname='ExprValue'>
-																<value/>
-															</CustFalseActTarget>
-															<LoopType classname='Str'>
-																<value>NoLooping</value>
-															</LoopType>
-															<LoopWhile classname='ExprValue'>
-																<value/>
-															</LoopWhile>
-															<LoopStatus classname='ExprValue'>
-																<value/>
-															</LoopStatus>
-															<LoopIncrement classname='ExprValue'>
-																<value>RunState.LoopIndex += 1</value>
-															</LoopIncrement>
-															<LoopInitialize classname='ExprValue'>
-																<value>RunState.LoopIndex = 0</value>
-															</LoopInitialize>
-															<LoopOpt classname='Num'>
-																<value>0</value>
-															</LoopOpt>
-															<PreExpr classname='ExprValue'>
-																<value/>
-															</PreExpr>
-															<PostExpr classname='ExprValue'>
-																<value>FindFile(FileGlobals.MeasurementLink.PinMapFileName,True,FileGlobals.MeasurementLink.PinMapPath)</value>
-															</PostExpr>
-															<StatusExpr classname='ExprValue'>
-																<value/>
-															</StatusExpr>
-															<CanSpecifyModule classname='Bool'>
-																<value>false</value>
-															</CanSpecifyModule>
-															<CanEditCode classname='Bool'>
-																<value>true</value>
-															</CanEditCode>
-															<CanEditModulePrototype classname='Bool'>
-																<value>true</value>
-															</CanEditModulePrototype>
-															<CanEditParameterAdditionalResults classname='Bool'>
-																<value>true</value>
-															</CanEditParameterAdditionalResults>
-															<PrecondIntExe classname='Num'>
-																<value>0</value>
-															</PrecondIntExe>
-															<CustomResults classname='Objs'>
-																<value lbound='[0]' ubound='[]'>
-																	<elemproto>
-																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-																			<subprops>
-																				<Name classname='ExprValue'>
-																					<value/>
-																				</Name>
-																				<ValueToLog classname='ExprValue'>
-																					<value/>
-																				</ValueToLog>
-																				<Condition classname='ExprValue'>
-																					<value/>
-																				</Condition>
-																				<Flags classname='Num'>
-																					<value>8192</value>
-																				</Flags>
-																				<CheckedState classname='Num'>
-																					<value>2</value>
-																				</CheckedState>
-																				<Type classname='PropertyObjectType'>
-																					<subprops>
-																						<ValueType classname='Num'>
-																							<value>3</value>
-																						</ValueType>
-																						<IsObject classname='Bool'>
-																							<value>true</value>
-																						</IsObject>
-																						<TypeName classname='Str'>
-																							<value/>
-																						</TypeName>
-																						<ElementType classname='Objs'>
-																							<value lbound='[0]' ubound='[]'/>
-																						</ElementType>
-																						<ArrayDimensions classname='ArrayDimensions'>
-																							<subprops>
-																								<LowerBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</LowerBounds>
-																								<UpperBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</UpperBounds>
-																							</subprops>
-																						</ArrayDimensions>
-																						<Representation classname='Num'>
-																							<value>1</value>
-																						</Representation>
-																						<ClassName classname='Str'>
-																							<value/>
-																						</ClassName>
-																					</subprops>
-																				</Type>
-																				<Elements classname='Objs'>
-																					<value lbound='[0]' ubound='[]'/>
-																				</Elements>
-																				<IsAnyType classname='Bool'>
-																					<value>true</value>
-																				</IsAnyType>
-																			</subprops>
-																		</_NAME_IN_ATTRIBUTE_>
-																	</elemproto>
-																</value>
-															</CustomResults>
-															<AdditionalResultsHints classname='Objs'>
-																<value lbound='[0]' ubound='[]'>
-																	<elemproto>
-																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-																			<subprops>
-																				<Name classname='ExprValue'>
-																					<value/>
-																				</Name>
-																				<ValueToLog classname='ExprValue'>
-																					<value/>
-																				</ValueToLog>
-																				<Condition classname='ExprValue'>
-																					<value/>
-																				</Condition>
-																				<Flags classname='Num'>
-																					<value>8192</value>
-																				</Flags>
-																				<CheckedState classname='Num'>
-																					<value>2</value>
-																				</CheckedState>
-																				<Type classname='PropertyObjectType'>
-																					<subprops>
-																						<ValueType classname='Num'>
-																							<value>3</value>
-																						</ValueType>
-																						<IsObject classname='Bool'>
-																							<value>true</value>
-																						</IsObject>
-																						<TypeName classname='Str'>
-																							<value/>
-																						</TypeName>
-																						<ElementType classname='Objs'>
-																							<value lbound='[0]' ubound='[]'/>
-																						</ElementType>
-																						<ArrayDimensions classname='ArrayDimensions'>
-																							<subprops>
-																								<LowerBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</LowerBounds>
-																								<UpperBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</UpperBounds>
-																							</subprops>
-																						</ArrayDimensions>
-																						<Representation classname='Num'>
-																							<value>1</value>
-																						</Representation>
-																						<ClassName classname='Str'>
-																							<value/>
-																						</ClassName>
-																					</subprops>
-																				</Type>
-																				<Elements classname='Objs'>
-																					<value lbound='[0]' ubound='[]'/>
-																				</Elements>
-																				<IsAnyType classname='Bool'>
-																					<value>true</value>
-																				</IsAnyType>
-																			</subprops>
-																		</_NAME_IN_ATTRIBUTE_>
-																	</elemproto>
-																</value>
-															</AdditionalResultsHints>
-														</subprops>
-													</TS>
-													<Result classname='Obj'>
-														<subprops>
-															<Error classname='Obj'>
-																<subprops>
-																	<Code classname='Num'>
-																		<value>0</value>
-																	</Code>
-																	<Msg classname='Str'>
-																		<value/>
-																	</Msg>
-																	<Occurred classname='Bool'>
-																		<value>false</value>
-																	</Occurred>
-																</subprops>
-															</Error>
-															<Status classname='Str'>
-																<value/>
-															</Status>
-															<ReportText classname='Str'>
-																<value/>
-															</ReportText>
-															<Common classname='Obj'/>
-														</subprops>
-													</Result>
-												</subprops>
-											</Step>
-										</value>
+									<value lbound='[0]' ubound='[1]'>
 										<value>
 											<Step typename='Action' xsi:type='Action' name='Update pin map'>
 												<subprops>
@@ -5176,7 +4794,7 @@
 																				<value>update_pin_map</value>
 																			</FunctionOrAttributeName>
 																			<Parameters classname='Objs'>
-																				<value lbound='[0]' ubound='[1]'>
+																				<value lbound='[0]' ubound='[2]'>
 																					<elemproto>
 																						<_NAME_IN_ATTRIBUTE_ name='' classname='CPythonParameter' structureflags='0'/>
 																					</elemproto>
@@ -5232,7 +4850,7 @@
 																						<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
 																							<subprops>
 																								<Name classname='Str'>
-																									<value>pin_map_id</value>
+																									<value>pin_map_path</value>
 																								</Name>
 																								<Type classname='Num'>
 																									<value>7</value>
@@ -5254,7 +4872,55 @@
 																													<value>8192</value>
 																												</Flags>
 																												<CheckedState classname='Num'>
+																													<value>2</value>
+																												</CheckedState>
+																											</subprops>
+																										</Input>
+																										<Output classname='PythonParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
 																													<value>1</value>
+																												</CheckedState>
+																											</subprops>
+																										</Output>
+																									</subprops>
+																								</AdditionalResults>
+																							</subprops>
+																						</CPythonParameter>
+																					</value>
+																					<value>
+																						<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
+																							<subprops>
+																								<Name classname='Str'>
+																									<value>sequence_context</value>
+																								</Name>
+																								<Type classname='Num'>
+																									<value>7</value>
+																								</Type>
+																								<ArgumentValue classname='ExprValue'>
+																									<value>ThisContext</value>
+																								</ArgumentValue>
+																								<ArgumentDisplayValue classname='ExprValue'>
+																									<value/>
+																								</ArgumentDisplayValue>
+																								<AdditionalResults classname='Obj'>
+																									<subprops>
+																										<Input classname='PythonParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
+																													<value>2</value>
 																												</CheckedState>
 																											</subprops>
 																										</Input>
@@ -5677,13 +5343,13 @@
 																						<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
 																							<subprops>
 																								<Name classname='Str'>
-																									<value>pin_map_id</value>
+																									<value>sequence_context</value>
 																								</Name>
 																								<Type classname='Num'>
 																									<value>7</value>
 																								</Type>
 																								<ArgumentValue classname='ExprValue'>
-																									<value>FileGlobals.MeasurementLink.PinMapPath</value>
+																									<value>ThisContext</value>
 																								</ArgumentValue>
 																								<ArgumentDisplayValue classname='ExprValue'>
 																									<value/>
@@ -5699,7 +5365,7 @@
 																													<value>8192</value>
 																												</Flags>
 																												<CheckedState classname='Num'>
-																													<value>1</value>
+																													<value>2</value>
 																												</CheckedState>
 																											</subprops>
 																										</Input>
@@ -6014,391 +5680,9 @@
 												</subprops>
 											</Step>
 										</value>
-										<value>
-											<Step typename='Statement' xsi:type='Statement' name='Register active PinMapId'>
-												<subprops>
-													<TS classname='Obj'>
-														<subprops>
-															<Id classname='Str'>
-																<value>ID#:7xzPK+Rw7RGuNrjdh1OqZD</value>
-															</Id>
-															<Icon classname='Str'>
-																<value>StatementStep.ico</value>
-															</Icon>
-															<PreCond classname='ExprValue'>
-																<value/>
-															</PreCond>
-															<LoadOpt classname='Str'>
-																<value>PreloadWhenExecuted</value>
-															</LoadOpt>
-															<UnloadOpt classname='Str'>
-																<value>UnloadWithFile</value>
-															</UnloadOpt>
-															<Mode classname='Str'>
-																<value>Normal</value>
-															</Mode>
-															<WindowActivation classname='Str'>
-																<value>None</value>
-															</WindowActivation>
-															<ResultOption classname='Num'>
-																<value>1</value>
-															</ResultOption>
-															<StepFCSeqF classname='Bool'>
-																<value>true</value>
-															</StepFCSeqF>
-															<IgnoreRTE classname='Bool'>
-																<value>false</value>
-															</IgnoreRTE>
-															<UseMutex classname='Bool'>
-																<value>false</value>
-															</UseMutex>
-															<MutexNameOrRef classname='ExprValue'>
-																<value/>
-															</MutexNameOrRef>
-															<BatchSyncOpt classname='Num'>
-																<value>0</value>
-															</BatchSyncOpt>
-															<SwitchEnabled classname='Bool'>
-																<value>false</value>
-															</SwitchEnabled>
-															<VirtualDeviceName classname='ExprValue'>
-																<value/>
-															</VirtualDeviceName>
-															<SwitchOperation classname='Num'>
-																<value>1</value>
-															</SwitchOperation>
-															<RouteGroupConnect classname='ExprValue'>
-																<value/>
-															</RouteGroupConnect>
-															<RouteGroupDisconnect classname='ExprValue'>
-																<value/>
-															</RouteGroupDisconnect>
-															<MulticonnectMode classname='Num'>
-																<value>1</value>
-															</MulticonnectMode>
-															<OperationOrder classname='Num'>
-																<value>2</value>
-															</OperationOrder>
-															<ConnectionLifetime classname='Num'>
-																<value>0</value>
-															</ConnectionLifetime>
-															<WaitForDebounce classname='Bool'>
-																<value>true</value>
-															</WaitForDebounce>
-															<PassAct classname='Str'>
-																<value>Next</value>
-															</PassAct>
-															<FailAct classname='Str'>
-																<value>Next</value>
-															</FailAct>
-															<PassActTarget classname='ExprValue'>
-																<value/>
-															</PassActTarget>
-															<FailActTarget classname='ExprValue'>
-																<value/>
-															</FailActTarget>
-															<CustExpr classname='ExprValue'>
-																<value/>
-															</CustExpr>
-															<CustTrueAct classname='Str'>
-																<value>Next</value>
-															</CustTrueAct>
-															<CustFalseAct classname='Str'>
-																<value>Next</value>
-															</CustFalseAct>
-															<CustTrueActTarget classname='ExprValue'>
-																<value/>
-															</CustTrueActTarget>
-															<CustFalseActTarget classname='ExprValue'>
-																<value/>
-															</CustFalseActTarget>
-															<LoopType classname='Str'>
-																<value>NoLooping</value>
-															</LoopType>
-															<LoopWhile classname='ExprValue'>
-																<value/>
-															</LoopWhile>
-															<LoopStatus classname='ExprValue'>
-																<value/>
-															</LoopStatus>
-															<LoopIncrement classname='ExprValue'>
-																<value>RunState.LoopIndex += 1</value>
-															</LoopIncrement>
-															<LoopInitialize classname='ExprValue'>
-																<value>RunState.LoopIndex = 0</value>
-															</LoopInitialize>
-															<LoopOpt classname='Num'>
-																<value>0</value>
-															</LoopOpt>
-															<PreExpr classname='ExprValue'>
-																<value/>
-															</PreExpr>
-															<PostExpr classname='ExprValue'>
-																<value>RunState.Engine.TemporaryGlobals.SetValString("NI.MeasurementLink.PinMapId", 0x1, FileGlobals.MeasurementLink.PinMapPath)</value>
-															</PostExpr>
-															<StatusExpr classname='ExprValue'>
-																<value/>
-															</StatusExpr>
-															<CanSpecifyModule classname='Bool'>
-																<value>false</value>
-															</CanSpecifyModule>
-															<CanEditCode classname='Bool'>
-																<value>true</value>
-															</CanEditCode>
-															<CanEditModulePrototype classname='Bool'>
-																<value>true</value>
-															</CanEditModulePrototype>
-															<CanEditParameterAdditionalResults classname='Bool'>
-																<value>true</value>
-															</CanEditParameterAdditionalResults>
-															<PrecondIntExe classname='Num'>
-																<value>0</value>
-															</PrecondIntExe>
-															<CustomResults classname='Objs'>
-																<value lbound='[0]' ubound='[]'>
-																	<elemproto>
-																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-																			<subprops>
-																				<Name classname='ExprValue'>
-																					<value/>
-																				</Name>
-																				<ValueToLog classname='ExprValue'>
-																					<value/>
-																				</ValueToLog>
-																				<Condition classname='ExprValue'>
-																					<value/>
-																				</Condition>
-																				<Flags classname='Num'>
-																					<value>8192</value>
-																				</Flags>
-																				<CheckedState classname='Num'>
-																					<value>2</value>
-																				</CheckedState>
-																				<Type classname='PropertyObjectType'>
-																					<subprops>
-																						<ValueType classname='Num'>
-																							<value>3</value>
-																						</ValueType>
-																						<IsObject classname='Bool'>
-																							<value>true</value>
-																						</IsObject>
-																						<TypeName classname='Str'>
-																							<value/>
-																						</TypeName>
-																						<ElementType classname='Objs'>
-																							<value lbound='[0]' ubound='[]'/>
-																						</ElementType>
-																						<ArrayDimensions classname='ArrayDimensions'>
-																							<subprops>
-																								<LowerBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</LowerBounds>
-																								<UpperBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</UpperBounds>
-																							</subprops>
-																						</ArrayDimensions>
-																						<Representation classname='Num'>
-																							<value>1</value>
-																						</Representation>
-																						<ClassName classname='Str'>
-																							<value/>
-																						</ClassName>
-																					</subprops>
-																				</Type>
-																				<Elements classname='Objs'>
-																					<value lbound='[0]' ubound='[]'/>
-																				</Elements>
-																				<IsAnyType classname='Bool'>
-																					<value>true</value>
-																				</IsAnyType>
-																			</subprops>
-																		</_NAME_IN_ATTRIBUTE_>
-																	</elemproto>
-																</value>
-															</CustomResults>
-															<AdditionalResultsHints classname='Objs'>
-																<value lbound='[0]' ubound='[]'>
-																	<elemproto>
-																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-																			<subprops>
-																				<Name classname='ExprValue'>
-																					<value/>
-																				</Name>
-																				<ValueToLog classname='ExprValue'>
-																					<value/>
-																				</ValueToLog>
-																				<Condition classname='ExprValue'>
-																					<value/>
-																				</Condition>
-																				<Flags classname='Num'>
-																					<value>8192</value>
-																				</Flags>
-																				<CheckedState classname='Num'>
-																					<value>2</value>
-																				</CheckedState>
-																				<Type classname='PropertyObjectType'>
-																					<subprops>
-																						<ValueType classname='Num'>
-																							<value>3</value>
-																						</ValueType>
-																						<IsObject classname='Bool'>
-																							<value>true</value>
-																						</IsObject>
-																						<TypeName classname='Str'>
-																							<value/>
-																						</TypeName>
-																						<ElementType classname='Objs'>
-																							<value lbound='[0]' ubound='[]'/>
-																						</ElementType>
-																						<ArrayDimensions classname='ArrayDimensions'>
-																							<subprops>
-																								<LowerBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</LowerBounds>
-																								<UpperBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</UpperBounds>
-																							</subprops>
-																						</ArrayDimensions>
-																						<Representation classname='Num'>
-																							<value>1</value>
-																						</Representation>
-																						<ClassName classname='Str'>
-																							<value/>
-																						</ClassName>
-																					</subprops>
-																				</Type>
-																				<Elements classname='Objs'>
-																					<value lbound='[0]' ubound='[]'/>
-																				</Elements>
-																				<IsAnyType classname='Bool'>
-																					<value>true</value>
-																				</IsAnyType>
-																			</subprops>
-																		</_NAME_IN_ATTRIBUTE_>
-																	</elemproto>
-																</value>
-															</AdditionalResultsHints>
-														</subprops>
-													</TS>
-													<Result classname='Obj'>
-														<subprops>
-															<Error classname='Obj'>
-																<subprops>
-																	<Code classname='Num'>
-																		<value>0</value>
-																	</Code>
-																	<Msg classname='Str'>
-																		<value/>
-																	</Msg>
-																	<Occurred classname='Bool'>
-																		<value>false</value>
-																	</Occurred>
-																</subprops>
-															</Error>
-															<Status classname='Str'>
-																<value/>
-															</Status>
-															<ReportText classname='Str'>
-																<value/>
-															</ReportText>
-															<Common classname='Obj'/>
-														</subprops>
-													</Result>
-												</subprops>
-											</Step>
-										</value>
 									</value>
-								</Main>
-								<Setup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
 								</Setup>
 								<Cleanup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
-								</Cleanup>
-								<RecordResults classname='Bool' valueflags='4194312'>
-									<value>false</value>
-								</RecordResults>
-								<RTS classname='Obj' valueflags='4456456'>
-									<subprops>
-										<Type classname='Num' valueflags='4194304'>
-											<value>0</value>
-										</Type>
-										<OptimizeNonReentrantCalls classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</OptimizeNonReentrantCalls>
-										<EPNameExpr classname='Str' valueflags='4194304'>
-											<value>"Unnamed Entry Point"</value>
-										</EPNameExpr>
-										<EPEnabledExpr classname='Str' valueflags='4194304'>
-											<value>True</value>
-										</EPEnabledExpr>
-										<EPMenuHint classname='Str' valueflags='4194304'>
-											<value/>
-										</EPMenuHint>
-										<EPIgnoreClient classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</EPIgnoreClient>
-										<EPInitiallyHidden classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</EPInitiallyHidden>
-										<EPCheckToSaveTitledFile classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</EPCheckToSaveTitledFile>
-										<ShowEPAlways classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPAlways>
-										<ShowEPForFileWin classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</ShowEPForFileWin>
-										<ShowEPForExeWin classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPForExeWin>
-										<ShowEPForEditorOnly classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPForEditorOnly>
-										<CopyStepsOnOverriding classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</CopyStepsOnOverriding>
-										<Priority classname='Num' valueflags='4194304'>
-											<value>2953567917</value>
-										</Priority>
-										<AllowIntExeOfEP classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</AllowIntExeOfEP>
-									</subprops>
-								</RTS>
-								<Requirements classname='Obj' valueflags='4456456'>
-									<subprops>
-										<Links classname='Strs' valueflags='71303168'>
-											<value lbound='[0]' ubound='[]'/>
-										</Links>
-									</subprops>
-								</Requirements>
-								<FailureAction classname='Num' valueflags='4194312'>
-									<value>2</value>
-								</FailureAction>
-							</subprops>
-						</Sequence>
-					</value>
-					<value>
-						<Sequence name='ProcessCleanup'>
-							<comment>Test UUTs and Single Pass call this callback in their cleanup step group. It is empty in the model file.  Override this in the client file to perform an action after all code in the model executes and just before the execution completes.</comment>
-							<subprops>
-								<Parameters classname='Obj' valueflags='4456448'/>
-								<Locals classname='Obj' valueflags='4194304'>
-									<subprops>
-										<ResultList classname='Objs'>
-											<value lbound='[0]' ubound='[]'>
-												<elemproto>
-													<_NAME_IN_ATTRIBUTE_ name='' classname='TEResult'/>
-												</elemproto>
-											</value>
-										</ResultList>
-									</subprops>
-								</Locals>
-								<Main classname='Objs' valueflags='4194304'>
 									<value lbound='[0]' ubound='[1]'>
 										<value>
 											<Step typename='Statement' xsi:type='Statement' name='Unregister active PinMapId'>
@@ -7093,15 +6377,9 @@
 											</Step>
 										</value>
 									</value>
-								</Main>
-								<Setup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
-								</Setup>
-								<Cleanup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
 								</Cleanup>
 								<RecordResults classname='Bool' valueflags='4194312'>
-									<value>false</value>
+									<value>true</value>
 								</RecordResults>
 								<RTS classname='Obj' valueflags='4456456'>
 									<subprops>
@@ -7141,15 +6419,15 @@
 										<ShowEPForEditorOnly classname='Bool' valueflags='4194304'>
 											<value>false</value>
 										</ShowEPForEditorOnly>
+										<AllowIntExeOfEP classname='Bool' valueflags='4194304'>
+											<value>false</value>
+										</AllowIntExeOfEP>
 										<CopyStepsOnOverriding classname='Bool' valueflags='4194304'>
 											<value>true</value>
 										</CopyStepsOnOverriding>
 										<Priority classname='Num' valueflags='4194304'>
 											<value>2953567917</value>
 										</Priority>
-										<AllowIntExeOfEP classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</AllowIntExeOfEP>
 									</subprops>
 								</RTS>
 								<Requirements classname='Obj' valueflags='4456456'>
@@ -7174,11 +6452,8 @@
 							<EnableMonitoring classname='Bool'>
 								<value>false</value>
 							</EnableMonitoring>
-							<PinMapFileName classname='Str'>
-								<value>NIVisaDmmMeasurement.pinmap</value>
-							</PinMapFileName>
 							<PinMapPath typename='Path' xsi:type='Path' classname='PathValue'>
-								<value/>
+								<value>NIVisaDmmMeasurement.pinmap</value>
 							</PinMapPath>
 						</subprops>
 					</MeasurementLink>

--- a/examples/nivisa_dmm_measurement/README.md
+++ b/examples/nivisa_dmm_measurement/README.md
@@ -11,7 +11,10 @@ and an NI Instrument Simulator v2.0.
 - Includes InstrumentStudio and MeasurementLink UI Editor project files
 - Includes a TestStand sequence showing how to configure the pin map, register
   instrument resources with the session management service, and run a measurement
-  - For the sake of simplicity, the TestStand sequence handles pin map and session registration and unregistration in the `Setup` and `Cleanup` sections of the main sequence. For **Test UUTs** and batch process model use cases, these steps should be moved to the `ProcessSetup` and `ProcessCleanup` callbacks.
+  - For the sake of simplicity, the TestStand sequence handles pin map and session
+    registration and unregistration in the `Setup` and `Cleanup` sections of the main 
+    sequence. For **Test UUTs** and batch process model use cases, these steps should
+    be moved to the `ProcessSetup` and `ProcessCleanup` callbacks.
 - Demonstrates how to share instrument resources with other measurement services
   when running measurements from TestStand, without using NI gRPC Device Server
 

--- a/examples/nivisa_dmm_measurement/README.md
+++ b/examples/nivisa_dmm_measurement/README.md
@@ -11,6 +11,7 @@ and an NI Instrument Simulator v2.0.
 - Includes InstrumentStudio and MeasurementLink UI Editor project files
 - Includes a TestStand sequence showing how to configure the pin map, register
   instrument resources with the session management service, and run a measurement
+  - For the sake of simplicity, the TestStand sequence handles pin map and session registration and unregistration in the `Setup` and `Cleanup` sections of the main sequence. For **Test UUTs** and batch process model use cases, these steps should be moved to the `ProcessSetup` and `ProcessCleanup` callbacks.
 - Demonstrates how to share instrument resources with other measurement services
   when running measurements from TestStand, without using NI gRPC Device Server
 

--- a/examples/nivisa_dmm_measurement/teststand_fixture.py
+++ b/examples/nivisa_dmm_measurement/teststand_fixture.py
@@ -1,7 +1,8 @@
 """Functions to set up and tear down NI-VISA DMM sessions in NI TestStand."""
+from typing import Any
 
 import pyvisa.resources
-from _helpers import GrpcChannelPoolHelper, PinMapClient
+from _helpers import GrpcChannelPoolHelper, PinMapClient, TestStandSupport
 from _visa_helpers import (
     INSTRUMENT_TYPE_DMM_SIMULATOR,
     create_visa_resource_manager,
@@ -15,28 +16,43 @@ import ni_measurementlink_service as nims
 # To use NI Instrument Simulator v2.0 hardware, set this to False.
 USE_SIMULATION = True
 
-
-def update_pin_map(pin_map_id: str) -> None:
+def update_pin_map(pin_map_path: str, sequence_context: Any) -> None:
     """Update registered pin map contents.
 
     Create and register a pin map if a pin map resource for the specified pin map id is not found.
 
     Args:
-        pin_map_id (str): The resource id of the pin map to register as a pin map resource. By
-            convention, the pin_map_id is the .pinmap file path.
-
+        pin_map_path:
+            An absolute or relative path to the pin map file.
+        sequence_context:
+            The SequenceContext COM object from the TestStand sequence execution.
+            (Dynamically typed.)
     """
+    teststand_support = TestStandSupport(sequence_context)
+    pin_map_abs_path = teststand_support.resolve_file_path(pin_map_path)
+
     with GrpcChannelPoolHelper() as grpc_channel_pool:
         pin_map_client = PinMapClient(grpc_channel=grpc_channel_pool.pin_map_channel)
-        pin_map_client.update_pin_map(pin_map_id)
+        pin_map_id = pin_map_client.update_pin_map(pin_map_abs_path)
+
+    teststand_support.set_active_pin_map_id(pin_map_id)
 
 
-def create_nivisa_dmm_sessions(pin_map_id: str) -> None:
-    """Create and register all NI-VISA DMM sessions."""
+def create_nivisa_dmm_sessions(sequence_context: Any) -> None:
+    """Create and register all NI-VISA DMM sessions.
+
+    Args:
+        sequence_context:
+            The SequenceContext COM object from the TestStand sequence execution.
+            (Dynamically typed.)
+    """
     with GrpcChannelPoolHelper() as grpc_channel_pool:
         session_management_client = nims.session_management.Client(
             grpc_channel=grpc_channel_pool.session_management_channel
         )
+
+        teststand_support = TestStandSupport(sequence_context)
+        pin_map_id = teststand_support.get_active_pin_map_id()
 
         pin_map_context = nims.session_management.PinMapContext(pin_map_id=pin_map_id, sites=None)
         with session_management_client.reserve_sessions(

--- a/examples/nivisa_dmm_measurement/teststand_fixture.py
+++ b/examples/nivisa_dmm_measurement/teststand_fixture.py
@@ -16,6 +16,7 @@ import ni_measurementlink_service as nims
 # To use NI Instrument Simulator v2.0 hardware, set this to False.
 USE_SIMULATION = True
 
+
 def update_pin_map(pin_map_path: str, sequence_context: Any) -> None:
     """Update registered pin map contents.
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
- Updates the TestStand sequence in the example measurement to make it simpler by moving the process setup and process cleanup steps to the main sequence.
-  The sequence update and their relevant python functions are done for below examples:
     - DMM
     - FGEN
     - SCOPE
     - SWITCH
     - VISA DMM
- Combines the logic for registering pin map into a single step in the Setup section. Previously this was handled in three steps.
- Updated the `Readme.md` file for the updated examples.

### Why should this Pull Request be merged?
Based on the feedback discussed in this [Teams post](https://teams.microsoft.com/l/message/19:36f0e963feb84c0c8122e6ddfbe7df7b@thread.tacv2/1676494204834?tenantId=87ba1f9a-44cd-43a6-b008-6fdb45a5204e&groupId=a092c504-be1c-4d21-9ef4-068a40ca6974&parentMessageId=1676494204834&teamName=MeasurementLink%20%26%20ETW%20Global%20Collaboration&channelName=Roadmap%20Input%20and%20Feature%20Ideas&createdTime=1676494204834&allowXTenantAccess=false), moving the process setup and process cleanup steps to the main sequence will simplify the example sequence as the user will only need to run the main sequence to get the expected result. Though this sequence is not efficient for multi-site use case, this change is encouraged as the example sequence is expected to be tailored to users who are beginners in TestStand.

### What testing has been done?
- Manually executed the TestStand example sequence with a simulated instrument and verified the result for below examples
     - DMM
     - FGEN
     - SCOPE
     - SWITCH
     - VISA DMM