### PR TITLE
RFC: examples: Refactor TestStand code module and add multiple_measurements example

### DIFF
--- a/examples/multiple_measurements/MultipleMeasurements.pinmap
+++ b/examples/multiple_measurements/MultipleMeasurements.pinmap
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<PinMap xmlns="http://www.ni.com/TestStand/SemiconductorModule/PinMap.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.1">
+	<Instruments>
+		<NIDCPowerInstrument name="DCPower1" numberOfChannels="4">
+			<ChannelGroup name="CommonDCPowerChannelGroup" />
+		</NIDCPowerInstrument>
+		<NIDmmInstrument name="DMM1" />
+	</Instruments>
+	<Pins>
+		<DUTPin name="Pin1" />
+		<DUTPin name="Pin2" />
+	</Pins>
+	<PinGroups></PinGroups>
+	<Sites>
+		<Site siteNumber="0" />
+	</Sites>
+	<Connections>
+		<Connection pin="Pin1" siteNumber="0" instrument="DCPower1" channel="0" />
+		<Connection pin="Pin2" siteNumber="0" instrument="DMM1" channel="0" />
+	</Connections>
+</PinMap>

--- a/examples/multiple_measurements/MultipleMeasurements.seq
+++ b/examples/multiple_measurements/MultipleMeasurements.seq
@@ -1,0 +1,8060 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<teststandfileheader type='SequenceFile' fileversion='962' productname='TestStand' productversion='2021 SP1 (21.1.0.49154)' compatibleversion='21.0.0.0' buildversion='21.0.0.49156' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.ni.com/TestStand/21.0.0/SequenceFile">
+	<typelist>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='1'>
+			<Expression classname='ExprValue' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436'>
+				<value/>
+			</Expression>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='2'>
+			<StepTypeMenu classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
+				<subprops>
+					<CanBeSubstepType classname='Bool'>
+						<value>false</value>
+					</CanBeSubstepType>
+					<CanOnlyBeSubstepType classname='Bool'>
+						<value>false</value>
+					</CanOnlyBeSubstepType>
+					<Category classname='Str'>
+						<value>""</value>
+					</Category>
+					<ItemName typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value>""</value>
+					</ItemName>
+					<SingularItemName classname='Str'>
+						<value>""</value>
+					</SingularItemName>
+					<SeparatorBeforeCategory classname='Bool'>
+						<value>false</value>
+					</SeparatorBeforeCategory>
+					<SeparatorBeforeItemName classname='Bool'>
+						<value>false</value>
+					</SeparatorBeforeItemName>
+					<Group classname='Str'>
+						<value/>
+					</Group>
+				</subprops>
+			</StepTypeMenu>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='3'>
+			<StepTypeSubstepsArray classname='Objs' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4849688' valueflags='24'>
+				<value lbound='[0]' ubound='[]'/>
+			</StepTypeSubstepsArray>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='4'>
+			<NI_ArrayDimensions classname='ArrayDimensions' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+				<subprops>
+					<LowerBounds classname='Nums'>
+						<value lbound='[0]' ubound='[]'/>
+					</LowerBounds>
+					<UpperBounds classname='Nums'>
+						<value lbound='[0]' ubound='[]'/>
+					</UpperBounds>
+				</subprops>
+			</NI_ArrayDimensions>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='5'>
+			<NI_PropertyObjectType classname='PropertyObjectType' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+				<subprops>
+					<ValueType classname='Num'>
+						<value>3</value>
+					</ValueType>
+					<IsObject classname='Bool'>
+						<value>true</value>
+					</IsObject>
+					<TypeName classname='Str'>
+						<value/>
+					</TypeName>
+					<ElementType classname='Objs'>
+						<value lbound='[0]' ubound='[]'/>
+					</ElementType>
+					<ArrayDimensions typename='NI_ArrayDimensions' xsi:type='NI_ArrayDimensions' classname='ArrayDimensions'>
+						<subprops>
+							<LowerBounds classname='Nums'>
+								<value lbound='[0]' ubound='[]'/>
+							</LowerBounds>
+							<UpperBounds classname='Nums'>
+								<value lbound='[0]' ubound='[]'/>
+							</UpperBounds>
+						</subprops>
+					</ArrayDimensions>
+					<Representation classname='Num'>
+						<value>1</value>
+					</Representation>
+					<ClassName classname='Str'>
+						<value/>
+					</ClassName>
+				</subprops>
+			</NI_PropertyObjectType>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='6'>
+			<NI_CustomResult classname='CustomResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+				<subprops>
+					<Name typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</Name>
+					<ValueToLog typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</ValueToLog>
+					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</Condition>
+					<Flags classname='Num'>
+						<value>8192</value>
+						<numericfmt>%#x</numericfmt>
+					</Flags>
+					<CheckedState classname='Num'>
+						<value>2</value>
+					</CheckedState>
+					<Type typename='NI_PropertyObjectType' xsi:type='NI_PropertyObjectType' classname='PropertyObjectType'>
+						<subprops>
+							<ValueType classname='Num'>
+								<value>3</value>
+							</ValueType>
+							<IsObject classname='Bool'>
+								<value>true</value>
+							</IsObject>
+							<TypeName classname='Str'>
+								<value/>
+							</TypeName>
+							<ElementType classname='Objs'>
+								<value lbound='[0]' ubound='[]'/>
+							</ElementType>
+							<ArrayDimensions classname='ArrayDimensions'>
+								<subprops>
+									<LowerBounds classname='Nums'>
+										<value lbound='[0]' ubound='[]'/>
+									</LowerBounds>
+									<UpperBounds classname='Nums'>
+										<value lbound='[0]' ubound='[]'/>
+									</UpperBounds>
+								</subprops>
+							</ArrayDimensions>
+							<Representation classname='Num'>
+								<value>1</value>
+							</Representation>
+							<ClassName classname='Str'>
+								<value/>
+							</ClassName>
+						</subprops>
+					</Type>
+					<Elements classname='Objs'>
+						<value lbound='[0]' ubound='[]'/>
+					</Elements>
+					<IsAnyType classname='Bool'>
+						<value>true</value>
+					</IsAnyType>
+				</subprops>
+			</NI_CustomResult>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='7'>
+			<TEInf classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4456472' instanceoverrideflags='4456472' valueflags='24'>
+				<subprops>
+					<Id classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
+						<value/>
+					</Id>
+					<Icon classname='Str' instanceoverrideflags='5046296'>
+						<value/>
+					</Icon>
+					<SData classname='Obj' flagsforinstances='2097152' instanceoverrideflags='7143448' structureflags='2097152'/>
+					<PreCond typename='Expression' xsi:type='Expression' classname='ExprValue' instanceoverrideflags='5046296'>
+						<value/>
+					</PreCond>
+					<LoadOpt classname='Str' instanceoverrideflags='5046296'>
+						<value>PreloadWhenExecuted</value>
+					</LoadOpt>
+					<UnloadOpt classname='Str' instanceoverrideflags='5046296'>
+						<value>UnloadWithFile</value>
+					</UnloadOpt>
+					<Mode classname='Str' instanceoverrideflags='5046296'>
+						<value>Normal</value>
+					</Mode>
+					<WindowActivation classname='Str' instanceoverrideflags='5046296'>
+						<value>None</value>
+					</WindowActivation>
+					<ResultOption classname='Num' instanceoverrideflags='5046296'>
+						<value>1</value>
+					</ResultOption>
+					<StepFCSeqF classname='Bool' instanceoverrideflags='5046296'>
+						<value>true</value>
+					</StepFCSeqF>
+					<IgnoreRTE classname='Bool' instanceoverrideflags='5046296'>
+						<value>false</value>
+					</IgnoreRTE>
+					<UseMutex classname='Bool' instanceoverrideflags='5046296'>
+						<value>false</value>
+					</UseMutex>
+					<MutexNameOrRef typename='Expression' xsi:type='Expression' classname='ExprValue' instanceoverrideflags='5046296'>
+						<value/>
+					</MutexNameOrRef>
+					<BatchSyncOpt classname='Num' instanceoverrideflags='5046296'>
+						<value>0</value>
+					</BatchSyncOpt>
+					<SwitchEnabled classname='Bool' instanceoverrideflags='5046296'>
+						<value>false</value>
+					</SwitchEnabled>
+					<VirtualDeviceName typename='Expression' xsi:type='Expression' classname='ExprValue' instanceoverrideflags='5046296'>
+						<value/>
+					</VirtualDeviceName>
+					<SwitchOperation classname='Num' instanceoverrideflags='5046296'>
+						<value>1</value>
+					</SwitchOperation>
+					<RouteGroupConnect typename='Expression' xsi:type='Expression' classname='ExprValue' instanceoverrideflags='5046296'>
+						<value/>
+					</RouteGroupConnect>
+					<RouteGroupDisconnect typename='Expression' xsi:type='Expression' classname='ExprValue' instanceoverrideflags='5046296'>
+						<value/>
+					</RouteGroupDisconnect>
+					<MulticonnectMode classname='Num' instanceoverrideflags='5046296'>
+						<value>1</value>
+					</MulticonnectMode>
+					<OperationOrder classname='Num' instanceoverrideflags='5046296'>
+						<value>2</value>
+					</OperationOrder>
+					<ConnectionLifetime classname='Num' instanceoverrideflags='5046296'>
+						<value>4</value>
+					</ConnectionLifetime>
+					<WaitForDebounce classname='Bool' instanceoverrideflags='5046296'>
+						<value>true</value>
+					</WaitForDebounce>
+					<PassAct classname='Str' instanceoverrideflags='5046296'>
+						<value>Next</value>
+					</PassAct>
+					<FailAct classname='Str' instanceoverrideflags='5046296'>
+						<value>Next</value>
+					</FailAct>
+					<PassActTarget typename='Expression' xsi:type='Expression' classname='ExprValue' instanceoverrideflags='5046296'>
+						<value/>
+					</PassActTarget>
+					<FailActTarget typename='Expression' xsi:type='Expression' classname='ExprValue' instanceoverrideflags='5046296'>
+						<value/>
+					</FailActTarget>
+					<CustExpr typename='Expression' xsi:type='Expression' classname='ExprValue' instanceoverrideflags='5046296'>
+						<value/>
+					</CustExpr>
+					<CustTrueAct classname='Str' instanceoverrideflags='5046296'>
+						<value>Next</value>
+					</CustTrueAct>
+					<CustFalseAct classname='Str' instanceoverrideflags='5046296'>
+						<value>Next</value>
+					</CustFalseAct>
+					<CustTrueActTarget typename='Expression' xsi:type='Expression' classname='ExprValue' instanceoverrideflags='5046296'>
+						<value/>
+					</CustTrueActTarget>
+					<CustFalseActTarget typename='Expression' xsi:type='Expression' classname='ExprValue' instanceoverrideflags='5046296'>
+						<value/>
+					</CustFalseActTarget>
+					<LoopType classname='Str' instanceoverrideflags='5046296'>
+						<value>NoLooping</value>
+					</LoopType>
+					<LoopWhile typename='Expression' xsi:type='Expression' classname='ExprValue' instanceoverrideflags='5046296'>
+						<value/>
+					</LoopWhile>
+					<LoopStatus typename='Expression' xsi:type='Expression' classname='ExprValue' instanceoverrideflags='5046296'>
+						<value/>
+					</LoopStatus>
+					<LoopIncrement typename='Expression' xsi:type='Expression' classname='ExprValue' instanceoverrideflags='5046296'>
+						<value>RunState.LoopIndex += 1</value>
+					</LoopIncrement>
+					<LoopInitialize typename='Expression' xsi:type='Expression' classname='ExprValue' instanceoverrideflags='5046296'>
+						<value>RunState.LoopIndex = 0</value>
+					</LoopInitialize>
+					<LoopOpt classname='Num' instanceoverrideflags='5046296'>
+						<value>0</value>
+					</LoopOpt>
+					<PreExpr typename='Expression' xsi:type='Expression' classname='ExprValue' instanceoverrideflags='5046296'>
+						<value/>
+					</PreExpr>
+					<PostExpr typename='Expression' xsi:type='Expression' classname='ExprValue' instanceoverrideflags='5046296'>
+						<value/>
+					</PostExpr>
+					<StatusExpr typename='Expression' xsi:type='Expression' classname='ExprValue' instanceoverrideflags='5046296'>
+						<value/>
+					</StatusExpr>
+					<CanSpecifyModule classname='Bool' instanceoverrideflags='5046296'>
+						<value>true</value>
+					</CanSpecifyModule>
+					<CanEditCode classname='Bool' instanceoverrideflags='5046296'>
+						<value>true</value>
+					</CanEditCode>
+					<CanEditModulePrototype classname='Bool' instanceoverrideflags='5046296'>
+						<value>true</value>
+					</CanEditModulePrototype>
+					<CanEditParameterAdditionalResults classname='Bool' instanceoverrideflags='5046296'>
+						<value>true</value>
+					</CanEditParameterAdditionalResults>
+					<PrecondIntExe classname='Num' instanceoverrideflags='5046296'>
+						<value>0</value>
+					</PrecondIntExe>
+					<Requirements classname='Obj' flagsforinstances='2097153' instanceoverrideflags='7143449' valueflags='1' structureflags='2097152'>
+						<subprops>
+							<Links classname='Strs' flagsforinstances='71303168' instanceoverrideflags='72286233' valueflags='71303168'>
+								<value lbound='[0]' ubound='[]'/>
+							</Links>
+						</subprops>
+					</Requirements>
+					<CustomResults classname='Objs' instanceoverrideflags='5046296'>
+						<value lbound='[0]' ubound='[]'>
+							<elemproto>
+								<_NAME_IN_ATTRIBUTE_ typename='NI_CustomResult' xsi:type='NI_CustomResult' name='' classname='CustomResult'>
+									<subprops>
+										<Name classname='ExprValue'>
+											<value/>
+										</Name>
+										<ValueToLog classname='ExprValue'>
+											<value/>
+										</ValueToLog>
+										<Condition classname='ExprValue'>
+											<value/>
+										</Condition>
+										<Flags classname='Num'>
+											<value>8192</value>
+										</Flags>
+										<CheckedState classname='Num'>
+											<value>2</value>
+										</CheckedState>
+										<Type classname='PropertyObjectType'>
+											<subprops>
+												<ValueType classname='Num'>
+													<value>3</value>
+												</ValueType>
+												<IsObject classname='Bool'>
+													<value>true</value>
+												</IsObject>
+												<TypeName classname='Str'>
+													<value/>
+												</TypeName>
+												<ElementType classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</ElementType>
+												<ArrayDimensions classname='ArrayDimensions'>
+													<subprops>
+														<LowerBounds classname='Nums'>
+															<value lbound='[0]' ubound='[]'/>
+														</LowerBounds>
+														<UpperBounds classname='Nums'>
+															<value lbound='[0]' ubound='[]'/>
+														</UpperBounds>
+													</subprops>
+												</ArrayDimensions>
+												<Representation classname='Num'>
+													<value>1</value>
+												</Representation>
+												<ClassName classname='Str'>
+													<value/>
+												</ClassName>
+											</subprops>
+										</Type>
+										<Elements classname='Objs'>
+											<value lbound='[0]' ubound='[]'/>
+										</Elements>
+										<IsAnyType classname='Bool'>
+											<value>true</value>
+										</IsAnyType>
+									</subprops>
+								</_NAME_IN_ATTRIBUTE_>
+							</elemproto>
+						</value>
+					</CustomResults>
+					<AdditionalResultsHints classname='Objs' instanceoverrideflags='5046296'>
+						<value lbound='[0]' ubound='[]'>
+							<elemproto>
+								<_NAME_IN_ATTRIBUTE_ typename='NI_CustomResult' xsi:type='NI_CustomResult' name='' classname='CustomResult'>
+									<subprops>
+										<Name classname='ExprValue'>
+											<value/>
+										</Name>
+										<ValueToLog classname='ExprValue'>
+											<value/>
+										</ValueToLog>
+										<Condition classname='ExprValue'>
+											<value/>
+										</Condition>
+										<Flags classname='Num'>
+											<value>8192</value>
+										</Flags>
+										<CheckedState classname='Num'>
+											<value>2</value>
+										</CheckedState>
+										<Type classname='PropertyObjectType'>
+											<subprops>
+												<ValueType classname='Num'>
+													<value>3</value>
+												</ValueType>
+												<IsObject classname='Bool'>
+													<value>true</value>
+												</IsObject>
+												<TypeName classname='Str'>
+													<value/>
+												</TypeName>
+												<ElementType classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</ElementType>
+												<ArrayDimensions classname='ArrayDimensions'>
+													<subprops>
+														<LowerBounds classname='Nums'>
+															<value lbound='[0]' ubound='[]'/>
+														</LowerBounds>
+														<UpperBounds classname='Nums'>
+															<value lbound='[0]' ubound='[]'/>
+														</UpperBounds>
+													</subprops>
+												</ArrayDimensions>
+												<Representation classname='Num'>
+													<value>1</value>
+												</Representation>
+												<ClassName classname='Str'>
+													<value/>
+												</ClassName>
+											</subprops>
+										</Type>
+										<Elements classname='Objs'>
+											<value lbound='[0]' ubound='[]'/>
+										</Elements>
+										<IsAnyType classname='Bool'>
+											<value>true</value>
+										</IsAnyType>
+									</subprops>
+								</_NAME_IN_ATTRIBUTE_>
+							</elemproto>
+						</value>
+					</AdditionalResultsHints>
+				</subprops>
+			</TEInf>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='8'>
+			<StepTypeNIData classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
+				<subprops>
+					<EditPanels classname='Strs'>
+						<value lbound='[0]' ubound='[]'/>
+					</EditPanels>
+				</subprops>
+			</StepTypeNIData>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='9'>
+			<Error classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436'>
+				<extdata controllername='STRUCT' allowstructpassing='true' packingoption='8' exclude='false' type='0' arraystorage='0' strbuffersize='256' strstorage='0'/>
+				<extdata controllername='CLUST' allowclusterpassing='true' exclude='false' memberlabel=''/>
+				<extdata controllername='DNSTRUCT' allowstructpassing='true' exclude='false' membername=''/>
+				<extdata controllername='BLVCLUSTER' allowclusterpassing='true' exclude='false' memberlabel=''/>
+				<subprops>
+					<Code classname='Num' flagsforinstances='4194304' valueflags='4194304'>
+						<value>0</value>
+						<extdata controllername='STRUCT' allowstructpassing='false' packingoption='0' exclude='false' type='6' arraystorage='0' strbuffersize='256' strstorage='0'/>
+						<extdata controllername='CLUST' allowclusterpassing='false' exclude='false' memberlabel='code'/>
+						<extdata controllername='DNSTRUCT' allowstructpassing='false' exclude='false' membername='code'/>
+						<extdata controllername='BLVCLUSTER' allowclusterpassing='false' exclude='false' memberlabel='code'/>
+					</Code>
+					<Msg classname='Str' flagsforinstances='4194304' valueflags='4194304'>
+						<value/>
+						<extdata controllername='STRUCT' allowstructpassing='false' packingoption='0' exclude='false' type='2' arraystorage='0' strbuffersize='1024' strstorage='1'/>
+						<extdata controllername='CLUST' allowclusterpassing='false' exclude='false' memberlabel='source'/>
+						<extdata controllername='DNSTRUCT' allowstructpassing='false' exclude='false' membername='msg'/>
+						<extdata controllername='BLVCLUSTER' allowclusterpassing='false' exclude='false' memberlabel='source'/>
+					</Msg>
+					<Occurred classname='Bool' flagsforinstances='4194304' valueflags='4194304'>
+						<value>false</value>
+						<extdata controllername='STRUCT' allowstructpassing='false' packingoption='0' exclude='false' type='6' arraystorage='0' strbuffersize='256' strstorage='0'/>
+						<extdata controllername='CLUST' allowclusterpassing='false' exclude='false' memberlabel='status'/>
+						<extdata controllername='DNSTRUCT' allowstructpassing='false' exclude='false' membername='occurred'/>
+						<extdata controllername='BLVCLUSTER' allowclusterpassing='false' exclude='false' memberlabel='status'/>
+					</Occurred>
+				</subprops>
+			</Error>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='10'>
+			<CommonResults classname='Obj' isroottypedef='true' typecategory='3' timestamp='1465572565' typeversion='3.1.0.100' typelastmodversion='21.1.0.49154' typeminprodversion='3.1.0.0' typeflags='33554432' flagsforinstances='4194304' valueflags='4194304'/>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='11'>
+			<Substep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
+				<subprops>
+					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
+						<value>"%ModuleDescription"</value>
+					</DescriptionFormat>
+					<DefaultNameFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
+						<value>ResStr("NI_STEPTYPES", "GENERIC_DEF_SUBSTEP_NAME")</value>
+					</DefaultNameFormat>
+					<BlockStartTypes classname='Str' valueflags='4194328' structureflags='524288'>
+						<value/>
+					</BlockStartTypes>
+					<BlockEndTypes classname='Str' valueflags='4194328' structureflags='524288'>
+						<value/>
+					</BlockEndTypes>
+					<AppliesToBlockStructure classname='Bool' valueflags='4194328' structureflags='524288'>
+						<value>false</value>
+					</AppliesToBlockStructure>
+					<Menu typename='StepTypeMenu' xsi:type='StepTypeMenu' classname='Obj'>
+						<subprops>
+							<CanBeSubstepType classname='Bool'>
+								<value>true</value>
+							</CanBeSubstepType>
+							<CanOnlyBeSubstepType classname='Bool'>
+								<value>true</value>
+							</CanOnlyBeSubstepType>
+							<Category classname='Str'>
+								<value>""</value>
+							</Category>
+							<ItemName classname='ExprValue'>
+								<value>ResStr("NI_STEPTYPES", "GENERIC_SUBSTEP_MENU_ITEM_NAME")</value>
+							</ItemName>
+							<SingularItemName classname='Str'>
+								<value>""</value>
+							</SingularItemName>
+							<SeparatorBeforeCategory classname='Bool'>
+								<value>false</value>
+							</SeparatorBeforeCategory>
+							<SeparatorBeforeItemName classname='Bool'>
+								<value>false</value>
+							</SeparatorBeforeItemName>
+							<Group classname='Str'>
+								<value>GenericSubsteps</value>
+							</Group>
+						</subprops>
+					</Menu>
+					<Substeps typename='StepTypeSubstepsArray' xsi:type='StepTypeSubstepsArray' classname='Objs'>
+						<value lbound='[0]' ubound='[]'/>
+					</Substeps>
+					<CodeTemplates classname='Str' valueflags='4194328' structureflags='524288'>
+						<value>DefaultLabVIEWNXG|DefaultLabVIEW|DefaultCVI|DefaultVB.NET|DefaultCSharp.NET|DefaultC++.NET|DefaultVC++_Template|DefaultHTB72_Template|DefaultHTB80_Template|Default_Template</value>
+					</CodeTemplates>
+					<AdditionalResultsHints classname='Objs' valueflags='4194328' structureflags='524288'>
+						<value lbound='[0]' ubound='[]'>
+							<elemproto>
+								<_NAME_IN_ATTRIBUTE_ typename='NI_CustomResult' xsi:type='NI_CustomResult' name='' classname='CustomResult'>
+									<subprops>
+										<Name classname='ExprValue'>
+											<value/>
+										</Name>
+										<ValueToLog classname='ExprValue'>
+											<value/>
+										</ValueToLog>
+										<Condition classname='ExprValue'>
+											<value/>
+										</Condition>
+										<Flags classname='Num'>
+											<value>8192</value>
+										</Flags>
+										<CheckedState classname='Num'>
+											<value>2</value>
+										</CheckedState>
+										<Type classname='PropertyObjectType'>
+											<subprops>
+												<ValueType classname='Num'>
+													<value>3</value>
+												</ValueType>
+												<IsObject classname='Bool'>
+													<value>true</value>
+												</IsObject>
+												<TypeName classname='Str'>
+													<value/>
+												</TypeName>
+												<ElementType classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</ElementType>
+												<ArrayDimensions classname='ArrayDimensions'>
+													<subprops>
+														<LowerBounds classname='Nums'>
+															<value lbound='[0]' ubound='[]'/>
+														</LowerBounds>
+														<UpperBounds classname='Nums'>
+															<value lbound='[0]' ubound='[]'/>
+														</UpperBounds>
+													</subprops>
+												</ArrayDimensions>
+												<Representation classname='Num'>
+													<value>1</value>
+												</Representation>
+												<ClassName classname='Str'>
+													<value/>
+												</ClassName>
+											</subprops>
+										</Type>
+										<Elements classname='Objs'>
+											<value lbound='[0]' ubound='[]'/>
+										</Elements>
+										<IsAnyType classname='Bool'>
+											<value>true</value>
+										</IsAnyType>
+									</subprops>
+								</_NAME_IN_ATTRIBUTE_>
+							</elemproto>
+						</value>
+					</AdditionalResultsHints>
+					<TS typename='TEInf' xsi:type='TEInf' classname='Obj' flagsforinstances='4456472'>
+						<subprops>
+							<Id classname='Str'>
+								<value/>
+							</Id>
+							<Icon classname='Str'>
+								<value/>
+							</Icon>
+							<SData classname='Obj' flagsforinstances='2097152' instanceoverrideflags='7274521' structureflags='2097152'/>
+							<PreCond classname='ExprValue'>
+								<value/>
+							</PreCond>
+							<LoadOpt classname='Str'>
+								<value>PreloadWhenExecuted</value>
+							</LoadOpt>
+							<UnloadOpt classname='Str'>
+								<value>UnloadWithFile</value>
+							</UnloadOpt>
+							<Mode classname='Str'>
+								<value>Normal</value>
+							</Mode>
+							<WindowActivation classname='Str'>
+								<value>None</value>
+							</WindowActivation>
+							<ResultOption classname='Num'>
+								<value>1</value>
+							</ResultOption>
+							<StepFCSeqF classname='Bool'>
+								<value>true</value>
+							</StepFCSeqF>
+							<IgnoreRTE classname='Bool'>
+								<value>false</value>
+							</IgnoreRTE>
+							<UseMutex classname='Bool'>
+								<value>false</value>
+							</UseMutex>
+							<MutexNameOrRef classname='ExprValue'>
+								<value/>
+							</MutexNameOrRef>
+							<BatchSyncOpt classname='Num'>
+								<value>0</value>
+							</BatchSyncOpt>
+							<SwitchEnabled classname='Bool'>
+								<value>false</value>
+							</SwitchEnabled>
+							<VirtualDeviceName classname='ExprValue'>
+								<value/>
+							</VirtualDeviceName>
+							<SwitchOperation classname='Num'>
+								<value>1</value>
+							</SwitchOperation>
+							<RouteGroupConnect classname='ExprValue'>
+								<value/>
+							</RouteGroupConnect>
+							<RouteGroupDisconnect classname='ExprValue'>
+								<value/>
+							</RouteGroupDisconnect>
+							<MulticonnectMode classname='Num'>
+								<value>1</value>
+							</MulticonnectMode>
+							<OperationOrder classname='Num'>
+								<value>2</value>
+							</OperationOrder>
+							<ConnectionLifetime classname='Num'>
+								<value>4</value>
+							</ConnectionLifetime>
+							<WaitForDebounce classname='Bool'>
+								<value>true</value>
+							</WaitForDebounce>
+							<PassAct classname='Str'>
+								<value>Next</value>
+							</PassAct>
+							<FailAct classname='Str'>
+								<value>Next</value>
+							</FailAct>
+							<PassActTarget classname='ExprValue'>
+								<value/>
+							</PassActTarget>
+							<FailActTarget classname='ExprValue'>
+								<value/>
+							</FailActTarget>
+							<CustExpr classname='ExprValue'>
+								<value/>
+							</CustExpr>
+							<CustTrueAct classname='Str'>
+								<value>Next</value>
+							</CustTrueAct>
+							<CustFalseAct classname='Str'>
+								<value>Next</value>
+							</CustFalseAct>
+							<CustTrueActTarget classname='ExprValue'>
+								<value/>
+							</CustTrueActTarget>
+							<CustFalseActTarget classname='ExprValue'>
+								<value/>
+							</CustFalseActTarget>
+							<LoopType classname='Str'>
+								<value>NoLooping</value>
+							</LoopType>
+							<LoopWhile classname='ExprValue'>
+								<value/>
+							</LoopWhile>
+							<LoopStatus classname='ExprValue'>
+								<value/>
+							</LoopStatus>
+							<LoopIncrement classname='ExprValue'>
+								<value>RunState.LoopIndex += 1</value>
+							</LoopIncrement>
+							<LoopInitialize classname='ExprValue'>
+								<value>RunState.LoopIndex = 0</value>
+							</LoopInitialize>
+							<LoopOpt classname='Num'>
+								<value>0</value>
+							</LoopOpt>
+							<PreExpr classname='ExprValue'>
+								<value/>
+							</PreExpr>
+							<PostExpr classname='ExprValue'>
+								<value/>
+							</PostExpr>
+							<StatusExpr classname='ExprValue'>
+								<value/>
+							</StatusExpr>
+							<CanSpecifyModule classname='Bool'>
+								<value>true</value>
+							</CanSpecifyModule>
+							<CanEditCode classname='Bool'>
+								<value>true</value>
+							</CanEditCode>
+							<CanEditModulePrototype classname='Bool'>
+								<value>true</value>
+							</CanEditModulePrototype>
+							<CanEditParameterAdditionalResults classname='Bool'>
+								<value>true</value>
+							</CanEditParameterAdditionalResults>
+							<PrecondIntExe classname='Num'>
+								<value>0</value>
+							</PrecondIntExe>
+							<Requirements classname='Obj' flagsforinstances='1' valueflags='1' structureflags='2097152'>
+								<subprops>
+									<Links classname='Strs' flagsforinstances='71303168' instanceoverrideflags='72286233' valueflags='71303168'>
+										<value lbound='[0]' ubound='[]'/>
+									</Links>
+								</subprops>
+							</Requirements>
+							<CustomResults classname='Objs'>
+								<value lbound='[0]' ubound='[]'>
+									<elemproto>
+										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+											<subprops>
+												<Name classname='ExprValue'>
+													<value/>
+												</Name>
+												<ValueToLog classname='ExprValue'>
+													<value/>
+												</ValueToLog>
+												<Condition classname='ExprValue'>
+													<value/>
+												</Condition>
+												<Flags classname='Num'>
+													<value>8192</value>
+												</Flags>
+												<CheckedState classname='Num'>
+													<value>2</value>
+												</CheckedState>
+												<Type classname='PropertyObjectType'>
+													<subprops>
+														<ValueType classname='Num'>
+															<value>3</value>
+														</ValueType>
+														<IsObject classname='Bool'>
+															<value>true</value>
+														</IsObject>
+														<TypeName classname='Str'>
+															<value/>
+														</TypeName>
+														<ElementType classname='Objs'>
+															<value lbound='[0]' ubound='[]'/>
+														</ElementType>
+														<ArrayDimensions classname='ArrayDimensions'>
+															<subprops>
+																<LowerBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</LowerBounds>
+																<UpperBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</UpperBounds>
+															</subprops>
+														</ArrayDimensions>
+														<Representation classname='Num'>
+															<value>1</value>
+														</Representation>
+														<ClassName classname='Str'>
+															<value/>
+														</ClassName>
+													</subprops>
+												</Type>
+												<Elements classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</Elements>
+												<IsAnyType classname='Bool'>
+													<value>true</value>
+												</IsAnyType>
+											</subprops>
+										</_NAME_IN_ATTRIBUTE_>
+									</elemproto>
+								</value>
+							</CustomResults>
+							<AdditionalResultsHints classname='Objs'>
+								<value lbound='[0]' ubound='[]'>
+									<elemproto>
+										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+											<subprops>
+												<Name classname='ExprValue'>
+													<value/>
+												</Name>
+												<ValueToLog classname='ExprValue'>
+													<value/>
+												</ValueToLog>
+												<Condition classname='ExprValue'>
+													<value/>
+												</Condition>
+												<Flags classname='Num'>
+													<value>8192</value>
+												</Flags>
+												<CheckedState classname='Num'>
+													<value>2</value>
+												</CheckedState>
+												<Type classname='PropertyObjectType'>
+													<subprops>
+														<ValueType classname='Num'>
+															<value>3</value>
+														</ValueType>
+														<IsObject classname='Bool'>
+															<value>true</value>
+														</IsObject>
+														<TypeName classname='Str'>
+															<value/>
+														</TypeName>
+														<ElementType classname='Objs'>
+															<value lbound='[0]' ubound='[]'/>
+														</ElementType>
+														<ArrayDimensions classname='ArrayDimensions'>
+															<subprops>
+																<LowerBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</LowerBounds>
+																<UpperBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</UpperBounds>
+															</subprops>
+														</ArrayDimensions>
+														<Representation classname='Num'>
+															<value>1</value>
+														</Representation>
+														<ClassName classname='Str'>
+															<value/>
+														</ClassName>
+													</subprops>
+												</Type>
+												<Elements classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</Elements>
+												<IsAnyType classname='Bool'>
+													<value>true</value>
+												</IsAnyType>
+											</subprops>
+										</_NAME_IN_ATTRIBUTE_>
+									</elemproto>
+								</value>
+							</AdditionalResultsHints>
+						</subprops>
+					</TS>
+					<NI_Data typename='StepTypeNIData' xsi:type='StepTypeNIData' classname='Obj'>
+						<subprops>
+							<EditPanels classname='Strs'>
+								<value lbound='[0]' ubound='[]'/>
+							</EditPanels>
+						</subprops>
+					</NI_Data>
+					<Result classname='Obj' flagsforinstances='4194304' valueflags='4194304'>
+						<subprops>
+							<Error typename='Error' xsi:type='Error' classname='Obj' flagsforinstances='4194304' valueflags='4194304'>
+								<subprops>
+									<Code classname='Num'>
+										<value>0</value>
+									</Code>
+									<Msg classname='Str'>
+										<value/>
+									</Msg>
+									<Occurred classname='Bool'>
+										<value>false</value>
+									</Occurred>
+								</subprops>
+							</Error>
+							<Status classname='Str' flagsforinstances='4194304' valueflags='4194304'>
+								<value/>
+							</Status>
+							<ReportText classname='Str' flagsforinstances='4194304' valueflags='4194304'>
+								<value/>
+							</ReportText>
+							<Common typename='CommonResults' xsi:type='CommonResults' classname='Obj'/>
+						</subprops>
+					</Result>
+					<CanEncapsulate classname='Bool' valueflags='4194328' structureflags='524288'>
+						<value>false</value>
+					</CanEncapsulate>
+				</subprops>
+			</Substep>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='12'>
+			<NI_DotNetParameterResult classname='DotNetParameterResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+				<subprops>
+					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</Condition>
+					<Flags classname='Num'>
+						<value>8192</value>
+						<numericfmt>%#x</numericfmt>
+					</Flags>
+					<CheckedState classname='Num'>
+						<value>1</value>
+					</CheckedState>
+				</subprops>
+			</NI_DotNetParameterResult>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='13'>
+			<DotNetParameter classname='DotNetParameter' isroottypedef='true' typecategory='3' timestamp='1650061192' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+				<subprops>
+					<Name classname='Str'>
+						<value>_notNamed</value>
+					</Name>
+					<ArgVal typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</ArgVal>
+					<ArgDisplayVal typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</ArgDisplayVal>
+					<Type classname='Num'>
+						<value>0</value>
+					</Type>
+					<TypeName classname='Str'>
+						<value/>
+					</TypeName>
+					<Flags classname='Num'>
+						<value>0</value>
+					</Flags>
+					<IsOptional classname='Bool'>
+						<value>false</value>
+					</IsOptional>
+					<CallDispose classname='Bool'>
+						<value>false</value>
+					</CallDispose>
+					<NumDimensions classname='Nums'>
+						<value lbound='[0]' ubound='[]'/>
+					</NumDimensions>
+					<MultiElement classname='Objs'>
+						<value lbound='[0]' ubound='[]'/>
+					</MultiElement>
+					<AdditionalResults classname='Obj'>
+						<subprops>
+							<Input typename='NI_DotNetParameterResult' xsi:type='NI_DotNetParameterResult' classname='DotNetParameterResult'>
+								<subprops>
+									<Condition classname='ExprValue'>
+										<value/>
+									</Condition>
+									<Flags classname='Num'>
+										<value>8192</value>
+									</Flags>
+									<CheckedState classname='Num'>
+										<value>1</value>
+									</CheckedState>
+								</subprops>
+							</Input>
+							<Output typename='NI_DotNetParameterResult' xsi:type='NI_DotNetParameterResult' classname='DotNetParameterResult'>
+								<subprops>
+									<Condition classname='ExprValue'>
+										<value/>
+									</Condition>
+									<Flags classname='Num'>
+										<value>8192</value>
+									</Flags>
+									<CheckedState classname='Num'>
+										<value>1</value>
+									</CheckedState>
+								</subprops>
+							</Output>
+						</subprops>
+					</AdditionalResults>
+					<UserData classname='Obj' flagsforinstances='2097152' structureflags='2097152'/>
+				</subprops>
+			</DotNetParameter>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='14'>
+			<NI_DotNetCallResult classname='DotNetCallResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+				<subprops>
+					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</Condition>
+					<Flags classname='Num'>
+						<value>8192</value>
+						<numericfmt>%#x</numericfmt>
+					</Flags>
+					<CheckedState classname='Num'>
+						<value>1</value>
+					</CheckedState>
+				</subprops>
+			</NI_DotNetCallResult>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='15'>
+			<DotNetCall classname='DotNetCall' isroottypedef='true' typecategory='3' timestamp='1650061192' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+				<subprops>
+					<ClassName classname='Str'>
+						<value/>
+					</ClassName>
+					<MemberType classname='Num'>
+						<value>0</value>
+					</MemberType>
+					<Static classname='Bool'>
+						<value>false</value>
+					</Static>
+					<MemberName classname='Str'>
+						<value/>
+					</MemberName>
+					<Params classname='Objs'>
+						<value lbound='[0]' ubound='[]'>
+							<elemproto>
+								<_NAME_IN_ATTRIBUTE_ typename='DotNetParameter' xsi:type='DotNetParameter' name='' classname='DotNetParameter' structureflags='131072'>
+									<subprops>
+										<Name classname='Str'>
+											<value>_notNamed</value>
+										</Name>
+										<ArgVal classname='ExprValue'>
+											<value/>
+										</ArgVal>
+										<ArgDisplayVal classname='ExprValue'>
+											<value/>
+										</ArgDisplayVal>
+										<Type classname='Num'>
+											<value>0</value>
+										</Type>
+										<TypeName classname='Str'>
+											<value/>
+										</TypeName>
+										<Flags classname='Num'>
+											<value>0</value>
+										</Flags>
+										<IsOptional classname='Bool'>
+											<value>false</value>
+										</IsOptional>
+										<CallDispose classname='Bool'>
+											<value>false</value>
+										</CallDispose>
+										<NumDimensions classname='Nums'>
+											<value lbound='[0]' ubound='[]'/>
+										</NumDimensions>
+										<MultiElement classname='Objs'>
+											<value lbound='[0]' ubound='[]'/>
+										</MultiElement>
+										<AdditionalResults classname='Obj'>
+											<subprops>
+												<Input classname='DotNetParameterResult'>
+													<subprops>
+														<Condition classname='ExprValue'>
+															<value/>
+														</Condition>
+														<Flags classname='Num'>
+															<value>8192</value>
+														</Flags>
+														<CheckedState classname='Num'>
+															<value>1</value>
+														</CheckedState>
+													</subprops>
+												</Input>
+												<Output classname='DotNetParameterResult'>
+													<subprops>
+														<Condition classname='ExprValue'>
+															<value/>
+														</Condition>
+														<Flags classname='Num'>
+															<value>8192</value>
+														</Flags>
+														<CheckedState classname='Num'>
+															<value>1</value>
+														</CheckedState>
+													</subprops>
+												</Output>
+											</subprops>
+										</AdditionalResults>
+									</subprops>
+								</_NAME_IN_ATTRIBUTE_>
+							</elemproto>
+						</value>
+					</Params>
+					<AdditionalResult typename='NI_DotNetCallResult' xsi:type='NI_DotNetCallResult' classname='DotNetCallResult'>
+						<subprops>
+							<Condition classname='ExprValue'>
+								<value/>
+							</Condition>
+							<Flags classname='Num'>
+								<value>8192</value>
+							</Flags>
+							<CheckedState classname='Num'>
+								<value>1</value>
+							</CheckedState>
+						</subprops>
+					</AdditionalResult>
+				</subprops>
+			</DotNetCall>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='0'>
+			<Path classname='PathValue' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436'>
+				<value/>
+			</Path>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='16'>
+			<DotNetStepAdditions classname='DotNetModule' isroottypedef='true' typecategory='3' timestamp='1650061192' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+				<subprops>
+					<Calls classname='Objs'>
+						<value lbound='[0]' ubound='[]'>
+							<elemproto>
+								<_NAME_IN_ATTRIBUTE_ typename='DotNetCall' xsi:type='DotNetCall' name='' classname='DotNetCall' structureflags='131072'>
+									<subprops>
+										<ClassName classname='Str'>
+											<value/>
+										</ClassName>
+										<MemberType classname='Num'>
+											<value>0</value>
+										</MemberType>
+										<Static classname='Bool'>
+											<value>false</value>
+										</Static>
+										<MemberName classname='Str'>
+											<value/>
+										</MemberName>
+										<Params classname='Objs'>
+											<value lbound='[0]' ubound='[]'>
+												<elemproto>
+													<_NAME_IN_ATTRIBUTE_ name='' classname='DotNetParameter' structureflags='0'/>
+												</elemproto>
+											</value>
+										</Params>
+										<AdditionalResult classname='DotNetCallResult'>
+											<subprops>
+												<Condition classname='ExprValue'>
+													<value/>
+												</Condition>
+												<Flags classname='Num'>
+													<value>8192</value>
+												</Flags>
+												<CheckedState classname='Num'>
+													<value>1</value>
+												</CheckedState>
+											</subprops>
+										</AdditionalResult>
+									</subprops>
+								</_NAME_IN_ATTRIBUTE_>
+							</elemproto>
+						</value>
+					</Calls>
+					<AssemblyPath typename='Path' xsi:type='Path' classname='PathValue'>
+						<value/>
+					</AssemblyPath>
+					<AssemblyStrongName classname='Str'>
+						<value/>
+					</AssemblyStrongName>
+					<AssemblyLocation classname='Num'>
+						<value>0</value>
+					</AssemblyLocation>
+					<ClassName classname='Str'>
+						<value/>
+					</ClassName>
+					<IsStruct classname='Bool'>
+						<value>false</value>
+					</IsStruct>
+					<StructDef typename='DotNetParameter' xsi:type='DotNetParameter' classname='DotNetParameter'>
+						<subprops>
+							<Name classname='Str'>
+								<value>_notNamed</value>
+							</Name>
+							<ArgVal classname='ExprValue'>
+								<value/>
+							</ArgVal>
+							<ArgDisplayVal classname='ExprValue'>
+								<value/>
+							</ArgDisplayVal>
+							<Type classname='Num'>
+								<value>0</value>
+							</Type>
+							<TypeName classname='Str'>
+								<value/>
+							</TypeName>
+							<Flags classname='Num'>
+								<value>0</value>
+							</Flags>
+							<IsOptional classname='Bool'>
+								<value>false</value>
+							</IsOptional>
+							<CallDispose classname='Bool'>
+								<value>false</value>
+							</CallDispose>
+							<NumDimensions classname='Nums'>
+								<value lbound='[0]' ubound='[]'/>
+							</NumDimensions>
+							<MultiElement classname='Objs'>
+								<value lbound='[0]' ubound='[]'/>
+							</MultiElement>
+							<AdditionalResults classname='Obj'>
+								<subprops>
+									<Input classname='DotNetParameterResult'>
+										<subprops>
+											<Condition classname='ExprValue'>
+												<value/>
+											</Condition>
+											<Flags classname='Num'>
+												<value>8192</value>
+											</Flags>
+											<CheckedState classname='Num'>
+												<value>1</value>
+											</CheckedState>
+										</subprops>
+									</Input>
+									<Output classname='DotNetParameterResult'>
+										<subprops>
+											<Condition classname='ExprValue'>
+												<value/>
+											</Condition>
+											<Flags classname='Num'>
+												<value>8192</value>
+											</Flags>
+											<CheckedState classname='Num'>
+												<value>1</value>
+											</CheckedState>
+										</subprops>
+									</Output>
+								</subprops>
+							</AdditionalResults>
+						</subprops>
+					</StructDef>
+					<RemoteSpecifiedByExpr classname='Bool'>
+						<value>false</value>
+					</RemoteSpecifiedByExpr>
+					<UseLoadSpec classname='Bool'>
+						<value>false</value>
+					</UseLoadSpec>
+					<ModuleSrcPath typename='Path' xsi:type='Path' classname='PathValue'>
+						<value/>
+					</ModuleSrcPath>
+					<ModulePrjPath typename='Path' xsi:type='Path' classname='PathValue'>
+						<value/>
+					</ModulePrjPath>
+					<ModuleSlnPath typename='Path' xsi:type='Path' classname='PathValue'>
+						<value/>
+					</ModuleSlnPath>
+					<FunctionName classname='Str'>
+						<value/>
+					</FunctionName>
+				</subprops>
+			</DotNetStepAdditions>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='17'>
+			<PostSubstep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
+				<subprops>
+					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
+						<value>"%ModuleDescription"</value>
+					</DescriptionFormat>
+					<DefaultNameFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
+						<value>ResStr("NI_STEPTYPES", "POST_DEF_SUBSTEP_NAME")</value>
+					</DefaultNameFormat>
+					<BlockStartTypes classname='Str' valueflags='4194328' structureflags='524288'>
+						<value/>
+					</BlockStartTypes>
+					<BlockEndTypes classname='Str' valueflags='4194328' structureflags='524288'>
+						<value/>
+					</BlockEndTypes>
+					<AppliesToBlockStructure classname='Bool' valueflags='4194328' structureflags='524288'>
+						<value>false</value>
+					</AppliesToBlockStructure>
+					<Menu typename='StepTypeMenu' xsi:type='StepTypeMenu' classname='Obj'>
+						<subprops>
+							<CanBeSubstepType classname='Bool'>
+								<value>true</value>
+							</CanBeSubstepType>
+							<CanOnlyBeSubstepType classname='Bool'>
+								<value>true</value>
+							</CanOnlyBeSubstepType>
+							<Category classname='Str'>
+								<value>""</value>
+							</Category>
+							<ItemName classname='ExprValue'>
+								<value>ResStr("NI_STEPTYPES", "POST_SUBSTEP_MENU_ITEM_NAME")</value>
+							</ItemName>
+							<SingularItemName classname='Str'>
+								<value>""</value>
+							</SingularItemName>
+							<SeparatorBeforeCategory classname='Bool'>
+								<value>false</value>
+							</SeparatorBeforeCategory>
+							<SeparatorBeforeItemName classname='Bool'>
+								<value>false</value>
+							</SeparatorBeforeItemName>
+							<Group classname='Str'>
+								<value>ExecSubsteps</value>
+							</Group>
+						</subprops>
+					</Menu>
+					<Substeps typename='StepTypeSubstepsArray' xsi:type='StepTypeSubstepsArray' classname='Objs'>
+						<value lbound='[0]' ubound='[]'/>
+					</Substeps>
+					<CodeTemplates classname='Str' valueflags='4194328' structureflags='524288'>
+						<value>DefaultLabVIEWNXG|DefaultLabVIEW|DefaultCVI|DefaultVB.NET|DefaultCSharp.NET|DefaultC++.NET|DefaultVC++_Template|DefaultHTB72_Template|DefaultHTB80_Template|Default_Template</value>
+					</CodeTemplates>
+					<AdditionalResultsHints classname='Objs' valueflags='4194328' structureflags='524288'>
+						<value lbound='[0]' ubound='[]'>
+							<elemproto>
+								<_NAME_IN_ATTRIBUTE_ typename='NI_CustomResult' xsi:type='NI_CustomResult' name='' classname='CustomResult'>
+									<subprops>
+										<Name classname='ExprValue'>
+											<value/>
+										</Name>
+										<ValueToLog classname='ExprValue'>
+											<value/>
+										</ValueToLog>
+										<Condition classname='ExprValue'>
+											<value/>
+										</Condition>
+										<Flags classname='Num'>
+											<value>8192</value>
+										</Flags>
+										<CheckedState classname='Num'>
+											<value>2</value>
+										</CheckedState>
+										<Type classname='PropertyObjectType'>
+											<subprops>
+												<ValueType classname='Num'>
+													<value>3</value>
+												</ValueType>
+												<IsObject classname='Bool'>
+													<value>true</value>
+												</IsObject>
+												<TypeName classname='Str'>
+													<value/>
+												</TypeName>
+												<ElementType classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</ElementType>
+												<ArrayDimensions classname='ArrayDimensions'>
+													<subprops>
+														<LowerBounds classname='Nums'>
+															<value lbound='[0]' ubound='[]'/>
+														</LowerBounds>
+														<UpperBounds classname='Nums'>
+															<value lbound='[0]' ubound='[]'/>
+														</UpperBounds>
+													</subprops>
+												</ArrayDimensions>
+												<Representation classname='Num'>
+													<value>1</value>
+												</Representation>
+												<ClassName classname='Str'>
+													<value/>
+												</ClassName>
+											</subprops>
+										</Type>
+										<Elements classname='Objs'>
+											<value lbound='[0]' ubound='[]'/>
+										</Elements>
+										<IsAnyType classname='Bool'>
+											<value>true</value>
+										</IsAnyType>
+									</subprops>
+								</_NAME_IN_ATTRIBUTE_>
+							</elemproto>
+						</value>
+					</AdditionalResultsHints>
+					<TS typename='TEInf' xsi:type='TEInf' classname='Obj' flagsforinstances='4456472'>
+						<subprops>
+							<Id classname='Str'>
+								<value/>
+							</Id>
+							<Icon classname='Str'>
+								<value/>
+							</Icon>
+							<SData classname='Obj' flagsforinstances='2097152' instanceoverrideflags='7274521' structureflags='2097152'/>
+							<PreCond classname='ExprValue'>
+								<value/>
+							</PreCond>
+							<LoadOpt classname='Str'>
+								<value>PreloadWhenExecuted</value>
+							</LoadOpt>
+							<UnloadOpt classname='Str'>
+								<value>UnloadWithFile</value>
+							</UnloadOpt>
+							<Mode classname='Str'>
+								<value>Normal</value>
+							</Mode>
+							<WindowActivation classname='Str'>
+								<value>None</value>
+							</WindowActivation>
+							<ResultOption classname='Num'>
+								<value>1</value>
+							</ResultOption>
+							<StepFCSeqF classname='Bool'>
+								<value>true</value>
+							</StepFCSeqF>
+							<IgnoreRTE classname='Bool'>
+								<value>false</value>
+							</IgnoreRTE>
+							<UseMutex classname='Bool'>
+								<value>false</value>
+							</UseMutex>
+							<MutexNameOrRef classname='ExprValue'>
+								<value/>
+							</MutexNameOrRef>
+							<BatchSyncOpt classname='Num'>
+								<value>0</value>
+							</BatchSyncOpt>
+							<SwitchEnabled classname='Bool'>
+								<value>false</value>
+							</SwitchEnabled>
+							<VirtualDeviceName classname='ExprValue'>
+								<value/>
+							</VirtualDeviceName>
+							<SwitchOperation classname='Num'>
+								<value>1</value>
+							</SwitchOperation>
+							<RouteGroupConnect classname='ExprValue'>
+								<value/>
+							</RouteGroupConnect>
+							<RouteGroupDisconnect classname='ExprValue'>
+								<value/>
+							</RouteGroupDisconnect>
+							<MulticonnectMode classname='Num'>
+								<value>1</value>
+							</MulticonnectMode>
+							<OperationOrder classname='Num'>
+								<value>2</value>
+							</OperationOrder>
+							<ConnectionLifetime classname='Num'>
+								<value>4</value>
+							</ConnectionLifetime>
+							<WaitForDebounce classname='Bool'>
+								<value>true</value>
+							</WaitForDebounce>
+							<PassAct classname='Str'>
+								<value>Next</value>
+							</PassAct>
+							<FailAct classname='Str'>
+								<value>Next</value>
+							</FailAct>
+							<PassActTarget classname='ExprValue'>
+								<value/>
+							</PassActTarget>
+							<FailActTarget classname='ExprValue'>
+								<value/>
+							</FailActTarget>
+							<CustExpr classname='ExprValue'>
+								<value/>
+							</CustExpr>
+							<CustTrueAct classname='Str'>
+								<value>Next</value>
+							</CustTrueAct>
+							<CustFalseAct classname='Str'>
+								<value>Next</value>
+							</CustFalseAct>
+							<CustTrueActTarget classname='ExprValue'>
+								<value/>
+							</CustTrueActTarget>
+							<CustFalseActTarget classname='ExprValue'>
+								<value/>
+							</CustFalseActTarget>
+							<LoopType classname='Str'>
+								<value>NoLooping</value>
+							</LoopType>
+							<LoopWhile classname='ExprValue'>
+								<value/>
+							</LoopWhile>
+							<LoopStatus classname='ExprValue'>
+								<value/>
+							</LoopStatus>
+							<LoopIncrement classname='ExprValue'>
+								<value>RunState.LoopIndex += 1</value>
+							</LoopIncrement>
+							<LoopInitialize classname='ExprValue'>
+								<value>RunState.LoopIndex = 0</value>
+							</LoopInitialize>
+							<LoopOpt classname='Num'>
+								<value>0</value>
+							</LoopOpt>
+							<PreExpr classname='ExprValue'>
+								<value/>
+							</PreExpr>
+							<PostExpr classname='ExprValue'>
+								<value/>
+							</PostExpr>
+							<StatusExpr classname='ExprValue'>
+								<value/>
+							</StatusExpr>
+							<CanSpecifyModule classname='Bool'>
+								<value>true</value>
+							</CanSpecifyModule>
+							<CanEditCode classname='Bool'>
+								<value>true</value>
+							</CanEditCode>
+							<CanEditModulePrototype classname='Bool'>
+								<value>true</value>
+							</CanEditModulePrototype>
+							<CanEditParameterAdditionalResults classname='Bool'>
+								<value>true</value>
+							</CanEditParameterAdditionalResults>
+							<PrecondIntExe classname='Num'>
+								<value>0</value>
+							</PrecondIntExe>
+							<Requirements classname='Obj' flagsforinstances='1' valueflags='1' structureflags='2097152'>
+								<subprops>
+									<Links classname='Strs' flagsforinstances='71303168' instanceoverrideflags='72286233' valueflags='71303168'>
+										<value lbound='[0]' ubound='[]'/>
+									</Links>
+								</subprops>
+							</Requirements>
+							<CustomResults classname='Objs'>
+								<value lbound='[0]' ubound='[]'>
+									<elemproto>
+										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+											<subprops>
+												<Name classname='ExprValue'>
+													<value/>
+												</Name>
+												<ValueToLog classname='ExprValue'>
+													<value/>
+												</ValueToLog>
+												<Condition classname='ExprValue'>
+													<value/>
+												</Condition>
+												<Flags classname='Num'>
+													<value>8192</value>
+												</Flags>
+												<CheckedState classname='Num'>
+													<value>2</value>
+												</CheckedState>
+												<Type classname='PropertyObjectType'>
+													<subprops>
+														<ValueType classname='Num'>
+															<value>3</value>
+														</ValueType>
+														<IsObject classname='Bool'>
+															<value>true</value>
+														</IsObject>
+														<TypeName classname='Str'>
+															<value/>
+														</TypeName>
+														<ElementType classname='Objs'>
+															<value lbound='[0]' ubound='[]'/>
+														</ElementType>
+														<ArrayDimensions classname='ArrayDimensions'>
+															<subprops>
+																<LowerBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</LowerBounds>
+																<UpperBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</UpperBounds>
+															</subprops>
+														</ArrayDimensions>
+														<Representation classname='Num'>
+															<value>1</value>
+														</Representation>
+														<ClassName classname='Str'>
+															<value/>
+														</ClassName>
+													</subprops>
+												</Type>
+												<Elements classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</Elements>
+												<IsAnyType classname='Bool'>
+													<value>true</value>
+												</IsAnyType>
+											</subprops>
+										</_NAME_IN_ATTRIBUTE_>
+									</elemproto>
+								</value>
+							</CustomResults>
+							<AdditionalResultsHints classname='Objs'>
+								<value lbound='[0]' ubound='[]'>
+									<elemproto>
+										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+											<subprops>
+												<Name classname='ExprValue'>
+													<value/>
+												</Name>
+												<ValueToLog classname='ExprValue'>
+													<value/>
+												</ValueToLog>
+												<Condition classname='ExprValue'>
+													<value/>
+												</Condition>
+												<Flags classname='Num'>
+													<value>8192</value>
+												</Flags>
+												<CheckedState classname='Num'>
+													<value>2</value>
+												</CheckedState>
+												<Type classname='PropertyObjectType'>
+													<subprops>
+														<ValueType classname='Num'>
+															<value>3</value>
+														</ValueType>
+														<IsObject classname='Bool'>
+															<value>true</value>
+														</IsObject>
+														<TypeName classname='Str'>
+															<value/>
+														</TypeName>
+														<ElementType classname='Objs'>
+															<value lbound='[0]' ubound='[]'/>
+														</ElementType>
+														<ArrayDimensions classname='ArrayDimensions'>
+															<subprops>
+																<LowerBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</LowerBounds>
+																<UpperBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</UpperBounds>
+															</subprops>
+														</ArrayDimensions>
+														<Representation classname='Num'>
+															<value>1</value>
+														</Representation>
+														<ClassName classname='Str'>
+															<value/>
+														</ClassName>
+													</subprops>
+												</Type>
+												<Elements classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</Elements>
+												<IsAnyType classname='Bool'>
+													<value>true</value>
+												</IsAnyType>
+											</subprops>
+										</_NAME_IN_ATTRIBUTE_>
+									</elemproto>
+								</value>
+							</AdditionalResultsHints>
+						</subprops>
+					</TS>
+					<NI_Data typename='StepTypeNIData' xsi:type='StepTypeNIData' classname='Obj'>
+						<subprops>
+							<EditPanels classname='Strs'>
+								<value lbound='[0]' ubound='[]'/>
+							</EditPanels>
+						</subprops>
+					</NI_Data>
+					<Result classname='Obj' flagsforinstances='4194304' valueflags='4194304'>
+						<subprops>
+							<Error typename='Error' xsi:type='Error' classname='Obj' flagsforinstances='4194304' valueflags='4194304'>
+								<subprops>
+									<Code classname='Num'>
+										<value>0</value>
+									</Code>
+									<Msg classname='Str'>
+										<value/>
+									</Msg>
+									<Occurred classname='Bool'>
+										<value>false</value>
+									</Occurred>
+								</subprops>
+							</Error>
+							<Status classname='Str' flagsforinstances='4194304' valueflags='4194304'>
+								<value/>
+							</Status>
+							<ReportText classname='Str' flagsforinstances='4194304' valueflags='4194304'>
+								<value/>
+							</ReportText>
+							<Common typename='CommonResults' xsi:type='CommonResults' classname='Obj'/>
+						</subprops>
+					</Result>
+					<CanEncapsulate classname='Bool' valueflags='4194328' structureflags='524288'>
+						<value>false</value>
+					</CanEncapsulate>
+				</subprops>
+			</PostSubstep>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='18'>
+			<NoneStepAdditions classname='NoneModule' isroottypedef='true' typecategory='3' timestamp='1650060850' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'/>
+		</typedef>
+		<protected>E@=3DJC4100hYLECF=_K@0@mKCYo_1KN:&lt;Ta239hF9[gHbEVFDfRINZfQ01CkaUMk5=k`[c;[42MMF9aiNliecVfMFCLXi_`f2H7c\G\X50M=Z4S4aT2QI&gt;A^D:d1\PCI`L11RlV5bM5AIZTc9STI5Mkg&lt;bHlle[O=CL_KEgb?8RiVHS7QmPY@S4X^7I58A@kPaKcPWCOC1;DBf61lViY=]`28BC\B_mEf20ZJS@W@GDDRffLe\Ci;aKbN&gt;i5P_4ScVVBTjIIfn0j8l&lt;e6IcMbZHgCI;n8CRlR7&lt;YcK0@cY[8aDHj=GGkNK;C?KC?b=]mMejoc1gGol1&gt;hL6lf5fZ92?Ia@l1;QL024f^NSm2MhNlcFg_YR[l5kclo:einXehbR&gt;98[4?GC:CX[3hm\UMob2aIMT0eJmgI@\;njRK9]fIl_8f=d]n4bQcRXDEl&lt;o=@Yiik\3Md@?k1=0Joj&gt;?Je`&lt;RUd&lt;JYmeOnOgB3G@Ub\FoGFgIQmQli8nGH=QjKD9i`2nf41XEKj;oDB8iZU`@XP^KWoAKEbOf:ViVAl=_I37KJSec7Ea\nJ5]NZj\OnJF;ASQemRIDbbdglb\U&gt;H[O^bDHO?XMLaOoeVCf=a^CC`d8^TX2B</protected>
+		<protected>E@=3@J\4110h]L]Mg[cK3fBoj\Kifo1C[KY_3VgFm3_6n&gt;DfdTDgjaSF_LdVUJaY::FII@T:GB9LaYOo80OP^053LBBVb1G?:50k4;P1c\^`03ffoj9S72=AOm;a2oh?Na\lC7TUOXcNfaSdfIbVCC_ao20aN9bmo_&lt;R_S=&gt;KV;lhbmh89SY[:2UflXcmGIlnngoE]\\ad_6_gW8X9GAXJSPJYin&gt;C71=c74a79JN&lt;`GPK]_\&gt;2`h9IOC]VA5BU4AMW1Qc`j?lJ\aR4__&gt;R4SI_`[_mmnM33ONg`3P[g4N5aSF;ce]^eVffg6&gt;cIRLhI]7CjE^W[jW`kZkGEWHk1=RR;gTe:O[H;k[bAd7UCaTVXgjlho3Af&gt;?oIJdjMo&gt;3=o;aTo\ZZnG9_cgcO7mjV^k&gt;\:gkoOkSn1jkfm@MgLnb&lt;Amg;\Nmj8klk3llhhnW&gt;nn^GCW_fW_&gt;ji]:Va&gt;TNnNQdK5LolNX?M@\6jN2ddlIHh=MT1E^[o4Q7I54R=RlVg[S\KmOe9GM:Qeh9OnUhWTeC^ZM7SAGP1V=LZ4[i\cOmoH[RS6YBL2L\PAg][JQ&lt;Eo?8;D9Mk3M]&gt;N^6&gt;HgJ]KP^a&gt;cfBkkmZ33RdU`]jB_NIOShWL4oDlbn3lNOCL??R7GCmKaTDhekoi_En`9oJKe&lt;e1`lBjmjXJ&lt;^4_^_^&gt;?7O?nEE_WTY:VYEc]3^eJm^cdC7;LcK_]Ei&gt;b&lt;^`9HR6YcO&gt;l@Amg&gt;PLXQbSb^=?FXRUZd&lt;[n&lt;SGjgCQ`mhTl;7NUbgaRQBkXNY4iX5iAJX6C`gdG[d3d&gt;`Uj3DPMF7h71WBBLLR&gt;Tk9dZlFCYSi__fNBBT`C;A&gt;jeP2CdONN52i5^eBEIEI=8EMHBBe^G^1ohD6&gt;LRiJgM\IPYE8Wn`T9W@jf8iEfN:@L3&lt;Ha_l0CCE&lt;HOJjXBRll_NLReo_^K7CQWihL&lt;B1::YXdSaG&lt;XFnCP94dQXb;^6V07F&gt;TkPem&gt;4QI;?9JkF`g80:`G?AULFSY^XW;4XL^_D=GZV9VVODS^[=]dL]b=N;O[ib6]2aLATM7\AcX=JH&lt;\1j8_?I9_VUO]5;PKjdi^o&gt;Kn=FbmhAmF3EXh?dAPF?cWPU;NHFT9YBblF15fj0n]RK9&gt;d;@lD9HXLGTZOAa;gEd6:MElAPOkOoMom`hnaYko^ne_;PeC\`kMYOoCalP3DR_^NADNSV6R1Nk4f?=Lo;VQ&gt;7&gt;fR@=2j8C:;D@3fk&gt;^=YHE^PQ1fU&gt;TFoNH&gt;GnfRGNMNW`[okK`S56RJfM4Zmo^6E9ZYc&gt;FNEO3PO=T9eK0:bgljYdR7WooKS9eTjd@bcImNVZ8UXa:AC_F_WCj]4\6ST&lt;:ie_AbZFIL7UmlIne:BcTQ5T2U]O2goYWXRN5F8oeQT^`HXPD=2LV[h;ibbNNj1kU]lXlnX4ACO5aRA@TfHY77@P?L=_N@4^cJG;Wi2@3M5OQ:^@&gt;2K9_9W:4Vn1LGaRN@WL9AFFVg1oYHdi`54XIa5G[\i&gt;iPT4506XA7h2^c_T`3d[ARdFICaAS2RM:1KgT7B&gt;MhXVaI&lt;kA^@CX2aS^I:B&gt;=W&lt;U?l&lt;DWU&lt;Jd7^cKe2R]EdIBcBQZni_K1JPCEhV&gt;VH]FBZ&lt;5413k[U]MAFA`Ohma2g2NoU0@E;FI93Yi;RjnlScC;`glEaH^X@K[NY9Y1EUZc6V6\3?FKC0APU0^[aP:_GMI=eeWnJ&lt;6e2]@;AXaAE&lt;S[lhAb`XFjPP@dTXNYS=&lt;568je\`W3?@gn9HDaM84^&gt;SDl0&lt;Ba6YNKCeYZ\CUU?WGnR4=m^aN[KTlFG\?VZ[MC:3HfflAagl\jZUG@ScZW:2K\FU9TQa&lt;h;?iYb&lt;RJI66IEg&lt;WHgdkU:\KFIZG\BDU=9W&gt;:\:W7nM3NIjXT;2YV[@dDaY3bhOQY^af&lt;UVo:ZV^^@0d_M5ObRQ2PIHZ9bbbGm;4Z\KEfEYI=M];D@9j1kZ@2@FIkf9:\CYe5KnKANXH7R@eMc2M;Pl]PZG]@4h2Q7OY:=QFh@\Y6]E6X1bL6mjS76a`JS=H=XQReG6Djb7[c&lt;h@S5UCX4`ABLQ4:ZZ7=JF9JejC5\[T:meE5_[:`Qm=DfI0EDQLRH6o]LAPRXlbTgXSbnW7ZTN?N]lH02JKm;Z4hn&lt;A[89:C8lM5hC]Ab^\\WNK7JGS]XainLm:PWFF3EmC15\]YC\D;I6a&lt;NiIhd2GMIG`A9\[]T00fP:UXIXSHk2jI&gt;XFG&gt;I521bbKDA`Xb]h&gt;oAl&gt;IolbRB7j=i9_H89&lt;FR=U572U\LjNhnkeeemHDJJ\GHX\;J51M&lt;?QV2DneREAR3in6&lt;M75M_Re=Ci3gEOQ2VO`4P8_hfhSO\dZ7m]n\hlV6gSlSC@PoZSe8WUaY3d0_;Z=9H:I6Gf2PVG`mf8CC87@DBlT62^h6QFFhZF64BJ46@Dh&lt;T1=C]0_9J?073S@61ADIUT31&lt;mVE&lt;W?R@RBUJP`@;50X2Bh618KM^bf033T033D?NM@P`?0\dBA3A8AXF0]@KnP[5&lt;EDfUICcBF^EZT=:cWKBKYTDKXD=&lt;A:mkNB7LFDHC9b7nG57NFZ1]Ubo]8]0MN]YWJJ&gt;eS42I?===3_n_?J=384=Go8e^0mdmBiTjRaf;F@8M4_gCZSGQ3cUUnF6J_R9WJV0PNaTJDk&lt;RiWS6=&gt;Rf9EmM:WgL4LHg5oH[aMbbOlnI6b`9KZ^Z]oAdeH\@YgaV8ChHTKjEVA]a^YN&lt;;71CAbR\&lt;jAYI\\Y&lt;R\`1AOol`j1&gt;53?d8MV_@kAN_W4nIdKc0gRYHEo`]U?HWN?0&lt;?l2h:ZC\&gt;^D]Ug4FNZl123fNoZ7fLRB[_HR6O&gt;BaoomWl_8YS0Q\8;RB]@j=GIIe]J&lt;AT[;1I&lt;5ZJ\?Va5g?&gt;7hXgcbU4V=lT&gt;nV[28JKeQJ5QX4^WD3MfTBIBPKU57e&gt;[FRd&gt;_EeSHJhDa4hM9S9TUlOR=KWn]eAJ]W5VROh9ak`n5&lt;LV6L9d&lt;0`?fk]J8FW52OlL2i&lt;L1kO=mGBf9e:\`^[_J:F&gt;7o0_9mGc_`=KP@SW_^NU525JcQcEGhR8Da3gf4mJ?R6a2lLPKjL:TlfL8iHOKf:Mjeb\&gt;Xb3&gt;0kM@iNkaifYHDFNIKP\e^;bhg@V&lt;g0Za7F]R=JKPMgdg&gt;nYaMSb8MAV0o05XKjM5&lt;5^V=albT\&lt;868hhl^jHPRa0KcT4i[31chfOeGW&gt;;``&gt;&gt;I;B:YafYW&gt;jW_7D1&gt;9_X14U9VXJ5E_PA2ZPb&gt;n6eBLcN]SU4eSd&lt;IDGD4D5WHMlFCU0DeARScb:h\?EC1&gt;IBWead&gt;7F&gt;FeBea\oCS]jf@kE47ZHcB?TlP6_K[QC2@_N&gt;ilNn0VdgZE&gt;Z98hXCHa4bNUM16M74Q;DhldmcZ&gt;V?_TG1J?NI:F8&lt;aomhdPX5^AEe6BRYle4clf_gSb6D9LaD2h]ij8SAH@[`J@cb2G7ee@iZWl2A&gt;`Ga95FDhJo7Xo&gt;Zd3[jL&lt;DQ4OILX9a;0T\SUDWY:Bh&gt;WGNb:dHQ[S`[8:1L:F@&gt;H[49RQ6_3QV&lt;UT0oIITF^H_\X=:&lt;42`N``YjM75HWEd]5O`&lt;EX89FTP`^oN:QHgED5k:\CaYbA2GbD1;X5:N;?SoLhVhR`R_9lg3hU4n:I`2Gn:IjDHED]5i=2fcTklTK1H6k4HjK;HBM&gt;;c]9;i[MFD?WaY1O]oS293kLd9S3N6He?:_QKEcBGLOc:jB6H@fR]h]HGB5;:&lt;RE&lt;`3K4Ibi29dR;nU&lt;&lt;TKBRnTdK[ZTT6oiOVVXKgaP6&lt;lMTO_JC\0&lt;RY5NkR352&lt;FbcCB&lt;_3?0XjQ`BJP;OJR::8eHFb3&lt;;M\9FOC8T:MkD:Z;C=eb^0:AMSbSY_^Lc=SGbD5WDh@6j]PCDc@;\X1Nb\[`Z0W_Th5&lt;HD4CafYghb`T95Ko571]SZJDHF2eE&lt;7jViL_\8TQ@dFRo]`G[h3&gt;862l:2F[UU6dVbFjU?NI&gt;OHOk&gt;JNcFNU[mXi]iJ[neWQ\mWa]i[e?IkO^Mf]LHTP[G3?43M8g^Wh``lW3kBT7ADM6b_IUCIPO=C8g5@?9R3&lt;hilXNY7_&lt;THNN&lt;KMLm;eGM6_A6AUDB\c5Q;S2POniP9[mdEeIDnO7;T7Nia2nFN\L2XZIP?ZJKW\2cK0U5fb[dLn?[C&gt;YAMXfVFic02OQA\6LHEk0oBd0f;`kR1hImAUl:@I;^:oFJUF?mDgPlLokm]OIgenn9;n5[Oh3g7@W7OWBCk9X1mYDPF9AQ4LOGeM_D_WR?I7QRlVEmN_0QlA9^lO[HjnfngGjkHokO\A35=_4hVU^jKm;\?Y9^B=RkTG1I&lt;6nI`AQ_kJ;of[GmIi[g0]1\UG_FKUnX]ZcGmoI;NUdDFOolHn;NbMLkT`1GEo;j63N_8b_O`PQ[KRjb&lt;NDHW4;\lT[Ila;nMd`56_c\C25fJLUS;9fn@6[[SMIBBMFK\8d;ZIRSI;fJ5_cojWSIfcY2kNd1jkS0f9A3BNfk8W1m4H0gRbfA3J6Q726nmNm4PQYcWZ___NEf_FmmmOm40IZ1mf4PmS?H8k&gt;=J3g&lt;\1K6j;CNTGZ8kY61mk30RLUO`T`_H`Hg&lt;`\K67=HJ3g&lt;\3K6iGRVO9``_1H`L`\K6`f=371ikY61mf30S&lt;W]K86enT`_H`Hg&lt;=fbaLQO`c@&lt;hK;Rmmf&gt;KT=]4\mm;NkW]^mcFgV[_]l=8aHk_j]MgIEYV5XJkiW]l^^CKnYn2OgNJ0g&lt;fR\mWo;?JNcFN^cfL_eWZ[Eff[LeWebL[d?YfWFm3O0neW6m3NP3nGQ@G_M?lS61c3KG?`NUXHYTJ?j1SoC7V&gt;RGj_]d[blRO_M^Qg&gt;f_[0oQJWgg`CkhXXJ\hG;1Ujg`4MNjIg_6l3GG;oohYSNBallm3eZnFmebBeaLSDIS17WJfDBN9nUo^n2oC_;Q\;4O3WWk7mAZI17;2]ChHfZeJ;I\fY;^dB\J;NW@cEDj]HE]B8GSiKJgN9M6f4UIKhV02kFjYnXXBH9lF?3gDC&lt;EC`d=4l&lt;aIYa?]YS&lt;9Zl8]AkXcPg:6L69WWX^8R2;YXfC&lt;Xg6AQg@oOoChH=41ln]AG?J3U0Wn&gt;8[8cdWGUnL2Z&gt;Ll4HaNcI&lt;f]SiWCVXSMeP?^a7:Tf&lt;`L3cKdmDl7?Uj&gt;FnPG5NSQBkHE`Yj&gt;ZNQ^;UbDk0kCT]3]YV&lt;50o&lt;2&lt;aTY7THb5hg;3^hl@GYRZE@mbL?5gdHJNW5`6W8[eho^38?;R459L4WN1Jg[egNX[3[_&gt;lAAY&gt;L9Z_H5YN]9:KZMj\cPGZco]??=ig[hH7YShgPS8:44leI:@9R?fLHKlH6UZ]nlAXHFAFUn7AdT=;FK^oZgocoK[2W_=Aj]T;2mBd8`7h`B0K&gt;IP&lt;04@S6]dA9N`8Q8YBk19T@8RFF4T29OB1V7TX7QM01@hI@3`QJ=4@H\nBkS2d5P1BDgN8?4B230Y8lb8ONC@?IPH0A@OMPD?HZ@1`&gt;mj`5N5c60PN06hNI1c8`@k6b0M9IN3`QM68;M1l5Bl&gt;6cX&gt;XD78V@S2j5Ad;C&lt;0cA7OX0nM8&lt;iaN3K0@0Kil664BNSOe:0@R=6NA66f9@PX0d0dHb:LL\6@1aSJl[5h6I38X&lt;0`;0&lt;Al748MXb84H=@Y&lt;lI\5@GNMD;RJd?DeY0Ac1J230g&gt;d1e00LP8d;&gt;V@59CQA1BG&lt;@2[2A45hE8CX:H0A=a\KRAC&lt;Q0YPRb5D&lt;IR63P1QX&lt;JXCS9a3FQ&gt;daQVRjO4I;1da1URZ;LZ444@R2PX2XAXA9Te@FngkoKI_ea&gt;NZN^m\`1H5CMhX9Bn1?ZYS0WAbR2RD8F3W@XajF1=AXS6&lt;TS4i09PN?`gPUG9G3J26`2GbAW]jGY5&lt;AGn^iZAjM_;W5&lt;g^kKMC]B[X13GZm3mmNffKMhb:cJ]DAT&gt;a?_4H8jZX2PIja6[DFTFC:]l]=1AN=PD`VJ&gt;HX2k?Pj7:bQ`W[XWe0\38&lt;V=I\:]2HOl74S6e0a;ZmCFf:3FnRcED67[hUWZPU7ZZKLUVD\PFX_FVE23Q7WUaWV=U&gt;&lt;ZRLQB8LDd0hS94OC1D?6J9N:\\`US2k:iaJY8jY]eTVWO0KLeICMh3dn\dH86aYA7eY]eZZ3=d6WJLE7IPEWIe=_c4FYLEhdA\b5XoJQE;n[HFdKI7C3oK`RFK6l`B8RhhCXhP8XnP3841548PB6P6B[DKHS41JU&lt;Qne:U\ARQ=B[VDHSOT307XA07Qhn2d8RBoajKU&gt;9P@S2lYle3RId0IIf072nP8&gt;;NUah=0ilGD:G5\RN_\=;5jTD@iTfQNGIfmQJ2oJl[SBFC]DLncWBE4mFZe6d_Ob&gt;3YC4APEA@D_mOFNI8ALek79bT&gt;:a8]EjYToY&lt;]8C`FV4Z``X`1aB@L&lt;?V9ARCQ4c:K71jA4o8X@_N2@;?hf9D0M0]D;:A]?]T5@Y1`&gt;Vi=L5H`I25YCYJTF@F?fd@VbI9Pf6?dDZY8JdAcR`QM5&gt;MT&lt;aOnO7&lt;DiRiB;\k?RRIHVCkC&lt;FWi=5fXF\he2n@Q&gt;2TEkZIo6kBK3\C@]3\oE]=7UY8knVi7O5=^_a6d;G^?DaLI=YY]ARAc7NRDMhAYZlK90=KQlem6G@;;lecBDFecfKNA=H&gt;mJl3I59=NFgn`nf[B1:05f5E[`fiTPQ4EDe1H=4ZRWkf3TWlOP&gt;Ela5hZDn]cQJC=UBXIIJdWiR@KZe]DHRbmfI;]VYoi&gt;o?3K1h=6</protected>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='21'>
+			<Action classname='StepType' isroottypedef='true' typecategory='1' timestamp='1618215606' typeversion='21.0.0.2' typelastmodversion='21.0.0.0' typeminprodversion='21.0.0.0' typeflags='33554446'>
+				<subprops>
+					<Substeps typename='StepTypeSubstepsArray' xsi:type='StepTypeSubstepsArray' classname='Objs' flagsforinstances='524312' instanceoverrideflags='655384'>
+						<value lbound='[0]' ubound='[]'/>
+					</Substeps>
+					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
+						<value>ResStr("NI_STEPTYPES", "ACTION_DESCRIPTION_NAME") + (("%ModuleDescription" == "") ? "" : ",  %ModuleDescription")</value>
+					</DescriptionFormat>
+					<DefaultNameFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
+						<value>ResStr("NI_STEPTYPES", "ACTION_DEF_STEP_NAME")</value>
+					</DefaultNameFormat>
+					<Menu typename='StepTypeMenu' xsi:type='StepTypeMenu' classname='Obj' flagsforinstances='524312' instanceoverrideflags='524312'>
+						<subprops>
+							<CanBeSubstepType classname='Bool'>
+								<value>false</value>
+							</CanBeSubstepType>
+							<CanOnlyBeSubstepType classname='Bool'>
+								<value>false</value>
+							</CanOnlyBeSubstepType>
+							<Category classname='Str'>
+								<value>""</value>
+							</Category>
+							<ItemName classname='ExprValue'>
+								<value>ResStr("NI_STEPTYPES", "ACTION_MENU_ITEM_NAME")</value>
+							</ItemName>
+							<SingularItemName classname='Str'>
+								<value>""</value>
+							</SingularItemName>
+							<SeparatorBeforeCategory classname='Bool'>
+								<value>false</value>
+							</SeparatorBeforeCategory>
+							<SeparatorBeforeItemName classname='Bool'>
+								<value>false</value>
+							</SeparatorBeforeItemName>
+							<Group classname='Str'>
+								<value>Action</value>
+							</Group>
+						</subprops>
+					</Menu>
+					<AdditionalResultsHints classname='Objs' valueflags='4194328' structureflags='524288'>
+						<value lbound='[0]' ubound='[]'>
+							<elemproto>
+								<_NAME_IN_ATTRIBUTE_ typename='NI_CustomResult' xsi:type='NI_CustomResult' name='' classname='CustomResult'>
+									<subprops>
+										<Name classname='ExprValue'>
+											<value/>
+										</Name>
+										<ValueToLog classname='ExprValue'>
+											<value/>
+										</ValueToLog>
+										<Condition classname='ExprValue'>
+											<value/>
+										</Condition>
+										<Flags classname='Num'>
+											<value>8192</value>
+										</Flags>
+										<CheckedState classname='Num'>
+											<value>2</value>
+										</CheckedState>
+										<Type classname='PropertyObjectType'>
+											<subprops>
+												<ValueType classname='Num'>
+													<value>3</value>
+												</ValueType>
+												<IsObject classname='Bool'>
+													<value>true</value>
+												</IsObject>
+												<TypeName classname='Str'>
+													<value/>
+												</TypeName>
+												<ElementType classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</ElementType>
+												<ArrayDimensions classname='ArrayDimensions'>
+													<subprops>
+														<LowerBounds classname='Nums'>
+															<value lbound='[0]' ubound='[]'/>
+														</LowerBounds>
+														<UpperBounds classname='Nums'>
+															<value lbound='[0]' ubound='[]'/>
+														</UpperBounds>
+													</subprops>
+												</ArrayDimensions>
+												<Representation classname='Num'>
+													<value>1</value>
+												</Representation>
+												<ClassName classname='Str'>
+													<value/>
+												</ClassName>
+											</subprops>
+										</Type>
+										<Elements classname='Objs'>
+											<value lbound='[0]' ubound='[]'/>
+										</Elements>
+										<IsAnyType classname='Bool'>
+											<value>true</value>
+										</IsAnyType>
+									</subprops>
+								</_NAME_IN_ATTRIBUTE_>
+							</elemproto>
+						</value>
+					</AdditionalResultsHints>
+					<TS typename='TEInf' xsi:type='TEInf' classname='Obj' flagsforinstances='262168' instanceoverrideflags='4456472'>
+						<subprops>
+							<Id classname='Str'>
+								<value/>
+							</Id>
+							<Icon classname='Str'>
+								<value/>
+							</Icon>
+							<SData classname='Obj' flagsforinstances='2097152' instanceoverrideflags='7143448' structureflags='2097152'/>
+							<PreCond classname='ExprValue'>
+								<value/>
+							</PreCond>
+							<LoadOpt classname='Str'>
+								<value>PreloadWhenExecuted</value>
+							</LoadOpt>
+							<UnloadOpt classname='Str'>
+								<value>UnloadWithFile</value>
+							</UnloadOpt>
+							<Mode classname='Str'>
+								<value>Normal</value>
+							</Mode>
+							<WindowActivation classname='Str'>
+								<value>None</value>
+							</WindowActivation>
+							<ResultOption classname='Num'>
+								<value>1</value>
+							</ResultOption>
+							<StepFCSeqF classname='Bool'>
+								<value>true</value>
+							</StepFCSeqF>
+							<IgnoreRTE classname='Bool'>
+								<value>false</value>
+							</IgnoreRTE>
+							<UseMutex classname='Bool'>
+								<value>false</value>
+							</UseMutex>
+							<MutexNameOrRef classname='ExprValue'>
+								<value/>
+							</MutexNameOrRef>
+							<BatchSyncOpt classname='Num'>
+								<value>0</value>
+							</BatchSyncOpt>
+							<SwitchEnabled classname='Bool'>
+								<value>false</value>
+							</SwitchEnabled>
+							<VirtualDeviceName classname='ExprValue'>
+								<value/>
+							</VirtualDeviceName>
+							<SwitchOperation classname='Num'>
+								<value>1</value>
+							</SwitchOperation>
+							<RouteGroupConnect classname='ExprValue'>
+								<value/>
+							</RouteGroupConnect>
+							<RouteGroupDisconnect classname='ExprValue'>
+								<value/>
+							</RouteGroupDisconnect>
+							<MulticonnectMode classname='Num'>
+								<value>1</value>
+							</MulticonnectMode>
+							<OperationOrder classname='Num'>
+								<value>2</value>
+							</OperationOrder>
+							<ConnectionLifetime classname='Num'>
+								<value>0</value>
+							</ConnectionLifetime>
+							<WaitForDebounce classname='Bool'>
+								<value>true</value>
+							</WaitForDebounce>
+							<PassAct classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
+								<value>Next</value>
+							</PassAct>
+							<FailAct classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
+								<value>Next</value>
+							</FailAct>
+							<PassActTarget classname='ExprValue' flagsforinstances='1' instanceoverrideflags='5046297'>
+								<value/>
+							</PassActTarget>
+							<FailActTarget classname='ExprValue' flagsforinstances='1' instanceoverrideflags='5046297'>
+								<value/>
+							</FailActTarget>
+							<CustExpr classname='ExprValue'>
+								<value/>
+							</CustExpr>
+							<CustTrueAct classname='Str'>
+								<value>Next</value>
+							</CustTrueAct>
+							<CustFalseAct classname='Str'>
+								<value>Next</value>
+							</CustFalseAct>
+							<CustTrueActTarget classname='ExprValue'>
+								<value/>
+							</CustTrueActTarget>
+							<CustFalseActTarget classname='ExprValue'>
+								<value/>
+							</CustFalseActTarget>
+							<LoopType classname='Str'>
+								<value>NoLooping</value>
+							</LoopType>
+							<LoopWhile classname='ExprValue'>
+								<value/>
+							</LoopWhile>
+							<LoopStatus classname='ExprValue'>
+								<value/>
+							</LoopStatus>
+							<LoopIncrement classname='ExprValue'>
+								<value>RunState.LoopIndex += 1</value>
+							</LoopIncrement>
+							<LoopInitialize classname='ExprValue'>
+								<value>RunState.LoopIndex = 0</value>
+							</LoopInitialize>
+							<LoopOpt classname='Num'>
+								<value>0</value>
+							</LoopOpt>
+							<PreExpr classname='ExprValue'>
+								<value/>
+							</PreExpr>
+							<PostExpr classname='ExprValue'>
+								<value/>
+							</PostExpr>
+							<StatusExpr classname='ExprValue'>
+								<value/>
+							</StatusExpr>
+							<CanSpecifyModule classname='Bool'>
+								<value>true</value>
+							</CanSpecifyModule>
+							<CanEditCode classname='Bool'>
+								<value>true</value>
+							</CanEditCode>
+							<CanEditModulePrototype classname='Bool'>
+								<value>true</value>
+							</CanEditModulePrototype>
+							<CanEditParameterAdditionalResults classname='Bool'>
+								<value>true</value>
+							</CanEditParameterAdditionalResults>
+							<PrecondIntExe classname='Num'>
+								<value>0</value>
+							</PrecondIntExe>
+							<Requirements classname='Obj' flagsforinstances='1' valueflags='1' structureflags='2097152'>
+								<subprops>
+									<Links classname='Strs' flagsforinstances='71303168' instanceoverrideflags='72286233' valueflags='71303168'>
+										<value lbound='[0]' ubound='[]'/>
+									</Links>
+								</subprops>
+							</Requirements>
+							<CustomResults classname='Objs'>
+								<value lbound='[0]' ubound='[]'>
+									<elemproto>
+										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+											<subprops>
+												<Name classname='ExprValue'>
+													<value/>
+												</Name>
+												<ValueToLog classname='ExprValue'>
+													<value/>
+												</ValueToLog>
+												<Condition classname='ExprValue'>
+													<value/>
+												</Condition>
+												<Flags classname='Num'>
+													<value>8192</value>
+												</Flags>
+												<CheckedState classname='Num'>
+													<value>2</value>
+												</CheckedState>
+												<Type classname='PropertyObjectType'>
+													<subprops>
+														<ValueType classname='Num'>
+															<value>3</value>
+														</ValueType>
+														<IsObject classname='Bool'>
+															<value>true</value>
+														</IsObject>
+														<TypeName classname='Str'>
+															<value/>
+														</TypeName>
+														<ElementType classname='Objs'>
+															<value lbound='[0]' ubound='[]'/>
+														</ElementType>
+														<ArrayDimensions classname='ArrayDimensions'>
+															<subprops>
+																<LowerBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</LowerBounds>
+																<UpperBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</UpperBounds>
+															</subprops>
+														</ArrayDimensions>
+														<Representation classname='Num'>
+															<value>1</value>
+														</Representation>
+														<ClassName classname='Str'>
+															<value/>
+														</ClassName>
+													</subprops>
+												</Type>
+												<Elements classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</Elements>
+												<IsAnyType classname='Bool'>
+													<value>true</value>
+												</IsAnyType>
+											</subprops>
+										</_NAME_IN_ATTRIBUTE_>
+									</elemproto>
+								</value>
+							</CustomResults>
+							<AdditionalResultsHints classname='Objs'>
+								<value lbound='[0]' ubound='[]'>
+									<elemproto>
+										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+											<subprops>
+												<Name classname='ExprValue'>
+													<value/>
+												</Name>
+												<ValueToLog classname='ExprValue'>
+													<value/>
+												</ValueToLog>
+												<Condition classname='ExprValue'>
+													<value/>
+												</Condition>
+												<Flags classname='Num'>
+													<value>8192</value>
+												</Flags>
+												<CheckedState classname='Num'>
+													<value>2</value>
+												</CheckedState>
+												<Type classname='PropertyObjectType'>
+													<subprops>
+														<ValueType classname='Num'>
+															<value>3</value>
+														</ValueType>
+														<IsObject classname='Bool'>
+															<value>true</value>
+														</IsObject>
+														<TypeName classname='Str'>
+															<value/>
+														</TypeName>
+														<ElementType classname='Objs'>
+															<value lbound='[0]' ubound='[]'/>
+														</ElementType>
+														<ArrayDimensions classname='ArrayDimensions'>
+															<subprops>
+																<LowerBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</LowerBounds>
+																<UpperBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</UpperBounds>
+															</subprops>
+														</ArrayDimensions>
+														<Representation classname='Num'>
+															<value>1</value>
+														</Representation>
+														<ClassName classname='Str'>
+															<value/>
+														</ClassName>
+													</subprops>
+												</Type>
+												<Elements classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</Elements>
+												<IsAnyType classname='Bool'>
+													<value>true</value>
+												</IsAnyType>
+											</subprops>
+										</_NAME_IN_ATTRIBUTE_>
+									</elemproto>
+								</value>
+							</AdditionalResultsHints>
+						</subprops>
+					</TS>
+					<NI_Data typename='StepTypeNIData' xsi:type='StepTypeNIData' classname='Obj'>
+						<subprops>
+							<EditPanels classname='Strs'>
+								<value lbound='[0]' ubound='[]'/>
+							</EditPanels>
+						</subprops>
+					</NI_Data>
+					<Result classname='Obj' flagsforinstances='4194304' valueflags='4194304'>
+						<subprops>
+							<Error typename='Error' xsi:type='Error' classname='Obj' flagsforinstances='4194304' instanceoverrideflags='4194304' valueflags='4194304'>
+								<subprops>
+									<Code classname='Num'>
+										<value>0</value>
+									</Code>
+									<Msg classname='Str'>
+										<value/>
+									</Msg>
+									<Occurred classname='Bool'>
+										<value>false</value>
+									</Occurred>
+								</subprops>
+							</Error>
+							<Status classname='Str' flagsforinstances='4194304' valueflags='4194304'>
+								<value/>
+							</Status>
+							<ReportText classname='Str' flagsforinstances='4194304' valueflags='4194304'>
+								<value/>
+							</ReportText>
+							<Common typename='CommonResults' xsi:type='CommonResults' classname='Obj' instanceoverrideflags='4194304'/>
+						</subprops>
+					</Result>
+					<CodeTemplates classname='Str' valueflags='4194328' structureflags='524288'>
+						<value>DefaultLabVIEW|DefaultLabVIEWNXG|DefaultCVI|DefaultVB.NET|DefaultCSharp.NET|DefaultC++.NET|DefaultVC++_Template|DefaultHTB72_Template|DefaultHTB80_Template|Default_Template</value>
+					</CodeTemplates>
+					<BlockStartTypes classname='Str' valueflags='4194328' structureflags='524288'>
+						<value/>
+					</BlockStartTypes>
+					<BlockEndTypes classname='Str' valueflags='4194328' structureflags='524288'>
+						<value/>
+					</BlockEndTypes>
+					<AppliesToBlockStructure classname='Bool' valueflags='4194328' structureflags='524288'>
+						<value>false</value>
+					</AppliesToBlockStructure>
+					<CanEncapsulate classname='Bool' valueflags='4194328' structureflags='524288'>
+						<value>false</value>
+					</CanEncapsulate>
+					<Category classname='Str' valueflags='24' structureflags='524288'>
+						<value>Action</value>
+					</Category>
+				</subprops>
+			</Action>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='29'>
+			<NI_PythonParameterResult classname='PythonParameterResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+				<subprops>
+					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</Condition>
+					<Flags classname='Num'>
+						<value>8192</value>
+						<numericfmt>%#x</numericfmt>
+					</Flags>
+					<CheckedState classname='Num'>
+						<value>1</value>
+					</CheckedState>
+				</subprops>
+			</NI_PythonParameterResult>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='28'>
+			<NI_PythonParameter classname='CPythonParameter' isroottypedef='true' typecategory='3' timestamp='1650060872' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+				<subprops>
+					<Name classname='Str'>
+						<value>_notNamed</value>
+					</Name>
+					<Type classname='Num'>
+						<value>7</value>
+					</Type>
+					<ArgumentValue typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</ArgumentValue>
+					<ArgumentDisplayValue typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</ArgumentDisplayValue>
+					<AdditionalResults classname='Obj'>
+						<subprops>
+							<Input typename='NI_PythonParameterResult' xsi:type='NI_PythonParameterResult' classname='PythonParameterResult'>
+								<subprops>
+									<Condition classname='ExprValue'>
+										<value/>
+									</Condition>
+									<Flags classname='Num'>
+										<value>8192</value>
+									</Flags>
+									<CheckedState classname='Num'>
+										<value>1</value>
+									</CheckedState>
+								</subprops>
+							</Input>
+							<Output typename='NI_PythonParameterResult' xsi:type='NI_PythonParameterResult' classname='PythonParameterResult'>
+								<subprops>
+									<Condition classname='ExprValue'>
+										<value/>
+									</Condition>
+									<Flags classname='Num'>
+										<value>8192</value>
+									</Flags>
+									<CheckedState classname='Num'>
+										<value>1</value>
+									</CheckedState>
+								</subprops>
+							</Output>
+						</subprops>
+					</AdditionalResults>
+				</subprops>
+			</NI_PythonParameter>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='27'>
+			<PythonStepAdditions classname='CPythonModule' isroottypedef='true' typecategory='3' timestamp='1650060872' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+				<subprops>
+					<PythonCall classname='CPythonCall'>
+						<subprops>
+							<UseAdapterSettingsForInterpreterSession classname='Bool'>
+								<value>true</value>
+							</UseAdapterSettingsForInterpreterSession>
+							<InterpreterSessionScope classname='Num'>
+								<value>3</value>
+							</InterpreterSessionScope>
+							<PythonVersion classname='Str'>
+								<value/>
+							</PythonVersion>
+							<PythonVirtualEnvironmentPath classname='Str'>
+								<value/>
+							</PythonVirtualEnvironmentPath>
+							<InterpreterLocation typename='Expression' xsi:type='Expression' classname='ExprValue'>
+								<value/>
+							</InterpreterLocation>
+							<CreateIfInterpreterDoesNotExist classname='Bool'>
+								<value>true</value>
+							</CreateIfInterpreterDoesNotExist>
+							<ModulePath typename='Path' xsi:type='Path' classname='PathValue'>
+								<value/>
+							</ModulePath>
+							<OperationType classname='Num'>
+								<value>1</value>
+							</OperationType>
+							<OperationScope classname='Num'>
+								<value>0</value>
+							</OperationScope>
+							<ClassName classname='Str'>
+								<value/>
+							</ClassName>
+							<ClassInstanceLocation typename='Expression' xsi:type='Expression' classname='ExprValue'>
+								<value/>
+							</ClassInstanceLocation>
+							<FunctionOrAttributeName classname='Str'>
+								<value/>
+							</FunctionOrAttributeName>
+							<Parameters classname='Objs'>
+								<value lbound='[0]' ubound='[0]'>
+									<elemproto>
+										<_NAME_IN_ATTRIBUTE_ typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name='' classname='CPythonParameter' structureflags='131072'>
+											<subprops>
+												<Name classname='Str'>
+													<value>_notNamed</value>
+												</Name>
+												<Type classname='Num'>
+													<value>7</value>
+												</Type>
+												<ArgumentValue classname='ExprValue'>
+													<value/>
+												</ArgumentValue>
+												<ArgumentDisplayValue classname='ExprValue'>
+													<value/>
+												</ArgumentDisplayValue>
+												<AdditionalResults classname='Obj'>
+													<subprops>
+														<Input classname='PythonParameterResult'>
+															<subprops>
+																<Condition classname='ExprValue'>
+																	<value/>
+																</Condition>
+																<Flags classname='Num'>
+																	<value>8192</value>
+																</Flags>
+																<CheckedState classname='Num'>
+																	<value>1</value>
+																</CheckedState>
+															</subprops>
+														</Input>
+														<Output classname='PythonParameterResult'>
+															<subprops>
+																<Condition classname='ExprValue'>
+																	<value/>
+																</Condition>
+																<Flags classname='Num'>
+																	<value>8192</value>
+																</Flags>
+																<CheckedState classname='Num'>
+																	<value>1</value>
+																</CheckedState>
+															</subprops>
+														</Output>
+													</subprops>
+												</AdditionalResults>
+											</subprops>
+										</_NAME_IN_ATTRIBUTE_>
+									</elemproto>
+									<value>
+										<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
+											<subprops>
+												<Name classname='Str'>
+													<value>Return Value</value>
+												</Name>
+												<Type classname='Num'>
+													<value>7</value>
+												</Type>
+												<ArgumentValue classname='ExprValue'>
+													<value/>
+												</ArgumentValue>
+												<ArgumentDisplayValue classname='ExprValue'>
+													<value/>
+												</ArgumentDisplayValue>
+												<AdditionalResults classname='Obj'>
+													<subprops>
+														<Input classname='PythonParameterResult'>
+															<subprops>
+																<Condition classname='ExprValue'>
+																	<value/>
+																</Condition>
+																<Flags classname='Num'>
+																	<value>8192</value>
+																</Flags>
+																<CheckedState classname='Num'>
+																	<value>1</value>
+																</CheckedState>
+															</subprops>
+														</Input>
+														<Output classname='PythonParameterResult'>
+															<subprops>
+																<Condition classname='ExprValue'>
+																	<value/>
+																</Condition>
+																<Flags classname='Num'>
+																	<value>8192</value>
+																</Flags>
+																<CheckedState classname='Num'>
+																	<value>1</value>
+																</CheckedState>
+															</subprops>
+														</Output>
+													</subprops>
+												</AdditionalResults>
+											</subprops>
+										</CPythonParameter>
+									</value>
+								</value>
+							</Parameters>
+							<DefaultParamCategoryForArray classname='Num'>
+								<value>5</value>
+							</DefaultParamCategoryForArray>
+						</subprops>
+					</PythonCall>
+				</subprops>
+			</PythonStepAdditions>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='22'>
+			<EditSubstep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
+				<subprops>
+					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
+						<value>"%ModuleDescription"</value>
+					</DescriptionFormat>
+					<DefaultNameFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
+						<value>ResStr("NI_STEPTYPES", "EDIT_DEF_SUBSTEP_NAME")</value>
+					</DefaultNameFormat>
+					<BlockStartTypes classname='Str' valueflags='4194328' structureflags='524288'>
+						<value/>
+					</BlockStartTypes>
+					<BlockEndTypes classname='Str' valueflags='4194328' structureflags='524288'>
+						<value/>
+					</BlockEndTypes>
+					<AppliesToBlockStructure classname='Bool' valueflags='4194328' structureflags='524288'>
+						<value>false</value>
+					</AppliesToBlockStructure>
+					<Menu typename='StepTypeMenu' xsi:type='StepTypeMenu' classname='Obj'>
+						<subprops>
+							<CanBeSubstepType classname='Bool'>
+								<value>true</value>
+							</CanBeSubstepType>
+							<CanOnlyBeSubstepType classname='Bool'>
+								<value>true</value>
+							</CanOnlyBeSubstepType>
+							<Category classname='Str'>
+								<value>""</value>
+							</Category>
+							<ItemName classname='ExprValue'>
+								<value>ResStr("NI_STEPTYPES", "EDIT_SUBSTEP_MENU_ITEM_NAME")</value>
+							</ItemName>
+							<SingularItemName classname='Str'>
+								<value>""</value>
+							</SingularItemName>
+							<SeparatorBeforeCategory classname='Bool'>
+								<value>false</value>
+							</SeparatorBeforeCategory>
+							<SeparatorBeforeItemName classname='Bool'>
+								<value>false</value>
+							</SeparatorBeforeItemName>
+							<Group classname='Str'>
+								<value>EditSubsteps</value>
+							</Group>
+						</subprops>
+					</Menu>
+					<Substeps typename='StepTypeSubstepsArray' xsi:type='StepTypeSubstepsArray' classname='Objs'>
+						<value lbound='[0]' ubound='[]'/>
+					</Substeps>
+					<CodeTemplates classname='Str' valueflags='4194328' structureflags='524288'>
+						<value>DefaultLabVIEWNXG|DefaultLabVIEW|DefaultCVI|DefaultVB.NET|DefaultCSharp.NET|DefaultC++.NET|DefaultVC++_Template|DefaultHTB72_Template|DefaultHTB80_Template|Default_Template</value>
+					</CodeTemplates>
+					<AdditionalResultsHints classname='Objs' valueflags='4194328' structureflags='524288'>
+						<value lbound='[0]' ubound='[]'>
+							<elemproto>
+								<_NAME_IN_ATTRIBUTE_ typename='NI_CustomResult' xsi:type='NI_CustomResult' name='' classname='CustomResult'>
+									<subprops>
+										<Name classname='ExprValue'>
+											<value/>
+										</Name>
+										<ValueToLog classname='ExprValue'>
+											<value/>
+										</ValueToLog>
+										<Condition classname='ExprValue'>
+											<value/>
+										</Condition>
+										<Flags classname='Num'>
+											<value>8192</value>
+										</Flags>
+										<CheckedState classname='Num'>
+											<value>2</value>
+										</CheckedState>
+										<Type classname='PropertyObjectType'>
+											<subprops>
+												<ValueType classname='Num'>
+													<value>3</value>
+												</ValueType>
+												<IsObject classname='Bool'>
+													<value>true</value>
+												</IsObject>
+												<TypeName classname='Str'>
+													<value/>
+												</TypeName>
+												<ElementType classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</ElementType>
+												<ArrayDimensions classname='ArrayDimensions'>
+													<subprops>
+														<LowerBounds classname='Nums'>
+															<value lbound='[0]' ubound='[]'/>
+														</LowerBounds>
+														<UpperBounds classname='Nums'>
+															<value lbound='[0]' ubound='[]'/>
+														</UpperBounds>
+													</subprops>
+												</ArrayDimensions>
+												<Representation classname='Num'>
+													<value>1</value>
+												</Representation>
+												<ClassName classname='Str'>
+													<value/>
+												</ClassName>
+											</subprops>
+										</Type>
+										<Elements classname='Objs'>
+											<value lbound='[0]' ubound='[]'/>
+										</Elements>
+										<IsAnyType classname='Bool'>
+											<value>true</value>
+										</IsAnyType>
+									</subprops>
+								</_NAME_IN_ATTRIBUTE_>
+							</elemproto>
+						</value>
+					</AdditionalResultsHints>
+					<TS typename='TEInf' xsi:type='TEInf' classname='Obj' flagsforinstances='4456472'>
+						<subprops>
+							<Id classname='Str'>
+								<value/>
+							</Id>
+							<Icon classname='Str'>
+								<value/>
+							</Icon>
+							<SData classname='Obj' flagsforinstances='2097152' instanceoverrideflags='7274521' structureflags='2097152'/>
+							<PreCond classname='ExprValue'>
+								<value/>
+							</PreCond>
+							<LoadOpt classname='Str'>
+								<value>PreloadWhenExecuted</value>
+							</LoadOpt>
+							<UnloadOpt classname='Str'>
+								<value>UnloadWithFile</value>
+							</UnloadOpt>
+							<Mode classname='Str'>
+								<value>Normal</value>
+							</Mode>
+							<WindowActivation classname='Str'>
+								<value>None</value>
+							</WindowActivation>
+							<ResultOption classname='Num'>
+								<value>1</value>
+							</ResultOption>
+							<StepFCSeqF classname='Bool'>
+								<value>true</value>
+							</StepFCSeqF>
+							<IgnoreRTE classname='Bool'>
+								<value>false</value>
+							</IgnoreRTE>
+							<UseMutex classname='Bool'>
+								<value>false</value>
+							</UseMutex>
+							<MutexNameOrRef classname='ExprValue'>
+								<value/>
+							</MutexNameOrRef>
+							<BatchSyncOpt classname='Num'>
+								<value>0</value>
+							</BatchSyncOpt>
+							<SwitchEnabled classname='Bool'>
+								<value>false</value>
+							</SwitchEnabled>
+							<VirtualDeviceName classname='ExprValue'>
+								<value/>
+							</VirtualDeviceName>
+							<SwitchOperation classname='Num'>
+								<value>1</value>
+							</SwitchOperation>
+							<RouteGroupConnect classname='ExprValue'>
+								<value/>
+							</RouteGroupConnect>
+							<RouteGroupDisconnect classname='ExprValue'>
+								<value/>
+							</RouteGroupDisconnect>
+							<MulticonnectMode classname='Num'>
+								<value>1</value>
+							</MulticonnectMode>
+							<OperationOrder classname='Num'>
+								<value>2</value>
+							</OperationOrder>
+							<ConnectionLifetime classname='Num'>
+								<value>4</value>
+							</ConnectionLifetime>
+							<WaitForDebounce classname='Bool'>
+								<value>true</value>
+							</WaitForDebounce>
+							<PassAct classname='Str'>
+								<value>Next</value>
+							</PassAct>
+							<FailAct classname='Str'>
+								<value>Next</value>
+							</FailAct>
+							<PassActTarget classname='ExprValue'>
+								<value/>
+							</PassActTarget>
+							<FailActTarget classname='ExprValue'>
+								<value/>
+							</FailActTarget>
+							<CustExpr classname='ExprValue'>
+								<value/>
+							</CustExpr>
+							<CustTrueAct classname='Str'>
+								<value>Next</value>
+							</CustTrueAct>
+							<CustFalseAct classname='Str'>
+								<value>Next</value>
+							</CustFalseAct>
+							<CustTrueActTarget classname='ExprValue'>
+								<value/>
+							</CustTrueActTarget>
+							<CustFalseActTarget classname='ExprValue'>
+								<value/>
+							</CustFalseActTarget>
+							<LoopType classname='Str'>
+								<value>NoLooping</value>
+							</LoopType>
+							<LoopWhile classname='ExprValue'>
+								<value/>
+							</LoopWhile>
+							<LoopStatus classname='ExprValue'>
+								<value/>
+							</LoopStatus>
+							<LoopIncrement classname='ExprValue'>
+								<value>RunState.LoopIndex += 1</value>
+							</LoopIncrement>
+							<LoopInitialize classname='ExprValue'>
+								<value>RunState.LoopIndex = 0</value>
+							</LoopInitialize>
+							<LoopOpt classname='Num'>
+								<value>0</value>
+							</LoopOpt>
+							<PreExpr classname='ExprValue'>
+								<value/>
+							</PreExpr>
+							<PostExpr classname='ExprValue'>
+								<value/>
+							</PostExpr>
+							<StatusExpr classname='ExprValue'>
+								<value/>
+							</StatusExpr>
+							<CanSpecifyModule classname='Bool'>
+								<value>true</value>
+							</CanSpecifyModule>
+							<CanEditCode classname='Bool'>
+								<value>true</value>
+							</CanEditCode>
+							<CanEditModulePrototype classname='Bool'>
+								<value>true</value>
+							</CanEditModulePrototype>
+							<CanEditParameterAdditionalResults classname='Bool'>
+								<value>true</value>
+							</CanEditParameterAdditionalResults>
+							<PrecondIntExe classname='Num'>
+								<value>0</value>
+							</PrecondIntExe>
+							<Requirements classname='Obj' flagsforinstances='1' valueflags='1' structureflags='2097152'>
+								<subprops>
+									<Links classname='Strs' flagsforinstances='71303168' instanceoverrideflags='72286233' valueflags='71303168'>
+										<value lbound='[0]' ubound='[]'/>
+									</Links>
+								</subprops>
+							</Requirements>
+							<CustomResults classname='Objs'>
+								<value lbound='[0]' ubound='[]'>
+									<elemproto>
+										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+											<subprops>
+												<Name classname='ExprValue'>
+													<value/>
+												</Name>
+												<ValueToLog classname='ExprValue'>
+													<value/>
+												</ValueToLog>
+												<Condition classname='ExprValue'>
+													<value/>
+												</Condition>
+												<Flags classname='Num'>
+													<value>8192</value>
+												</Flags>
+												<CheckedState classname='Num'>
+													<value>2</value>
+												</CheckedState>
+												<Type classname='PropertyObjectType'>
+													<subprops>
+														<ValueType classname='Num'>
+															<value>3</value>
+														</ValueType>
+														<IsObject classname='Bool'>
+															<value>true</value>
+														</IsObject>
+														<TypeName classname='Str'>
+															<value/>
+														</TypeName>
+														<ElementType classname='Objs'>
+															<value lbound='[0]' ubound='[]'/>
+														</ElementType>
+														<ArrayDimensions classname='ArrayDimensions'>
+															<subprops>
+																<LowerBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</LowerBounds>
+																<UpperBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</UpperBounds>
+															</subprops>
+														</ArrayDimensions>
+														<Representation classname='Num'>
+															<value>1</value>
+														</Representation>
+														<ClassName classname='Str'>
+															<value/>
+														</ClassName>
+													</subprops>
+												</Type>
+												<Elements classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</Elements>
+												<IsAnyType classname='Bool'>
+													<value>true</value>
+												</IsAnyType>
+											</subprops>
+										</_NAME_IN_ATTRIBUTE_>
+									</elemproto>
+								</value>
+							</CustomResults>
+							<AdditionalResultsHints classname='Objs'>
+								<value lbound='[0]' ubound='[]'>
+									<elemproto>
+										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+											<subprops>
+												<Name classname='ExprValue'>
+													<value/>
+												</Name>
+												<ValueToLog classname='ExprValue'>
+													<value/>
+												</ValueToLog>
+												<Condition classname='ExprValue'>
+													<value/>
+												</Condition>
+												<Flags classname='Num'>
+													<value>8192</value>
+												</Flags>
+												<CheckedState classname='Num'>
+													<value>2</value>
+												</CheckedState>
+												<Type classname='PropertyObjectType'>
+													<subprops>
+														<ValueType classname='Num'>
+															<value>3</value>
+														</ValueType>
+														<IsObject classname='Bool'>
+															<value>true</value>
+														</IsObject>
+														<TypeName classname='Str'>
+															<value/>
+														</TypeName>
+														<ElementType classname='Objs'>
+															<value lbound='[0]' ubound='[]'/>
+														</ElementType>
+														<ArrayDimensions classname='ArrayDimensions'>
+															<subprops>
+																<LowerBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</LowerBounds>
+																<UpperBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</UpperBounds>
+															</subprops>
+														</ArrayDimensions>
+														<Representation classname='Num'>
+															<value>1</value>
+														</Representation>
+														<ClassName classname='Str'>
+															<value/>
+														</ClassName>
+													</subprops>
+												</Type>
+												<Elements classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</Elements>
+												<IsAnyType classname='Bool'>
+													<value>true</value>
+												</IsAnyType>
+											</subprops>
+										</_NAME_IN_ATTRIBUTE_>
+									</elemproto>
+								</value>
+							</AdditionalResultsHints>
+						</subprops>
+					</TS>
+					<NI_Data typename='StepTypeNIData' xsi:type='StepTypeNIData' classname='Obj'>
+						<subprops>
+							<EditPanels classname='Strs'>
+								<value lbound='[0]' ubound='[]'/>
+							</EditPanels>
+						</subprops>
+					</NI_Data>
+					<Result classname='Obj' flagsforinstances='4194304' valueflags='4194304'>
+						<subprops>
+							<Error typename='Error' xsi:type='Error' classname='Obj' flagsforinstances='4194304' valueflags='4194304'>
+								<subprops>
+									<Code classname='Num'>
+										<value>0</value>
+									</Code>
+									<Msg classname='Str'>
+										<value/>
+									</Msg>
+									<Occurred classname='Bool'>
+										<value>false</value>
+									</Occurred>
+								</subprops>
+							</Error>
+							<Status classname='Str' flagsforinstances='4194304' valueflags='4194304'>
+								<value/>
+							</Status>
+							<ReportText classname='Str' flagsforinstances='4194304' valueflags='4194304'>
+								<value/>
+							</ReportText>
+							<Common typename='CommonResults' xsi:type='CommonResults' classname='Obj'/>
+						</subprops>
+					</Result>
+					<CanEncapsulate classname='Bool' valueflags='4194328' structureflags='524288'>
+						<value>false</value>
+					</CanEncapsulate>
+					<MenuName typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</MenuName>
+					<SupportsReadOnly classname='Bool'>
+						<value>false</value>
+					</SupportsReadOnly>
+					<HasEditPanel classname='Bool'>
+						<value>false</value>
+					</HasEditPanel>
+				</subprops>
+			</EditSubstep>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='23'>
+			<NI_CommonCParameterResult classname='CommonCParameterResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+				<subprops>
+					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</Condition>
+					<Flags classname='Num'>
+						<value>8192</value>
+						<numericfmt>%#x</numericfmt>
+					</Flags>
+					<CheckedState classname='Num'>
+						<value>1</value>
+					</CheckedState>
+				</subprops>
+			</NI_CommonCParameterResult>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='24'>
+			<FCParameter classname='FCParameter' isroottypedef='true' typecategory='3' timestamp='1650060844' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+				<subprops>
+					<Name classname='Str'>
+						<value>_notNamed</value>
+					</Name>
+					<Type classname='Num'>
+						<value>0</value>
+					</Type>
+					<NumType classname='Num'>
+						<value>4</value>
+					</NumType>
+					<ObjType classname='Num'>
+						<value>0</value>
+					</ObjType>
+					<StructType classname='Str'>
+						<value/>
+					</StructType>
+					<NumPass classname='Num'>
+						<value>0</value>
+					</NumPass>
+					<StrPass classname='Num'>
+						<value>0</value>
+					</StrPass>
+					<ElemPass classname='Num'>
+						<value>0</value>
+					</ElemPass>
+					<ArrayDimensionsSize classname='Objs'>
+						<value lbound='[0]' ubound='[]'>
+							<elemproto>
+								<_NAME_IN_ATTRIBUTE_ typename='Expression' xsi:type='Expression' name='' classname='ExprValue' structureflags='131072'>
+									<value>1024</value>
+								</_NAME_IN_ATTRIBUTE_>
+							</elemproto>
+						</value>
+					</ArrayDimensionsSize>
+					<StrSize typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value>1024</value>
+					</StrSize>
+					<ResultAct classname='Num' instanceoverrideflags='5177368'>
+						<value>0</value>
+					</ResultAct>
+					<ArgVal typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</ArgVal>
+					<ArgDisplayVal typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</ArgDisplayVal>
+					<Flags classname='Num' instanceoverrideflags='5177368'>
+						<value>0</value>
+					</Flags>
+					<AdditionalResults classname='Obj'>
+						<subprops>
+							<Input typename='NI_CommonCParameterResult' xsi:type='NI_CommonCParameterResult' classname='CommonCParameterResult'>
+								<subprops>
+									<Condition classname='ExprValue'>
+										<value/>
+									</Condition>
+									<Flags classname='Num'>
+										<value>8192</value>
+									</Flags>
+									<CheckedState classname='Num'>
+										<value>1</value>
+									</CheckedState>
+								</subprops>
+							</Input>
+							<Output typename='NI_CommonCParameterResult' xsi:type='NI_CommonCParameterResult' classname='CommonCParameterResult'>
+								<subprops>
+									<Condition classname='ExprValue'>
+										<value/>
+									</Condition>
+									<Flags classname='Num'>
+										<value>8192</value>
+									</Flags>
+									<CheckedState classname='Num'>
+										<value>1</value>
+									</CheckedState>
+								</subprops>
+							</Output>
+						</subprops>
+					</AdditionalResults>
+					<UserData classname='Obj' flagsforinstances='2097152' structureflags='2097152'/>
+					<ArgValImag typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</ArgValImag>
+				</subprops>
+			</FCParameter>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='25'>
+			<FlexCStepAdditions classname='FCModule' isroottypedef='true' typecategory='3' timestamp='1650060844' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+				<subprops>
+					<Call classname='ExternalCall'>
+						<subprops>
+							<LibPath typename='Path' xsi:type='Path' classname='PathValue'>
+								<value/>
+							</LibPath>
+							<Func classname='Str'>
+								<value/>
+							</Func>
+							<Parms classname='Objs'>
+								<value lbound='[0]' ubound='[0]'>
+									<elemproto>
+										<_NAME_IN_ATTRIBUTE_ typename='FCParameter' xsi:type='FCParameter' name='' classname='FCParameter' structureflags='131072'>
+											<subprops>
+												<Name classname='Str'>
+													<value>_notNamed</value>
+												</Name>
+												<Type classname='Num'>
+													<value>0</value>
+												</Type>
+												<NumType classname='Num'>
+													<value>4</value>
+												</NumType>
+												<ObjType classname='Num'>
+													<value>0</value>
+												</ObjType>
+												<StructType classname='Str'>
+													<value/>
+												</StructType>
+												<NumPass classname='Num'>
+													<value>0</value>
+												</NumPass>
+												<StrPass classname='Num'>
+													<value>0</value>
+												</StrPass>
+												<ElemPass classname='Num'>
+													<value>0</value>
+												</ElemPass>
+												<ArrayDimensionsSize classname='Objs'>
+													<value lbound='[0]' ubound='[]'>
+														<elemproto>
+															<_NAME_IN_ATTRIBUTE_ name='' classname='ExprValue' structureflags='0'>
+																<value>1024</value>
+															</_NAME_IN_ATTRIBUTE_>
+														</elemproto>
+													</value>
+												</ArrayDimensionsSize>
+												<StrSize classname='ExprValue'>
+													<value>1024</value>
+												</StrSize>
+												<ResultAct classname='Num'>
+													<value>0</value>
+												</ResultAct>
+												<ArgVal classname='ExprValue'>
+													<value/>
+												</ArgVal>
+												<ArgDisplayVal classname='ExprValue'>
+													<value/>
+												</ArgDisplayVal>
+												<Flags classname='Num'>
+													<value>0</value>
+												</Flags>
+												<AdditionalResults classname='Obj'>
+													<subprops>
+														<Input classname='CommonCParameterResult'>
+															<subprops>
+																<Condition classname='ExprValue'>
+																	<value/>
+																</Condition>
+																<Flags classname='Num'>
+																	<value>8192</value>
+																</Flags>
+																<CheckedState classname='Num'>
+																	<value>1</value>
+																</CheckedState>
+															</subprops>
+														</Input>
+														<Output classname='CommonCParameterResult'>
+															<subprops>
+																<Condition classname='ExprValue'>
+																	<value/>
+																</Condition>
+																<Flags classname='Num'>
+																	<value>8192</value>
+																</Flags>
+																<CheckedState classname='Num'>
+																	<value>1</value>
+																</CheckedState>
+															</subprops>
+														</Output>
+													</subprops>
+												</AdditionalResults>
+												<ArgValImag classname='ExprValue'>
+													<value/>
+												</ArgValImag>
+											</subprops>
+										</_NAME_IN_ATTRIBUTE_>
+									</elemproto>
+									<value>
+										<FCParameter typename='FCParameter' xsi:type='FCParameter' name=''>
+											<subprops>
+												<Name classname='Str'>
+													<value>Return Value</value>
+												</Name>
+												<Type classname='Num'>
+													<value>3</value>
+												</Type>
+												<NumType classname='Num'>
+													<value>4</value>
+												</NumType>
+												<ObjType classname='Num'>
+													<value>0</value>
+												</ObjType>
+												<StructType classname='Str'>
+													<value/>
+												</StructType>
+												<NumPass classname='Num'>
+													<value>0</value>
+												</NumPass>
+												<StrPass classname='Num'>
+													<value>0</value>
+												</StrPass>
+												<ElemPass classname='Num'>
+													<value>0</value>
+												</ElemPass>
+												<ArrayDimensionsSize classname='Objs'>
+													<value lbound='[0]' ubound='[]'>
+														<elemproto>
+															<_NAME_IN_ATTRIBUTE_ name='' classname='ExprValue' structureflags='0'>
+																<value>1024</value>
+															</_NAME_IN_ATTRIBUTE_>
+														</elemproto>
+													</value>
+												</ArrayDimensionsSize>
+												<StrSize classname='ExprValue'>
+													<value>1024</value>
+												</StrSize>
+												<ResultAct classname='Num'>
+													<value>0</value>
+												</ResultAct>
+												<ArgVal classname='ExprValue'>
+													<value/>
+												</ArgVal>
+												<ArgDisplayVal classname='ExprValue'>
+													<value/>
+												</ArgDisplayVal>
+												<Flags classname='Num'>
+													<value>0</value>
+												</Flags>
+												<AdditionalResults classname='Obj'>
+													<subprops>
+														<Input classname='CommonCParameterResult'>
+															<subprops>
+																<Condition classname='ExprValue'>
+																	<value/>
+																</Condition>
+																<Flags classname='Num'>
+																	<value>8192</value>
+																</Flags>
+																<CheckedState classname='Num'>
+																	<value>1</value>
+																</CheckedState>
+															</subprops>
+														</Input>
+														<Output classname='CommonCParameterResult'>
+															<subprops>
+																<Condition classname='ExprValue'>
+																	<value/>
+																</Condition>
+																<Flags classname='Num'>
+																	<value>8192</value>
+																</Flags>
+																<CheckedState classname='Num'>
+																	<value>1</value>
+																</CheckedState>
+															</subprops>
+														</Output>
+													</subprops>
+												</AdditionalResults>
+												<ArgValImag classname='ExprValue'>
+													<value/>
+												</ArgValImag>
+											</subprops>
+										</FCParameter>
+									</value>
+								</value>
+							</Parms>
+						</subprops>
+					</Call>
+					<ModuleSrcPath typename='Path' xsi:type='Path' classname='PathValue'>
+						<value/>
+					</ModuleSrcPath>
+					<ModulePrjPath typename='Path' xsi:type='Path' classname='PathValue'>
+						<value/>
+					</ModulePrjPath>
+					<ModuleWorkspacePath typename='Path' xsi:type='Path' classname='PathValue'>
+						<value/>
+					</ModuleWorkspacePath>
+					<CodeTemplateName classname='Str'>
+						<value/>
+					</CodeTemplateName>
+					<ModuleCreateSrcType classname='Num'>
+						<value>0</value>
+					</ModuleCreateSrcType>
+				</subprops>
+			</FlexCStepAdditions>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='26'>
+			<Statement classname='StepType' isroottypedef='true' typecategory='1' timestamp='1618215676' typeversion='21.0.0.2' typelastmodversion='21.0.0.0' typeminprodversion='21.0.0.0' typeflags='33554446'>
+				<subprops>
+					<Substeps typename='StepTypeSubstepsArray' xsi:type='StepTypeSubstepsArray' classname='Objs' flagsforinstances='524312' instanceoverrideflags='655384'>
+						<value lbound='[0]' ubound='[0]'>
+							<value>
+								<Step typename='EditSubstep' xsi:type='EditSubstep' name='Edit'>
+									<subprops>
+										<TS classname='Obj' flagsforinstances='262168' instanceoverrideflags='262168'>
+											<subprops>
+												<Id classname='Str'>
+													<value/>
+												</Id>
+												<Icon classname='Str'>
+													<value/>
+												</Icon>
+												<SData typename='FlexCStepAdditions' xsi:type='FlexCStepAdditions' classname='FCModule' flagsforinstances='2097152' instanceoverrideflags='2097152' structureflags='2097152'>
+													<subprops>
+														<Call classname='ExternalCall'>
+															<subprops>
+																<LibPath classname='PathValue'>
+																	<value>CommonSubsteps.dll</value>
+																</LibPath>
+																<Func classname='Str'>
+																	<value>EditStatementStep</value>
+																</Func>
+																<Parms classname='Objs'>
+																	<value lbound='[0]' ubound='[3]'>
+																		<elemproto>
+																			<_NAME_IN_ATTRIBUTE_ name='' classname='FCParameter' structureflags='0'/>
+																		</elemproto>
+																		<value>
+																			<FCParameter typename='FCParameter' xsi:type='FCParameter' name=''>
+																				<subprops>
+																					<Name classname='Str'>
+																						<value>Return Value</value>
+																					</Name>
+																					<Type classname='Num'>
+																						<value>3</value>
+																					</Type>
+																					<NumType classname='Num'>
+																						<value>4</value>
+																					</NumType>
+																					<ObjType classname='Num'>
+																						<value>2</value>
+																					</ObjType>
+																					<StructType classname='Str'>
+																						<value/>
+																					</StructType>
+																					<NumPass classname='Num'>
+																						<value>0</value>
+																					</NumPass>
+																					<StrPass classname='Num'>
+																						<value>0</value>
+																					</StrPass>
+																					<ElemPass classname='Num'>
+																						<value>0</value>
+																					</ElemPass>
+																					<ArrayDimensionsSize classname='Objs'>
+																						<value lbound='[0]' ubound='[]'>
+																							<elemproto>
+																								<_NAME_IN_ATTRIBUTE_ name='' classname='ExprValue' structureflags='0'>
+																									<value>1024</value>
+																								</_NAME_IN_ATTRIBUTE_>
+																							</elemproto>
+																						</value>
+																					</ArrayDimensionsSize>
+																					<StrSize classname='ExprValue'>
+																						<value>1024</value>
+																					</StrSize>
+																					<ResultAct classname='Num' instanceoverrideflags='5177369'>
+																						<value>0</value>
+																					</ResultAct>
+																					<ArgVal classname='ExprValue'>
+																						<value/>
+																					</ArgVal>
+																					<ArgDisplayVal classname='ExprValue'>
+																						<value/>
+																					</ArgDisplayVal>
+																					<Flags classname='Num' instanceoverrideflags='5177369'>
+																						<value>0</value>
+																					</Flags>
+																					<AdditionalResults classname='Obj'>
+																						<subprops>
+																							<Input classname='CommonCParameterResult'>
+																								<subprops>
+																									<Condition classname='ExprValue'>
+																										<value/>
+																									</Condition>
+																									<Flags classname='Num'>
+																										<value>8192</value>
+																									</Flags>
+																									<CheckedState classname='Num'>
+																										<value>1</value>
+																									</CheckedState>
+																								</subprops>
+																							</Input>
+																							<Output classname='CommonCParameterResult'>
+																								<subprops>
+																									<Condition classname='ExprValue'>
+																										<value/>
+																									</Condition>
+																									<Flags classname='Num'>
+																										<value>8192</value>
+																									</Flags>
+																									<CheckedState classname='Num'>
+																										<value>1</value>
+																									</CheckedState>
+																								</subprops>
+																							</Output>
+																						</subprops>
+																					</AdditionalResults>
+																					<ArgValImag classname='ExprValue'>
+																						<value/>
+																					</ArgValImag>
+																				</subprops>
+																			</FCParameter>
+																		</value>
+																		<value>
+																			<FCParameter typename='FCParameter' xsi:type='FCParameter' name=''>
+																				<subprops>
+																					<Name classname='Str'>
+																						<value>context</value>
+																					</Name>
+																					<Type classname='Num'>
+																						<value>4</value>
+																					</Type>
+																					<NumType classname='Num'>
+																						<value>4</value>
+																					</NumType>
+																					<ObjType classname='Num'>
+																						<value>0</value>
+																					</ObjType>
+																					<StructType classname='Str'>
+																						<value/>
+																					</StructType>
+																					<NumPass classname='Num'>
+																						<value>0</value>
+																					</NumPass>
+																					<StrPass classname='Num'>
+																						<value>0</value>
+																					</StrPass>
+																					<ElemPass classname='Num'>
+																						<value>0</value>
+																					</ElemPass>
+																					<ArrayDimensionsSize classname='Objs'>
+																						<value lbound='[0]' ubound='[]'>
+																							<elemproto>
+																								<_NAME_IN_ATTRIBUTE_ name='' classname='ExprValue' structureflags='0'>
+																									<value>1024</value>
+																								</_NAME_IN_ATTRIBUTE_>
+																							</elemproto>
+																						</value>
+																					</ArrayDimensionsSize>
+																					<StrSize classname='ExprValue'>
+																						<value>1024</value>
+																					</StrSize>
+																					<ResultAct classname='Num' instanceoverrideflags='5177369'>
+																						<value>0</value>
+																					</ResultAct>
+																					<ArgVal classname='ExprValue'>
+																						<value>ThisContext</value>
+																					</ArgVal>
+																					<ArgDisplayVal classname='ExprValue'>
+																						<value/>
+																					</ArgDisplayVal>
+																					<Flags classname='Num' instanceoverrideflags='5177369'>
+																						<value>0</value>
+																					</Flags>
+																					<AdditionalResults classname='Obj'>
+																						<subprops>
+																							<Input classname='CommonCParameterResult'>
+																								<subprops>
+																									<Condition classname='ExprValue'>
+																										<value/>
+																									</Condition>
+																									<Flags classname='Num'>
+																										<value>8192</value>
+																									</Flags>
+																									<CheckedState classname='Num'>
+																										<value>1</value>
+																									</CheckedState>
+																								</subprops>
+																							</Input>
+																							<Output classname='CommonCParameterResult'>
+																								<subprops>
+																									<Condition classname='ExprValue'>
+																										<value/>
+																									</Condition>
+																									<Flags classname='Num'>
+																										<value>8192</value>
+																									</Flags>
+																									<CheckedState classname='Num'>
+																										<value>1</value>
+																									</CheckedState>
+																								</subprops>
+																							</Output>
+																						</subprops>
+																					</AdditionalResults>
+																					<ArgValImag classname='ExprValue'>
+																						<value/>
+																					</ArgValImag>
+																				</subprops>
+																			</FCParameter>
+																		</value>
+																		<value>
+																			<FCParameter typename='FCParameter' xsi:type='FCParameter' name=''>
+																				<subprops>
+																					<Name classname='Str'>
+																						<value>reserved</value>
+																					</Name>
+																					<Type classname='Num'>
+																						<value>0</value>
+																					</Type>
+																					<NumType classname='Num'>
+																						<value>4</value>
+																					</NumType>
+																					<ObjType classname='Num'>
+																						<value>0</value>
+																					</ObjType>
+																					<StructType classname='Str'>
+																						<value/>
+																					</StructType>
+																					<NumPass classname='Num'>
+																						<value>0</value>
+																					</NumPass>
+																					<StrPass classname='Num'>
+																						<value>0</value>
+																					</StrPass>
+																					<ElemPass classname='Num'>
+																						<value>0</value>
+																					</ElemPass>
+																					<ArrayDimensionsSize classname='Objs'>
+																						<value lbound='[0]' ubound='[]'>
+																							<elemproto>
+																								<_NAME_IN_ATTRIBUTE_ name='' classname='ExprValue' structureflags='0'>
+																									<value>1024</value>
+																								</_NAME_IN_ATTRIBUTE_>
+																							</elemproto>
+																						</value>
+																					</ArrayDimensionsSize>
+																					<StrSize classname='ExprValue'>
+																						<value>1024</value>
+																					</StrSize>
+																					<ResultAct classname='Num' instanceoverrideflags='5177369'>
+																						<value>0</value>
+																					</ResultAct>
+																					<ArgVal classname='ExprValue'>
+																						<value>0</value>
+																					</ArgVal>
+																					<ArgDisplayVal classname='ExprValue'>
+																						<value/>
+																					</ArgDisplayVal>
+																					<Flags classname='Num' instanceoverrideflags='5177369'>
+																						<value>0</value>
+																					</Flags>
+																					<AdditionalResults classname='Obj'>
+																						<subprops>
+																							<Input classname='CommonCParameterResult'>
+																								<subprops>
+																									<Condition classname='ExprValue'>
+																										<value/>
+																									</Condition>
+																									<Flags classname='Num'>
+																										<value>8192</value>
+																									</Flags>
+																									<CheckedState classname='Num'>
+																										<value>1</value>
+																									</CheckedState>
+																								</subprops>
+																							</Input>
+																							<Output classname='CommonCParameterResult'>
+																								<subprops>
+																									<Condition classname='ExprValue'>
+																										<value/>
+																									</Condition>
+																									<Flags classname='Num'>
+																										<value>8192</value>
+																									</Flags>
+																									<CheckedState classname='Num'>
+																										<value>1</value>
+																									</CheckedState>
+																								</subprops>
+																							</Output>
+																						</subprops>
+																					</AdditionalResults>
+																					<ArgValImag classname='ExprValue'>
+																						<value/>
+																					</ArgValImag>
+																				</subprops>
+																			</FCParameter>
+																		</value>
+																		<value>
+																			<FCParameter typename='FCParameter' xsi:type='FCParameter' name=''>
+																				<subprops>
+																					<Name classname='Str'>
+																						<value>changed</value>
+																					</Name>
+																					<Type classname='Num'>
+																						<value>0</value>
+																					</Type>
+																					<NumType classname='Num'>
+																						<value>4</value>
+																					</NumType>
+																					<ObjType classname='Num'>
+																						<value>2</value>
+																					</ObjType>
+																					<StructType classname='Str'>
+																						<value/>
+																					</StructType>
+																					<NumPass classname='Num'>
+																						<value>1</value>
+																					</NumPass>
+																					<StrPass classname='Num'>
+																						<value>0</value>
+																					</StrPass>
+																					<ElemPass classname='Num'>
+																						<value>0</value>
+																					</ElemPass>
+																					<ArrayDimensionsSize classname='Objs'>
+																						<value lbound='[0]' ubound='[]'>
+																							<elemproto>
+																								<_NAME_IN_ATTRIBUTE_ name='' classname='ExprValue' structureflags='0'>
+																									<value>1024</value>
+																								</_NAME_IN_ATTRIBUTE_>
+																							</elemproto>
+																						</value>
+																					</ArrayDimensionsSize>
+																					<StrSize classname='ExprValue'>
+																						<value>1024</value>
+																					</StrSize>
+																					<ResultAct classname='Num' instanceoverrideflags='5177369'>
+																						<value>0</value>
+																					</ResultAct>
+																					<ArgVal classname='ExprValue'>
+																						<value>RunState.InitialSelection.SelectedFile.ChangeCount</value>
+																					</ArgVal>
+																					<ArgDisplayVal classname='ExprValue'>
+																						<value/>
+																					</ArgDisplayVal>
+																					<Flags classname='Num' instanceoverrideflags='5177369'>
+																						<value>0</value>
+																					</Flags>
+																					<AdditionalResults classname='Obj'>
+																						<subprops>
+																							<Input classname='CommonCParameterResult'>
+																								<subprops>
+																									<Condition classname='ExprValue'>
+																										<value/>
+																									</Condition>
+																									<Flags classname='Num'>
+																										<value>8192</value>
+																									</Flags>
+																									<CheckedState classname='Num'>
+																										<value>1</value>
+																									</CheckedState>
+																								</subprops>
+																							</Input>
+																							<Output classname='CommonCParameterResult'>
+																								<subprops>
+																									<Condition classname='ExprValue'>
+																										<value/>
+																									</Condition>
+																									<Flags classname='Num'>
+																										<value>8192</value>
+																									</Flags>
+																									<CheckedState classname='Num'>
+																										<value>1</value>
+																									</CheckedState>
+																								</subprops>
+																							</Output>
+																						</subprops>
+																					</AdditionalResults>
+																					<ArgValImag classname='ExprValue'>
+																						<value/>
+																					</ArgValImag>
+																				</subprops>
+																			</FCParameter>
+																		</value>
+																	</value>
+																</Parms>
+															</subprops>
+														</Call>
+														<ModuleSrcPath classname='PathValue'>
+															<value/>
+														</ModuleSrcPath>
+														<ModulePrjPath classname='PathValue'>
+															<value/>
+														</ModulePrjPath>
+														<ModuleWorkspacePath classname='PathValue'>
+															<value/>
+														</ModuleWorkspacePath>
+														<CodeTemplateName classname='Str'>
+															<value/>
+														</CodeTemplateName>
+														<ModuleCreateSrcType classname='Num'>
+															<value>0</value>
+														</ModuleCreateSrcType>
+													</subprops>
+												</SData>
+												<PreCond classname='ExprValue'>
+													<value/>
+												</PreCond>
+												<LoadOpt classname='Str'>
+													<value>PreloadWhenExecuted</value>
+												</LoadOpt>
+												<UnloadOpt classname='Str'>
+													<value>UnloadWithFile</value>
+												</UnloadOpt>
+												<Mode classname='Str'>
+													<value>Normal</value>
+												</Mode>
+												<WindowActivation classname='Str'>
+													<value>None</value>
+												</WindowActivation>
+												<ResultOption classname='Num'>
+													<value>1</value>
+												</ResultOption>
+												<StepFCSeqF classname='Bool'>
+													<value>true</value>
+												</StepFCSeqF>
+												<IgnoreRTE classname='Bool'>
+													<value>false</value>
+												</IgnoreRTE>
+												<UseMutex classname='Bool'>
+													<value>false</value>
+												</UseMutex>
+												<MutexNameOrRef classname='ExprValue'>
+													<value/>
+												</MutexNameOrRef>
+												<BatchSyncOpt classname='Num'>
+													<value>0</value>
+												</BatchSyncOpt>
+												<SwitchEnabled classname='Bool'>
+													<value>false</value>
+												</SwitchEnabled>
+												<VirtualDeviceName classname='ExprValue'>
+													<value/>
+												</VirtualDeviceName>
+												<SwitchOperation classname='Num'>
+													<value>1</value>
+												</SwitchOperation>
+												<RouteGroupConnect classname='ExprValue'>
+													<value/>
+												</RouteGroupConnect>
+												<RouteGroupDisconnect classname='ExprValue'>
+													<value/>
+												</RouteGroupDisconnect>
+												<MulticonnectMode classname='Num'>
+													<value>1</value>
+												</MulticonnectMode>
+												<OperationOrder classname='Num'>
+													<value>2</value>
+												</OperationOrder>
+												<ConnectionLifetime classname='Num'>
+													<value>0</value>
+												</ConnectionLifetime>
+												<WaitForDebounce classname='Bool'>
+													<value>true</value>
+												</WaitForDebounce>
+												<PassAct classname='Str'>
+													<value>Next</value>
+												</PassAct>
+												<FailAct classname='Str'>
+													<value>Next</value>
+												</FailAct>
+												<PassActTarget classname='ExprValue'>
+													<value/>
+												</PassActTarget>
+												<FailActTarget classname='ExprValue'>
+													<value/>
+												</FailActTarget>
+												<CustExpr classname='ExprValue'>
+													<value/>
+												</CustExpr>
+												<CustTrueAct classname='Str'>
+													<value>Next</value>
+												</CustTrueAct>
+												<CustFalseAct classname='Str'>
+													<value>Next</value>
+												</CustFalseAct>
+												<CustTrueActTarget classname='ExprValue'>
+													<value/>
+												</CustTrueActTarget>
+												<CustFalseActTarget classname='ExprValue'>
+													<value/>
+												</CustFalseActTarget>
+												<LoopType classname='Str'>
+													<value>NoLooping</value>
+												</LoopType>
+												<LoopWhile classname='ExprValue'>
+													<value/>
+												</LoopWhile>
+												<LoopStatus classname='ExprValue'>
+													<value/>
+												</LoopStatus>
+												<LoopIncrement classname='ExprValue'>
+													<value>RunState.LoopIndex += 1</value>
+												</LoopIncrement>
+												<LoopInitialize classname='ExprValue'>
+													<value>RunState.LoopIndex = 0</value>
+												</LoopInitialize>
+												<LoopOpt classname='Num'>
+													<value>0</value>
+												</LoopOpt>
+												<PreExpr classname='ExprValue'>
+													<value/>
+												</PreExpr>
+												<PostExpr classname='ExprValue'>
+													<value/>
+												</PostExpr>
+												<StatusExpr classname='ExprValue'>
+													<value/>
+												</StatusExpr>
+												<CanSpecifyModule classname='Bool'>
+													<value>true</value>
+												</CanSpecifyModule>
+												<CanEditCode classname='Bool'>
+													<value>true</value>
+												</CanEditCode>
+												<CanEditModulePrototype classname='Bool'>
+													<value>true</value>
+												</CanEditModulePrototype>
+												<CanEditParameterAdditionalResults classname='Bool'>
+													<value>true</value>
+												</CanEditParameterAdditionalResults>
+												<PrecondIntExe classname='Num'>
+													<value>0</value>
+												</PrecondIntExe>
+												<CustomResults classname='Objs'>
+													<value lbound='[0]' ubound='[]'>
+														<elemproto>
+															<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+																<subprops>
+																	<Name classname='ExprValue'>
+																		<value/>
+																	</Name>
+																	<ValueToLog classname='ExprValue'>
+																		<value/>
+																	</ValueToLog>
+																	<Condition classname='ExprValue'>
+																		<value/>
+																	</Condition>
+																	<Flags classname='Num'>
+																		<value>8192</value>
+																	</Flags>
+																	<CheckedState classname='Num'>
+																		<value>2</value>
+																	</CheckedState>
+																	<Type classname='PropertyObjectType'>
+																		<subprops>
+																			<ValueType classname='Num'>
+																				<value>3</value>
+																			</ValueType>
+																			<IsObject classname='Bool'>
+																				<value>true</value>
+																			</IsObject>
+																			<TypeName classname='Str'>
+																				<value/>
+																			</TypeName>
+																			<ElementType classname='Objs'>
+																				<value lbound='[0]' ubound='[]'/>
+																			</ElementType>
+																			<ArrayDimensions classname='ArrayDimensions'>
+																				<subprops>
+																					<LowerBounds classname='Nums'>
+																						<value lbound='[0]' ubound='[]'/>
+																					</LowerBounds>
+																					<UpperBounds classname='Nums'>
+																						<value lbound='[0]' ubound='[]'/>
+																					</UpperBounds>
+																				</subprops>
+																			</ArrayDimensions>
+																			<Representation classname='Num'>
+																				<value>1</value>
+																			</Representation>
+																			<ClassName classname='Str'>
+																				<value/>
+																			</ClassName>
+																		</subprops>
+																	</Type>
+																	<Elements classname='Objs'>
+																		<value lbound='[0]' ubound='[]'/>
+																	</Elements>
+																	<IsAnyType classname='Bool'>
+																		<value>true</value>
+																	</IsAnyType>
+																</subprops>
+															</_NAME_IN_ATTRIBUTE_>
+														</elemproto>
+													</value>
+												</CustomResults>
+												<AdditionalResultsHints classname='Objs'>
+													<value lbound='[0]' ubound='[]'>
+														<elemproto>
+															<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+																<subprops>
+																	<Name classname='ExprValue'>
+																		<value/>
+																	</Name>
+																	<ValueToLog classname='ExprValue'>
+																		<value/>
+																	</ValueToLog>
+																	<Condition classname='ExprValue'>
+																		<value/>
+																	</Condition>
+																	<Flags classname='Num'>
+																		<value>8192</value>
+																	</Flags>
+																	<CheckedState classname='Num'>
+																		<value>2</value>
+																	</CheckedState>
+																	<Type classname='PropertyObjectType'>
+																		<subprops>
+																			<ValueType classname='Num'>
+																				<value>3</value>
+																			</ValueType>
+																			<IsObject classname='Bool'>
+																				<value>true</value>
+																			</IsObject>
+																			<TypeName classname='Str'>
+																				<value/>
+																			</TypeName>
+																			<ElementType classname='Objs'>
+																				<value lbound='[0]' ubound='[]'/>
+																			</ElementType>
+																			<ArrayDimensions classname='ArrayDimensions'>
+																				<subprops>
+																					<LowerBounds classname='Nums'>
+																						<value lbound='[0]' ubound='[]'/>
+																					</LowerBounds>
+																					<UpperBounds classname='Nums'>
+																						<value lbound='[0]' ubound='[]'/>
+																					</UpperBounds>
+																				</subprops>
+																			</ArrayDimensions>
+																			<Representation classname='Num'>
+																				<value>1</value>
+																			</Representation>
+																			<ClassName classname='Str'>
+																				<value/>
+																			</ClassName>
+																		</subprops>
+																	</Type>
+																	<Elements classname='Objs'>
+																		<value lbound='[0]' ubound='[]'/>
+																	</Elements>
+																	<IsAnyType classname='Bool'>
+																		<value>true</value>
+																	</IsAnyType>
+																</subprops>
+															</_NAME_IN_ATTRIBUTE_>
+														</elemproto>
+													</value>
+												</AdditionalResultsHints>
+											</subprops>
+										</TS>
+										<Result classname='Obj'>
+											<subprops>
+												<Error classname='Obj' instanceoverrideflags='4194304'>
+													<subprops>
+														<Code classname='Num'>
+															<value>0</value>
+														</Code>
+														<Msg classname='Str'>
+															<value/>
+														</Msg>
+														<Occurred classname='Bool'>
+															<value>false</value>
+														</Occurred>
+													</subprops>
+												</Error>
+												<Status classname='Str'>
+													<value/>
+												</Status>
+												<ReportText classname='Str' flagsforinstances='0'>
+													<value/>
+												</ReportText>
+												<Common classname='Obj' instanceoverrideflags='4194304'/>
+											</subprops>
+										</Result>
+										<MenuName classname='ExprValue'>
+											<value>ResStr("NI_SUBSTEPS", "STATEMENT_EDIT_STEP_MENU_NAME")</value>
+										</MenuName>
+										<SupportsReadOnly classname='Bool'>
+											<value>true</value>
+										</SupportsReadOnly>
+										<HasEditPanel classname='Bool'>
+											<value>true</value>
+										</HasEditPanel>
+									</subprops>
+								</Step>
+							</value>
+						</value>
+					</Substeps>
+					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
+						<value>LocalizeExpression(Step.TS.PostExpr)</value>
+					</DescriptionFormat>
+					<DefaultNameFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
+						<value>ResStr("NI_SUBSTEPS", "STATEMENT_DEF_STEP_NAME")</value>
+					</DefaultNameFormat>
+					<Menu typename='StepTypeMenu' xsi:type='StepTypeMenu' classname='Obj' flagsforinstances='524312' instanceoverrideflags='524312'>
+						<subprops>
+							<CanBeSubstepType classname='Bool'>
+								<value>false</value>
+							</CanBeSubstepType>
+							<CanOnlyBeSubstepType classname='Bool'>
+								<value>false</value>
+							</CanOnlyBeSubstepType>
+							<Category classname='Str'>
+								<value>""</value>
+							</Category>
+							<ItemName classname='ExprValue'>
+								<value>ResStr("NI_SUBSTEPS", "STATEMENT_MENU_ITEM_NAME")</value>
+							</ItemName>
+							<SingularItemName classname='Str'>
+								<value>""</value>
+							</SingularItemName>
+							<SeparatorBeforeCategory classname='Bool'>
+								<value>false</value>
+							</SeparatorBeforeCategory>
+							<SeparatorBeforeItemName classname='Bool'>
+								<value>false</value>
+							</SeparatorBeforeItemName>
+							<Group classname='Str'>
+								<value>NI_Miscellaneous</value>
+							</Group>
+						</subprops>
+					</Menu>
+					<AdditionalResultsHints classname='Objs' valueflags='4194328' structureflags='524288'>
+						<value lbound='[0]' ubound='[0]'>
+							<elemproto>
+								<_NAME_IN_ATTRIBUTE_ typename='NI_CustomResult' xsi:type='NI_CustomResult' name='' classname='CustomResult'>
+									<subprops>
+										<Name classname='ExprValue'>
+											<value/>
+										</Name>
+										<ValueToLog classname='ExprValue'>
+											<value/>
+										</ValueToLog>
+										<Condition classname='ExprValue'>
+											<value/>
+										</Condition>
+										<Flags classname='Num'>
+											<value>8192</value>
+										</Flags>
+										<CheckedState classname='Num'>
+											<value>2</value>
+										</CheckedState>
+										<Type classname='PropertyObjectType'>
+											<subprops>
+												<ValueType classname='Num'>
+													<value>3</value>
+												</ValueType>
+												<IsObject classname='Bool'>
+													<value>true</value>
+												</IsObject>
+												<TypeName classname='Str'>
+													<value/>
+												</TypeName>
+												<ElementType classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</ElementType>
+												<ArrayDimensions classname='ArrayDimensions'>
+													<subprops>
+														<LowerBounds classname='Nums'>
+															<value lbound='[0]' ubound='[]'/>
+														</LowerBounds>
+														<UpperBounds classname='Nums'>
+															<value lbound='[0]' ubound='[]'/>
+														</UpperBounds>
+													</subprops>
+												</ArrayDimensions>
+												<Representation classname='Num'>
+													<value>1</value>
+												</Representation>
+												<ClassName classname='Str'>
+													<value/>
+												</ClassName>
+											</subprops>
+										</Type>
+										<Elements classname='Objs'>
+											<value lbound='[0]' ubound='[]'/>
+										</Elements>
+										<IsAnyType classname='Bool'>
+											<value>true</value>
+										</IsAnyType>
+									</subprops>
+								</_NAME_IN_ATTRIBUTE_>
+							</elemproto>
+							<value>
+								<CustomResult typename='NI_CustomResult' xsi:type='NI_CustomResult' name=''>
+									<subprops>
+										<Name classname='ExprValue'>
+											<value>ResStr("NI_SUBSTEPS", "STATEMENT_EXPRESSION")</value>
+										</Name>
+										<ValueToLog classname='ExprValue'>
+											<value>LocalizeExpression(Step.PostExpression)</value>
+										</ValueToLog>
+										<Condition classname='ExprValue'>
+											<value/>
+										</Condition>
+										<Flags classname='Num'>
+											<value>8192</value>
+										</Flags>
+										<CheckedState classname='Num'>
+											<value>2</value>
+										</CheckedState>
+										<Type classname='PropertyObjectType'>
+											<subprops>
+												<ValueType classname='Num'>
+													<value>3</value>
+												</ValueType>
+												<IsObject classname='Bool'>
+													<value>true</value>
+												</IsObject>
+												<TypeName classname='Str'>
+													<value/>
+												</TypeName>
+												<ElementType classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</ElementType>
+												<ArrayDimensions classname='ArrayDimensions'>
+													<subprops>
+														<LowerBounds classname='Nums'>
+															<value lbound='[0]' ubound='[]'/>
+														</LowerBounds>
+														<UpperBounds classname='Nums'>
+															<value lbound='[0]' ubound='[]'/>
+														</UpperBounds>
+													</subprops>
+												</ArrayDimensions>
+												<Representation classname='Num'>
+													<value>1</value>
+												</Representation>
+												<ClassName classname='Str'>
+													<value/>
+												</ClassName>
+											</subprops>
+										</Type>
+										<Elements classname='Objs'>
+											<value lbound='[0]' ubound='[]'/>
+										</Elements>
+										<IsAnyType classname='Bool'>
+											<value>true</value>
+										</IsAnyType>
+									</subprops>
+								</CustomResult>
+							</value>
+						</value>
+					</AdditionalResultsHints>
+					<TS typename='TEInf' xsi:type='TEInf' classname='Obj' flagsforinstances='262168' instanceoverrideflags='4456472'>
+						<subprops>
+							<Id classname='Str'>
+								<value/>
+							</Id>
+							<Icon classname='Str'>
+								<value>StatementStep.ico</value>
+							</Icon>
+							<SData typename='NoneStepAdditions' xsi:type='NoneStepAdditions' classname='NoneModule' flagsforinstances='2097152' instanceoverrideflags='7143448' structureflags='2097152'/>
+							<PreCond classname='ExprValue'>
+								<value/>
+							</PreCond>
+							<LoadOpt classname='Str'>
+								<value>PreloadWhenExecuted</value>
+							</LoadOpt>
+							<UnloadOpt classname='Str'>
+								<value>UnloadWithFile</value>
+							</UnloadOpt>
+							<Mode classname='Str'>
+								<value>Normal</value>
+							</Mode>
+							<WindowActivation classname='Str'>
+								<value>None</value>
+							</WindowActivation>
+							<ResultOption classname='Num'>
+								<value>1</value>
+							</ResultOption>
+							<StepFCSeqF classname='Bool'>
+								<value>true</value>
+							</StepFCSeqF>
+							<IgnoreRTE classname='Bool'>
+								<value>false</value>
+							</IgnoreRTE>
+							<UseMutex classname='Bool'>
+								<value>false</value>
+							</UseMutex>
+							<MutexNameOrRef classname='ExprValue'>
+								<value/>
+							</MutexNameOrRef>
+							<BatchSyncOpt classname='Num'>
+								<value>0</value>
+							</BatchSyncOpt>
+							<SwitchEnabled classname='Bool'>
+								<value>false</value>
+							</SwitchEnabled>
+							<VirtualDeviceName classname='ExprValue'>
+								<value/>
+							</VirtualDeviceName>
+							<SwitchOperation classname='Num'>
+								<value>1</value>
+							</SwitchOperation>
+							<RouteGroupConnect classname='ExprValue'>
+								<value/>
+							</RouteGroupConnect>
+							<RouteGroupDisconnect classname='ExprValue'>
+								<value/>
+							</RouteGroupDisconnect>
+							<MulticonnectMode classname='Num'>
+								<value>1</value>
+							</MulticonnectMode>
+							<OperationOrder classname='Num'>
+								<value>2</value>
+							</OperationOrder>
+							<ConnectionLifetime classname='Num'>
+								<value>0</value>
+							</ConnectionLifetime>
+							<WaitForDebounce classname='Bool'>
+								<value>true</value>
+							</WaitForDebounce>
+							<PassAct classname='Str'>
+								<value>Next</value>
+							</PassAct>
+							<FailAct classname='Str'>
+								<value>Next</value>
+							</FailAct>
+							<PassActTarget classname='ExprValue'>
+								<value/>
+							</PassActTarget>
+							<FailActTarget classname='ExprValue'>
+								<value/>
+							</FailActTarget>
+							<CustExpr classname='ExprValue'>
+								<value/>
+							</CustExpr>
+							<CustTrueAct classname='Str'>
+								<value>Next</value>
+							</CustTrueAct>
+							<CustFalseAct classname='Str'>
+								<value>Next</value>
+							</CustFalseAct>
+							<CustTrueActTarget classname='ExprValue'>
+								<value/>
+							</CustTrueActTarget>
+							<CustFalseActTarget classname='ExprValue'>
+								<value/>
+							</CustFalseActTarget>
+							<LoopType classname='Str'>
+								<value>NoLooping</value>
+							</LoopType>
+							<LoopWhile classname='ExprValue'>
+								<value/>
+							</LoopWhile>
+							<LoopStatus classname='ExprValue'>
+								<value/>
+							</LoopStatus>
+							<LoopIncrement classname='ExprValue'>
+								<value>RunState.LoopIndex += 1</value>
+							</LoopIncrement>
+							<LoopInitialize classname='ExprValue'>
+								<value>RunState.LoopIndex = 0</value>
+							</LoopInitialize>
+							<LoopOpt classname='Num'>
+								<value>0</value>
+							</LoopOpt>
+							<PreExpr classname='ExprValue'>
+								<value/>
+							</PreExpr>
+							<PostExpr classname='ExprValue'>
+								<value/>
+							</PostExpr>
+							<StatusExpr classname='ExprValue'>
+								<value/>
+							</StatusExpr>
+							<CanSpecifyModule classname='Bool'>
+								<value>false</value>
+							</CanSpecifyModule>
+							<CanEditCode classname='Bool'>
+								<value>true</value>
+							</CanEditCode>
+							<CanEditModulePrototype classname='Bool'>
+								<value>true</value>
+							</CanEditModulePrototype>
+							<CanEditParameterAdditionalResults classname='Bool'>
+								<value>true</value>
+							</CanEditParameterAdditionalResults>
+							<PrecondIntExe classname='Num'>
+								<value>0</value>
+							</PrecondIntExe>
+							<Requirements classname='Obj' flagsforinstances='1' valueflags='1' structureflags='2097152'>
+								<subprops>
+									<Links classname='Strs' flagsforinstances='71303168' instanceoverrideflags='72286233' valueflags='71303168'>
+										<value lbound='[0]' ubound='[]'/>
+									</Links>
+								</subprops>
+							</Requirements>
+							<CustomResults classname='Objs'>
+								<value lbound='[0]' ubound='[]'>
+									<elemproto>
+										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+											<subprops>
+												<Name classname='ExprValue'>
+													<value/>
+												</Name>
+												<ValueToLog classname='ExprValue'>
+													<value/>
+												</ValueToLog>
+												<Condition classname='ExprValue'>
+													<value/>
+												</Condition>
+												<Flags classname='Num'>
+													<value>8192</value>
+												</Flags>
+												<CheckedState classname='Num'>
+													<value>2</value>
+												</CheckedState>
+												<Type classname='PropertyObjectType'>
+													<subprops>
+														<ValueType classname='Num'>
+															<value>3</value>
+														</ValueType>
+														<IsObject classname='Bool'>
+															<value>true</value>
+														</IsObject>
+														<TypeName classname='Str'>
+															<value/>
+														</TypeName>
+														<ElementType classname='Objs'>
+															<value lbound='[0]' ubound='[]'/>
+														</ElementType>
+														<ArrayDimensions classname='ArrayDimensions'>
+															<subprops>
+																<LowerBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</LowerBounds>
+																<UpperBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</UpperBounds>
+															</subprops>
+														</ArrayDimensions>
+														<Representation classname='Num'>
+															<value>1</value>
+														</Representation>
+														<ClassName classname='Str'>
+															<value/>
+														</ClassName>
+													</subprops>
+												</Type>
+												<Elements classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</Elements>
+												<IsAnyType classname='Bool'>
+													<value>true</value>
+												</IsAnyType>
+											</subprops>
+										</_NAME_IN_ATTRIBUTE_>
+									</elemproto>
+								</value>
+							</CustomResults>
+							<AdditionalResultsHints classname='Objs'>
+								<value lbound='[0]' ubound='[]'>
+									<elemproto>
+										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+											<subprops>
+												<Name classname='ExprValue'>
+													<value/>
+												</Name>
+												<ValueToLog classname='ExprValue'>
+													<value/>
+												</ValueToLog>
+												<Condition classname='ExprValue'>
+													<value/>
+												</Condition>
+												<Flags classname='Num'>
+													<value>8192</value>
+												</Flags>
+												<CheckedState classname='Num'>
+													<value>2</value>
+												</CheckedState>
+												<Type classname='PropertyObjectType'>
+													<subprops>
+														<ValueType classname='Num'>
+															<value>3</value>
+														</ValueType>
+														<IsObject classname='Bool'>
+															<value>true</value>
+														</IsObject>
+														<TypeName classname='Str'>
+															<value/>
+														</TypeName>
+														<ElementType classname='Objs'>
+															<value lbound='[0]' ubound='[]'/>
+														</ElementType>
+														<ArrayDimensions classname='ArrayDimensions'>
+															<subprops>
+																<LowerBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</LowerBounds>
+																<UpperBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</UpperBounds>
+															</subprops>
+														</ArrayDimensions>
+														<Representation classname='Num'>
+															<value>1</value>
+														</Representation>
+														<ClassName classname='Str'>
+															<value/>
+														</ClassName>
+													</subprops>
+												</Type>
+												<Elements classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</Elements>
+												<IsAnyType classname='Bool'>
+													<value>true</value>
+												</IsAnyType>
+											</subprops>
+										</_NAME_IN_ATTRIBUTE_>
+									</elemproto>
+								</value>
+							</AdditionalResultsHints>
+						</subprops>
+					</TS>
+					<NI_Data typename='StepTypeNIData' xsi:type='StepTypeNIData' classname='Obj'>
+						<subprops>
+							<EditPanels classname='Strs'>
+								<value lbound='[0]' ubound='[0]'>
+									<value arrayindex='[0]'>NIStepTypeControls.dll|NationalInstruments.TestStand.StepTypeControls.StatementTabInfo</value>
+								</value>
+							</EditPanels>
+						</subprops>
+					</NI_Data>
+					<Result classname='Obj' flagsforinstances='4194304' valueflags='4194304'>
+						<subprops>
+							<Error typename='Error' xsi:type='Error' classname='Obj' flagsforinstances='4194304' instanceoverrideflags='4194304' valueflags='4194304'>
+								<subprops>
+									<Code classname='Num'>
+										<value>0</value>
+									</Code>
+									<Msg classname='Str'>
+										<value/>
+									</Msg>
+									<Occurred classname='Bool'>
+										<value>false</value>
+									</Occurred>
+								</subprops>
+							</Error>
+							<Status classname='Str' flagsforinstances='4194304' valueflags='4194304'>
+								<value/>
+							</Status>
+							<ReportText classname='Str' flagsforinstances='4194304' valueflags='4194304'>
+								<value/>
+							</ReportText>
+							<Common typename='CommonResults' xsi:type='CommonResults' classname='Obj' instanceoverrideflags='4194304'/>
+						</subprops>
+					</Result>
+					<CodeTemplates classname='Str' valueflags='4194328' structureflags='524288'>
+						<value/>
+					</CodeTemplates>
+					<BlockStartTypes classname='Str' valueflags='4194328' structureflags='524288'>
+						<value/>
+					</BlockStartTypes>
+					<BlockEndTypes classname='Str' valueflags='4194328' structureflags='524288'>
+						<value/>
+					</BlockEndTypes>
+					<AppliesToBlockStructure classname='Bool' valueflags='4194328' structureflags='524288'>
+						<value>false</value>
+					</AppliesToBlockStructure>
+					<CanEncapsulate classname='Bool' valueflags='4194328' structureflags='524288'>
+						<value>false</value>
+					</CanEncapsulate>
+				</subprops>
+			</Statement>
+		</typedef>
+	</typelist>
+	<Data classname='SequenceFileData' valueflags='4194304'>
+		<subprops>
+			<Seq classname='Objs' valueflags='4194304'>
+				<value lbound='[0]' ubound='[0]'>
+					<value>
+						<Sequence name='MainSequence'>
+							<subprops>
+								<Parameters classname='Obj' valueflags='4456448'/>
+								<Locals classname='Obj' valueflags='4194304'>
+									<subprops>
+										<ResultList classname='Objs' valueflags='4194304'>
+											<value lbound='[0]' ubound='[]'>
+												<elemproto>
+													<_NAME_IN_ATTRIBUTE_ name='' classname='TEResult'/>
+												</elemproto>
+											</value>
+										</ResultList>
+									</subprops>
+								</Locals>
+								<Main classname='Objs' valueflags='4194304'>
+									<value lbound='[0]' ubound='[1]'>
+										<value>
+											<Step typename='NI_Measurement' xsi:type='_CustomStepType_' name='Source DC voltage and measure voltage/current'>
+												<subprops>
+													<TS classname='Obj'>
+														<subprops>
+															<Id classname='Str'>
+																<value>ID#:YGXle+jm7RGhzZiQlrVX7C</value>
+															</Id>
+															<Icon classname='Str'>
+																<value>Measurement\Measurement.ico</value>
+															</Icon>
+															<PreCond classname='ExprValue'>
+																<value/>
+															</PreCond>
+															<LoadOpt classname='Str'>
+																<value>PreloadWhenExecuted</value>
+															</LoadOpt>
+															<UnloadOpt classname='Str'>
+																<value>UnloadWithFile</value>
+															</UnloadOpt>
+															<Mode classname='Str'>
+																<value>Normal</value>
+															</Mode>
+															<WindowActivation classname='Str'>
+																<value>None</value>
+															</WindowActivation>
+															<ResultOption classname='Num'>
+																<value>1</value>
+															</ResultOption>
+															<StepFCSeqF classname='Bool'>
+																<value>true</value>
+															</StepFCSeqF>
+															<IgnoreRTE classname='Bool'>
+																<value>false</value>
+															</IgnoreRTE>
+															<UseMutex classname='Bool'>
+																<value>false</value>
+															</UseMutex>
+															<MutexNameOrRef classname='ExprValue'>
+																<value/>
+															</MutexNameOrRef>
+															<BatchSyncOpt classname='Num'>
+																<value>0</value>
+															</BatchSyncOpt>
+															<SwitchEnabled classname='Bool'>
+																<value>false</value>
+															</SwitchEnabled>
+															<VirtualDeviceName classname='ExprValue'>
+																<value/>
+															</VirtualDeviceName>
+															<SwitchOperation classname='Num'>
+																<value>1</value>
+															</SwitchOperation>
+															<RouteGroupConnect classname='ExprValue'>
+																<value/>
+															</RouteGroupConnect>
+															<RouteGroupDisconnect classname='ExprValue'>
+																<value/>
+															</RouteGroupDisconnect>
+															<MulticonnectMode classname='Num'>
+																<value>1</value>
+															</MulticonnectMode>
+															<OperationOrder classname='Num'>
+																<value>2</value>
+															</OperationOrder>
+															<ConnectionLifetime classname='Num'>
+																<value>4</value>
+															</ConnectionLifetime>
+															<WaitForDebounce classname='Bool'>
+																<value>true</value>
+															</WaitForDebounce>
+															<PassAct classname='Str'>
+																<value>Next</value>
+															</PassAct>
+															<FailAct classname='Str'>
+																<value>Next</value>
+															</FailAct>
+															<PassActTarget classname='ExprValue'>
+																<value/>
+															</PassActTarget>
+															<FailActTarget classname='ExprValue'>
+																<value/>
+															</FailActTarget>
+															<CustExpr classname='ExprValue'>
+																<value/>
+															</CustExpr>
+															<CustTrueAct classname='Str'>
+																<value>Next</value>
+															</CustTrueAct>
+															<CustFalseAct classname='Str'>
+																<value>Next</value>
+															</CustFalseAct>
+															<CustTrueActTarget classname='ExprValue'>
+																<value/>
+															</CustTrueActTarget>
+															<CustFalseActTarget classname='ExprValue'>
+																<value/>
+															</CustFalseActTarget>
+															<LoopType classname='Str'>
+																<value>NoLooping</value>
+															</LoopType>
+															<LoopWhile classname='ExprValue'>
+																<value/>
+															</LoopWhile>
+															<LoopStatus classname='ExprValue'>
+																<value/>
+															</LoopStatus>
+															<LoopIncrement classname='ExprValue'>
+																<value>RunState.LoopIndex += 1</value>
+															</LoopIncrement>
+															<LoopInitialize classname='ExprValue'>
+																<value>RunState.LoopIndex = 0</value>
+															</LoopInitialize>
+															<LoopOpt classname='Num'>
+																<value>0</value>
+															</LoopOpt>
+															<PreExpr classname='ExprValue'>
+																<value/>
+															</PreExpr>
+															<PostExpr classname='ExprValue'>
+																<value/>
+															</PostExpr>
+															<StatusExpr classname='ExprValue'>
+																<value/>
+															</StatusExpr>
+															<CanEditCode classname='Bool'>
+																<value>true</value>
+															</CanEditCode>
+															<CanEditModulePrototype classname='Bool'>
+																<value>true</value>
+															</CanEditModulePrototype>
+															<CanEditParameterAdditionalResults classname='Bool'>
+																<value>true</value>
+															</CanEditParameterAdditionalResults>
+															<PrecondIntExe classname='Num'>
+																<value>0</value>
+															</PrecondIntExe>
+															<CustomResults classname='Objs'>
+																<value lbound='[0]' ubound='[]'>
+																	<elemproto>
+																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+																			<subprops>
+																				<Name classname='ExprValue'>
+																					<value/>
+																				</Name>
+																				<ValueToLog classname='ExprValue'>
+																					<value/>
+																				</ValueToLog>
+																				<Condition classname='ExprValue'>
+																					<value/>
+																				</Condition>
+																				<Flags classname='Num'>
+																					<value>8192</value>
+																				</Flags>
+																				<CheckedState classname='Num'>
+																					<value>2</value>
+																				</CheckedState>
+																				<Type classname='PropertyObjectType'>
+																					<subprops>
+																						<ValueType classname='Num'>
+																							<value>3</value>
+																						</ValueType>
+																						<IsObject classname='Bool'>
+																							<value>true</value>
+																						</IsObject>
+																						<TypeName classname='Str'>
+																							<value/>
+																						</TypeName>
+																						<ElementType classname='Objs'>
+																							<value lbound='[0]' ubound='[]'/>
+																						</ElementType>
+																						<ArrayDimensions classname='ArrayDimensions'>
+																							<subprops>
+																								<LowerBounds classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</LowerBounds>
+																								<UpperBounds classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</UpperBounds>
+																							</subprops>
+																						</ArrayDimensions>
+																						<Representation classname='Num'>
+																							<value>1</value>
+																						</Representation>
+																						<ClassName classname='Str'>
+																							<value/>
+																						</ClassName>
+																					</subprops>
+																				</Type>
+																				<Elements classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</Elements>
+																				<IsAnyType classname='Bool'>
+																					<value>true</value>
+																				</IsAnyType>
+																			</subprops>
+																		</_NAME_IN_ATTRIBUTE_>
+																	</elemproto>
+																</value>
+															</CustomResults>
+															<AdditionalResultsHints classname='Objs'>
+																<value lbound='[0]' ubound='[]'>
+																	<elemproto>
+																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+																			<subprops>
+																				<Name classname='ExprValue'>
+																					<value/>
+																				</Name>
+																				<ValueToLog classname='ExprValue'>
+																					<value/>
+																				</ValueToLog>
+																				<Condition classname='ExprValue'>
+																					<value/>
+																				</Condition>
+																				<Flags classname='Num'>
+																					<value>8192</value>
+																				</Flags>
+																				<CheckedState classname='Num'>
+																					<value>2</value>
+																				</CheckedState>
+																				<Type classname='PropertyObjectType'>
+																					<subprops>
+																						<ValueType classname='Num'>
+																							<value>3</value>
+																						</ValueType>
+																						<IsObject classname='Bool'>
+																							<value>true</value>
+																						</IsObject>
+																						<TypeName classname='Str'>
+																							<value/>
+																						</TypeName>
+																						<ElementType classname='Objs'>
+																							<value lbound='[0]' ubound='[]'/>
+																						</ElementType>
+																						<ArrayDimensions classname='ArrayDimensions'>
+																							<subprops>
+																								<LowerBounds classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</LowerBounds>
+																								<UpperBounds classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</UpperBounds>
+																							</subprops>
+																						</ArrayDimensions>
+																						<Representation classname='Num'>
+																							<value>1</value>
+																						</Representation>
+																						<ClassName classname='Str'>
+																							<value/>
+																						</ClassName>
+																					</subprops>
+																				</Type>
+																				<Elements classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</Elements>
+																				<IsAnyType classname='Bool'>
+																					<value>true</value>
+																				</IsAnyType>
+																			</subprops>
+																		</_NAME_IN_ATTRIBUTE_>
+																	</elemproto>
+																</value>
+															</AdditionalResultsHints>
+														</subprops>
+													</TS>
+													<Result classname='Obj'>
+														<subprops>
+															<Error classname='Obj'>
+																<subprops>
+																	<Code classname='Num'>
+																		<value>0</value>
+																	</Code>
+																	<Msg classname='Str'>
+																		<value/>
+																	</Msg>
+																	<Occurred classname='Bool'>
+																		<value>false</value>
+																	</Occurred>
+																</subprops>
+															</Error>
+															<Status classname='Str'>
+																<value/>
+															</Status>
+															<ReportText classname='Str'>
+																<value/>
+															</ReportText>
+															<Common classname='Obj'/>
+														</subprops>
+													</Result>
+													<Measurement classname='Obj'>
+														<subprops>
+															<Name classname='Str'>
+																<value>ni.examples.NIDCPowerSourceDCVoltage_Python</value>
+															</Name>
+															<Parameters classname='Objs'>
+																<value lbound='[0]' ubound='[10]'>
+																	<elemproto>
+																		<_NAME_IN_ATTRIBUTE_ name='' classname='Obj'>
+																			<subprops>
+																				<Name classname='Str'>
+																					<value/>
+																				</Name>
+																				<ArgumentValue classname='ExprValue'>
+																					<value/>
+																				</ArgumentValue>
+																				<Direction classname='Str'>
+																					<value/>
+																				</Direction>
+																				<Log classname='Bool'>
+																					<value>false</value>
+																				</Log>
+																				<Dimension classname='Num'>
+																					<value representation='UInt64'>0</value>
+																				</Dimension>
+																				<Type classname='Str'>
+																					<value/>
+																				</Type>
+																				<ID classname='Num'>
+																					<value representation='Int64'>0</value>
+																				</ID>
+																				<TypeSpecialization classname='Str'>
+																					<value/>
+																				</TypeSpecialization>
+																			</subprops>
+																		</_NAME_IN_ATTRIBUTE_>
+																	</elemproto>
+																	<value>
+																		<Obj typename='NI_MeasurementParameter' name=''>
+																			<subprops>
+																				<Name classname='Str'>
+																					<value>pin_names</value>
+																				</Name>
+																				<ArgumentValue classname='ExprValue'>
+																					<value>{"Pin1"}</value>
+																				</ArgumentValue>
+																				<Direction classname='Str'>
+																					<value>In</value>
+																				</Direction>
+																				<Log classname='Bool'>
+																					<value>true</value>
+																				</Log>
+																				<Dimension classname='Num'>
+																					<value representation='UInt64'>1</value>
+																				</Dimension>
+																				<Type classname='Str'>
+																					<value>TypeString</value>
+																				</Type>
+																				<ID classname='Num'>
+																					<value representation='Int64'>1</value>
+																				</ID>
+																				<TypeSpecialization classname='Str'>
+																					<value>Pin</value>
+																				</TypeSpecialization>
+																			</subprops>
+																		</Obj>
+																	</value>
+																	<value>
+																		<Obj typename='NI_MeasurementParameter' name=''>
+																			<subprops>
+																				<Name classname='Str'>
+																					<value>voltage_level</value>
+																				</Name>
+																				<ArgumentValue classname='ExprValue'>
+																					<value>6</value>
+																				</ArgumentValue>
+																				<Direction classname='Str'>
+																					<value>In</value>
+																				</Direction>
+																				<Log classname='Bool'>
+																					<value>true</value>
+																				</Log>
+																				<Dimension classname='Num'>
+																					<value representation='UInt64'>0</value>
+																				</Dimension>
+																				<Type classname='Str'>
+																					<value>TypeDouble</value>
+																				</Type>
+																				<ID classname='Num'>
+																					<value representation='Int64'>2</value>
+																				</ID>
+																				<TypeSpecialization classname='Str'>
+																					<value>None</value>
+																				</TypeSpecialization>
+																			</subprops>
+																		</Obj>
+																	</value>
+																	<value>
+																		<Obj typename='NI_MeasurementParameter' name=''>
+																			<subprops>
+																				<Name classname='Str'>
+																					<value>voltage_level_range</value>
+																				</Name>
+																				<ArgumentValue classname='ExprValue'>
+																					<value>6</value>
+																				</ArgumentValue>
+																				<Direction classname='Str'>
+																					<value>In</value>
+																				</Direction>
+																				<Log classname='Bool'>
+																					<value>true</value>
+																				</Log>
+																				<Dimension classname='Num'>
+																					<value representation='UInt64'>0</value>
+																				</Dimension>
+																				<Type classname='Str'>
+																					<value>TypeDouble</value>
+																				</Type>
+																				<ID classname='Num'>
+																					<value representation='Int64'>3</value>
+																				</ID>
+																				<TypeSpecialization classname='Str'>
+																					<value>None</value>
+																				</TypeSpecialization>
+																			</subprops>
+																		</Obj>
+																	</value>
+																	<value>
+																		<Obj typename='NI_MeasurementParameter' name=''>
+																			<subprops>
+																				<Name classname='Str'>
+																					<value>current_limit</value>
+																				</Name>
+																				<ArgumentValue classname='ExprValue'>
+																					<value>0.01</value>
+																				</ArgumentValue>
+																				<Direction classname='Str'>
+																					<value>In</value>
+																				</Direction>
+																				<Log classname='Bool'>
+																					<value>true</value>
+																				</Log>
+																				<Dimension classname='Num'>
+																					<value representation='UInt64'>0</value>
+																				</Dimension>
+																				<Type classname='Str'>
+																					<value>TypeDouble</value>
+																				</Type>
+																				<ID classname='Num'>
+																					<value representation='Int64'>4</value>
+																				</ID>
+																				<TypeSpecialization classname='Str'>
+																					<value>None</value>
+																				</TypeSpecialization>
+																			</subprops>
+																		</Obj>
+																	</value>
+																	<value>
+																		<Obj typename='NI_MeasurementParameter' name=''>
+																			<subprops>
+																				<Name classname='Str'>
+																					<value>current_limit_range</value>
+																				</Name>
+																				<ArgumentValue classname='ExprValue'>
+																					<value>0.01</value>
+																				</ArgumentValue>
+																				<Direction classname='Str'>
+																					<value>In</value>
+																				</Direction>
+																				<Log classname='Bool'>
+																					<value>true</value>
+																				</Log>
+																				<Dimension classname='Num'>
+																					<value representation='UInt64'>0</value>
+																				</Dimension>
+																				<Type classname='Str'>
+																					<value>TypeDouble</value>
+																				</Type>
+																				<ID classname='Num'>
+																					<value representation='Int64'>5</value>
+																				</ID>
+																				<TypeSpecialization classname='Str'>
+																					<value>None</value>
+																				</TypeSpecialization>
+																			</subprops>
+																		</Obj>
+																	</value>
+																	<value>
+																		<Obj typename='NI_MeasurementParameter' name=''>
+																			<subprops>
+																				<Name classname='Str'>
+																					<value>source_delay</value>
+																				</Name>
+																				<ArgumentValue classname='ExprValue'>
+																					<value>0</value>
+																				</ArgumentValue>
+																				<Direction classname='Str'>
+																					<value>In</value>
+																				</Direction>
+																				<Log classname='Bool'>
+																					<value>true</value>
+																				</Log>
+																				<Dimension classname='Num'>
+																					<value representation='UInt64'>0</value>
+																				</Dimension>
+																				<Type classname='Str'>
+																					<value>TypeDouble</value>
+																				</Type>
+																				<ID classname='Num'>
+																					<value representation='Int64'>6</value>
+																				</ID>
+																				<TypeSpecialization classname='Str'>
+																					<value>None</value>
+																				</TypeSpecialization>
+																			</subprops>
+																		</Obj>
+																	</value>
+																	<value>
+																		<Obj typename='NI_MeasurementParameter' name=''>
+																			<subprops>
+																				<Name classname='Str'>
+																					<value>measurement_sites</value>
+																				</Name>
+																				<ArgumentValue classname='ExprValue'>
+																					<value/>
+																				</ArgumentValue>
+																				<Direction classname='Str'>
+																					<value>Out</value>
+																				</Direction>
+																				<Log classname='Bool'>
+																					<value>true</value>
+																				</Log>
+																				<Dimension classname='Num'>
+																					<value representation='UInt64'>1</value>
+																				</Dimension>
+																				<Type classname='Str'>
+																					<value>TypeInt32</value>
+																				</Type>
+																				<ID classname='Num'>
+																					<value representation='Int64'>1</value>
+																				</ID>
+																				<TypeSpecialization classname='Str'>
+																					<value>None</value>
+																				</TypeSpecialization>
+																			</subprops>
+																		</Obj>
+																	</value>
+																	<value>
+																		<Obj typename='NI_MeasurementParameter' name=''>
+																			<subprops>
+																				<Name classname='Str'>
+																					<value>measurement_pin_names</value>
+																				</Name>
+																				<ArgumentValue classname='ExprValue'>
+																					<value/>
+																				</ArgumentValue>
+																				<Direction classname='Str'>
+																					<value>Out</value>
+																				</Direction>
+																				<Log classname='Bool'>
+																					<value>true</value>
+																				</Log>
+																				<Dimension classname='Num'>
+																					<value representation='UInt64'>1</value>
+																				</Dimension>
+																				<Type classname='Str'>
+																					<value>TypeString</value>
+																				</Type>
+																				<ID classname='Num'>
+																					<value representation='Int64'>2</value>
+																				</ID>
+																				<TypeSpecialization classname='Str'>
+																					<value>None</value>
+																				</TypeSpecialization>
+																			</subprops>
+																		</Obj>
+																	</value>
+																	<value>
+																		<Obj typename='NI_MeasurementParameter' name=''>
+																			<subprops>
+																				<Name classname='Str'>
+																					<value>voltage_measurements</value>
+																				</Name>
+																				<ArgumentValue classname='ExprValue'>
+																					<value/>
+																				</ArgumentValue>
+																				<Direction classname='Str'>
+																					<value>Out</value>
+																				</Direction>
+																				<Log classname='Bool'>
+																					<value>true</value>
+																				</Log>
+																				<Dimension classname='Num'>
+																					<value representation='UInt64'>1</value>
+																				</Dimension>
+																				<Type classname='Str'>
+																					<value>TypeDouble</value>
+																				</Type>
+																				<ID classname='Num'>
+																					<value representation='Int64'>3</value>
+																				</ID>
+																				<TypeSpecialization classname='Str'>
+																					<value>None</value>
+																				</TypeSpecialization>
+																			</subprops>
+																		</Obj>
+																	</value>
+																	<value>
+																		<Obj typename='NI_MeasurementParameter' name=''>
+																			<subprops>
+																				<Name classname='Str'>
+																					<value>current_measurements</value>
+																				</Name>
+																				<ArgumentValue classname='ExprValue'>
+																					<value/>
+																				</ArgumentValue>
+																				<Direction classname='Str'>
+																					<value>Out</value>
+																				</Direction>
+																				<Log classname='Bool'>
+																					<value>true</value>
+																				</Log>
+																				<Dimension classname='Num'>
+																					<value representation='UInt64'>1</value>
+																				</Dimension>
+																				<Type classname='Str'>
+																					<value>TypeDouble</value>
+																				</Type>
+																				<ID classname='Num'>
+																					<value representation='Int64'>4</value>
+																				</ID>
+																				<TypeSpecialization classname='Str'>
+																					<value>None</value>
+																				</TypeSpecialization>
+																			</subprops>
+																		</Obj>
+																	</value>
+																	<value>
+																		<Obj typename='NI_MeasurementParameter' name=''>
+																			<subprops>
+																				<Name classname='Str'>
+																					<value>in_compliance</value>
+																				</Name>
+																				<ArgumentValue classname='ExprValue'>
+																					<value/>
+																				</ArgumentValue>
+																				<Direction classname='Str'>
+																					<value>Out</value>
+																				</Direction>
+																				<Log classname='Bool'>
+																					<value>true</value>
+																				</Log>
+																				<Dimension classname='Num'>
+																					<value representation='UInt64'>1</value>
+																				</Dimension>
+																				<Type classname='Str'>
+																					<value>TypeBool</value>
+																				</Type>
+																				<ID classname='Num'>
+																					<value representation='Int64'>5</value>
+																				</ID>
+																				<TypeSpecialization classname='Str'>
+																					<value>None</value>
+																				</TypeSpecialization>
+																			</subprops>
+																		</Obj>
+																	</value>
+																</value>
+															</Parameters>
+														</subprops>
+													</Measurement>
+												</subprops>
+											</Step>
+										</value>
+										<value>
+											<Step typename='NI_Measurement' xsi:type='_CustomStepType_' name='Perform a measurement using an NI DMM'>
+												<subprops>
+													<TS classname='Obj'>
+														<subprops>
+															<Id classname='Str'>
+																<value>ID#:1m8fotxw7RGuNrjdh1OqZD</value>
+															</Id>
+															<Icon classname='Str'>
+																<value>Measurement\Measurement.ico</value>
+															</Icon>
+															<PreCond classname='ExprValue'>
+																<value/>
+															</PreCond>
+															<LoadOpt classname='Str'>
+																<value>PreloadWhenExecuted</value>
+															</LoadOpt>
+															<UnloadOpt classname='Str'>
+																<value>UnloadWithFile</value>
+															</UnloadOpt>
+															<Mode classname='Str'>
+																<value>Normal</value>
+															</Mode>
+															<WindowActivation classname='Str'>
+																<value>None</value>
+															</WindowActivation>
+															<ResultOption classname='Num'>
+																<value>1</value>
+															</ResultOption>
+															<StepFCSeqF classname='Bool'>
+																<value>true</value>
+															</StepFCSeqF>
+															<IgnoreRTE classname='Bool'>
+																<value>false</value>
+															</IgnoreRTE>
+															<UseMutex classname='Bool'>
+																<value>false</value>
+															</UseMutex>
+															<MutexNameOrRef classname='ExprValue'>
+																<value/>
+															</MutexNameOrRef>
+															<BatchSyncOpt classname='Num'>
+																<value>0</value>
+															</BatchSyncOpt>
+															<SwitchEnabled classname='Bool'>
+																<value>false</value>
+															</SwitchEnabled>
+															<VirtualDeviceName classname='ExprValue'>
+																<value/>
+															</VirtualDeviceName>
+															<SwitchOperation classname='Num'>
+																<value>1</value>
+															</SwitchOperation>
+															<RouteGroupConnect classname='ExprValue'>
+																<value/>
+															</RouteGroupConnect>
+															<RouteGroupDisconnect classname='ExprValue'>
+																<value/>
+															</RouteGroupDisconnect>
+															<MulticonnectMode classname='Num'>
+																<value>1</value>
+															</MulticonnectMode>
+															<OperationOrder classname='Num'>
+																<value>2</value>
+															</OperationOrder>
+															<ConnectionLifetime classname='Num'>
+																<value>4</value>
+															</ConnectionLifetime>
+															<WaitForDebounce classname='Bool'>
+																<value>true</value>
+															</WaitForDebounce>
+															<PassAct classname='Str'>
+																<value>Next</value>
+															</PassAct>
+															<FailAct classname='Str'>
+																<value>Next</value>
+															</FailAct>
+															<PassActTarget classname='ExprValue'>
+																<value/>
+															</PassActTarget>
+															<FailActTarget classname='ExprValue'>
+																<value/>
+															</FailActTarget>
+															<CustExpr classname='ExprValue'>
+																<value/>
+															</CustExpr>
+															<CustTrueAct classname='Str'>
+																<value>Next</value>
+															</CustTrueAct>
+															<CustFalseAct classname='Str'>
+																<value>Next</value>
+															</CustFalseAct>
+															<CustTrueActTarget classname='ExprValue'>
+																<value/>
+															</CustTrueActTarget>
+															<CustFalseActTarget classname='ExprValue'>
+																<value/>
+															</CustFalseActTarget>
+															<LoopType classname='Str'>
+																<value>NoLooping</value>
+															</LoopType>
+															<LoopWhile classname='ExprValue'>
+																<value/>
+															</LoopWhile>
+															<LoopStatus classname='ExprValue'>
+																<value/>
+															</LoopStatus>
+															<LoopIncrement classname='ExprValue'>
+																<value>RunState.LoopIndex += 1</value>
+															</LoopIncrement>
+															<LoopInitialize classname='ExprValue'>
+																<value>RunState.LoopIndex = 0</value>
+															</LoopInitialize>
+															<LoopOpt classname='Num'>
+																<value>0</value>
+															</LoopOpt>
+															<PreExpr classname='ExprValue'>
+																<value/>
+															</PreExpr>
+															<PostExpr classname='ExprValue'>
+																<value/>
+															</PostExpr>
+															<StatusExpr classname='ExprValue'>
+																<value/>
+															</StatusExpr>
+															<CanEditCode classname='Bool'>
+																<value>true</value>
+															</CanEditCode>
+															<CanEditModulePrototype classname='Bool'>
+																<value>true</value>
+															</CanEditModulePrototype>
+															<CanEditParameterAdditionalResults classname='Bool'>
+																<value>true</value>
+															</CanEditParameterAdditionalResults>
+															<PrecondIntExe classname='Num'>
+																<value>0</value>
+															</PrecondIntExe>
+															<CustomResults classname='Objs'>
+																<value lbound='[0]' ubound='[]'>
+																	<elemproto>
+																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+																			<subprops>
+																				<Name classname='ExprValue'>
+																					<value/>
+																				</Name>
+																				<ValueToLog classname='ExprValue'>
+																					<value/>
+																				</ValueToLog>
+																				<Condition classname='ExprValue'>
+																					<value/>
+																				</Condition>
+																				<Flags classname='Num'>
+																					<value>8192</value>
+																				</Flags>
+																				<CheckedState classname='Num'>
+																					<value>2</value>
+																				</CheckedState>
+																				<Type classname='PropertyObjectType'>
+																					<subprops>
+																						<ValueType classname='Num'>
+																							<value>3</value>
+																						</ValueType>
+																						<IsObject classname='Bool'>
+																							<value>true</value>
+																						</IsObject>
+																						<TypeName classname='Str'>
+																							<value/>
+																						</TypeName>
+																						<ElementType classname='Objs'>
+																							<value lbound='[0]' ubound='[]'/>
+																						</ElementType>
+																						<ArrayDimensions classname='ArrayDimensions'>
+																							<subprops>
+																								<LowerBounds classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</LowerBounds>
+																								<UpperBounds classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</UpperBounds>
+																							</subprops>
+																						</ArrayDimensions>
+																						<Representation classname='Num'>
+																							<value>1</value>
+																						</Representation>
+																						<ClassName classname='Str'>
+																							<value/>
+																						</ClassName>
+																					</subprops>
+																				</Type>
+																				<Elements classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</Elements>
+																				<IsAnyType classname='Bool'>
+																					<value>true</value>
+																				</IsAnyType>
+																			</subprops>
+																		</_NAME_IN_ATTRIBUTE_>
+																	</elemproto>
+																</value>
+															</CustomResults>
+															<AdditionalResultsHints classname='Objs'>
+																<value lbound='[0]' ubound='[]'>
+																	<elemproto>
+																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+																			<subprops>
+																				<Name classname='ExprValue'>
+																					<value/>
+																				</Name>
+																				<ValueToLog classname='ExprValue'>
+																					<value/>
+																				</ValueToLog>
+																				<Condition classname='ExprValue'>
+																					<value/>
+																				</Condition>
+																				<Flags classname='Num'>
+																					<value>8192</value>
+																				</Flags>
+																				<CheckedState classname='Num'>
+																					<value>2</value>
+																				</CheckedState>
+																				<Type classname='PropertyObjectType'>
+																					<subprops>
+																						<ValueType classname='Num'>
+																							<value>3</value>
+																						</ValueType>
+																						<IsObject classname='Bool'>
+																							<value>true</value>
+																						</IsObject>
+																						<TypeName classname='Str'>
+																							<value/>
+																						</TypeName>
+																						<ElementType classname='Objs'>
+																							<value lbound='[0]' ubound='[]'/>
+																						</ElementType>
+																						<ArrayDimensions classname='ArrayDimensions'>
+																							<subprops>
+																								<LowerBounds classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</LowerBounds>
+																								<UpperBounds classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</UpperBounds>
+																							</subprops>
+																						</ArrayDimensions>
+																						<Representation classname='Num'>
+																							<value>1</value>
+																						</Representation>
+																						<ClassName classname='Str'>
+																							<value/>
+																						</ClassName>
+																					</subprops>
+																				</Type>
+																				<Elements classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</Elements>
+																				<IsAnyType classname='Bool'>
+																					<value>true</value>
+																				</IsAnyType>
+																			</subprops>
+																		</_NAME_IN_ATTRIBUTE_>
+																	</elemproto>
+																</value>
+															</AdditionalResultsHints>
+														</subprops>
+													</TS>
+													<Result classname='Obj'>
+														<subprops>
+															<Error classname='Obj'>
+																<subprops>
+																	<Code classname='Num'>
+																		<value>0</value>
+																	</Code>
+																	<Msg classname='Str'>
+																		<value/>
+																	</Msg>
+																	<Occurred classname='Bool'>
+																		<value>false</value>
+																	</Occurred>
+																</subprops>
+															</Error>
+															<Status classname='Str'>
+																<value/>
+															</Status>
+															<ReportText classname='Str'>
+																<value/>
+															</ReportText>
+															<Common classname='Obj'/>
+														</subprops>
+													</Result>
+													<Measurement classname='Obj'>
+														<subprops>
+															<Name classname='Str'>
+																<value>ni.examples.NIDmmMeasurement_Python</value>
+															</Name>
+															<Parameters classname='Objs'>
+																<value lbound='[0]' ubound='[6]'>
+																	<elemproto>
+																		<_NAME_IN_ATTRIBUTE_ name='' classname='Obj'>
+																			<subprops>
+																				<Name classname='Str'>
+																					<value/>
+																				</Name>
+																				<ArgumentValue classname='ExprValue'>
+																					<value/>
+																				</ArgumentValue>
+																				<Direction classname='Str'>
+																					<value/>
+																				</Direction>
+																				<Log classname='Bool'>
+																					<value>false</value>
+																				</Log>
+																				<Dimension classname='Num'>
+																					<value representation='UInt64'>0</value>
+																				</Dimension>
+																				<Type classname='Str'>
+																					<value/>
+																				</Type>
+																				<ID classname='Num'>
+																					<value representation='Int64'>0</value>
+																				</ID>
+																				<TypeSpecialization classname='Str'>
+																					<value/>
+																				</TypeSpecialization>
+																			</subprops>
+																		</_NAME_IN_ATTRIBUTE_>
+																	</elemproto>
+																	<value>
+																		<Obj typename='NI_MeasurementParameter' name=''>
+																			<subprops>
+																				<Name classname='Str'>
+																					<value>pin_name</value>
+																				</Name>
+																				<ArgumentValue classname='ExprValue'>
+																					<value>"Pin2"</value>
+																				</ArgumentValue>
+																				<Direction classname='Str'>
+																					<value>In</value>
+																				</Direction>
+																				<Log classname='Bool'>
+																					<value>false</value>
+																				</Log>
+																				<Dimension classname='Num'>
+																					<value representation='UInt64'>0</value>
+																				</Dimension>
+																				<Type classname='Str'>
+																					<value>TypeString</value>
+																				</Type>
+																				<ID classname='Num'>
+																					<value representation='Int64'>1</value>
+																				</ID>
+																				<TypeSpecialization classname='Str'>
+																					<value>Pin</value>
+																				</TypeSpecialization>
+																			</subprops>
+																		</Obj>
+																	</value>
+																	<value>
+																		<Obj typename='NI_MeasurementParameter' name=''>
+																			<subprops>
+																				<Name classname='Str'>
+																					<value>measurement_type</value>
+																				</Name>
+																				<ArgumentValue classname='ExprValue'>
+																					<value>"DC Volts"</value>
+																				</ArgumentValue>
+																				<Direction classname='Str'>
+																					<value>In</value>
+																				</Direction>
+																				<Log classname='Bool'>
+																					<value>false</value>
+																				</Log>
+																				<Dimension classname='Num'>
+																					<value representation='UInt64'>0</value>
+																				</Dimension>
+																				<Type classname='Str'>
+																					<value>TypeString</value>
+																				</Type>
+																				<ID classname='Num'>
+																					<value representation='Int64'>2</value>
+																				</ID>
+																				<TypeSpecialization classname='Str'>
+																					<value>None</value>
+																				</TypeSpecialization>
+																			</subprops>
+																		</Obj>
+																	</value>
+																	<value>
+																		<Obj typename='NI_MeasurementParameter' name=''>
+																			<subprops>
+																				<Name classname='Str'>
+																					<value>range</value>
+																				</Name>
+																				<ArgumentValue classname='ExprValue'>
+																					<value>10</value>
+																				</ArgumentValue>
+																				<Direction classname='Str'>
+																					<value>In</value>
+																				</Direction>
+																				<Log classname='Bool'>
+																					<value>false</value>
+																				</Log>
+																				<Dimension classname='Num'>
+																					<value representation='UInt64'>0</value>
+																				</Dimension>
+																				<Type classname='Str'>
+																					<value>TypeDouble</value>
+																				</Type>
+																				<ID classname='Num'>
+																					<value representation='Int64'>3</value>
+																				</ID>
+																				<TypeSpecialization classname='Str'>
+																					<value>None</value>
+																				</TypeSpecialization>
+																			</subprops>
+																		</Obj>
+																	</value>
+																	<value>
+																		<Obj typename='NI_MeasurementParameter' name=''>
+																			<subprops>
+																				<Name classname='Str'>
+																					<value>resolution_digits</value>
+																				</Name>
+																				<ArgumentValue classname='ExprValue'>
+																					<value>5.5</value>
+																				</ArgumentValue>
+																				<Direction classname='Str'>
+																					<value>In</value>
+																				</Direction>
+																				<Log classname='Bool'>
+																					<value>false</value>
+																				</Log>
+																				<Dimension classname='Num'>
+																					<value representation='UInt64'>0</value>
+																				</Dimension>
+																				<Type classname='Str'>
+																					<value>TypeDouble</value>
+																				</Type>
+																				<ID classname='Num'>
+																					<value representation='Int64'>4</value>
+																				</ID>
+																				<TypeSpecialization classname='Str'>
+																					<value>None</value>
+																				</TypeSpecialization>
+																			</subprops>
+																		</Obj>
+																	</value>
+																	<value>
+																		<Obj typename='NI_MeasurementParameter' name=''>
+																			<subprops>
+																				<Name classname='Str'>
+																					<value>measured_value</value>
+																				</Name>
+																				<ArgumentValue classname='ExprValue'>
+																					<value/>
+																				</ArgumentValue>
+																				<Direction classname='Str'>
+																					<value>Out</value>
+																				</Direction>
+																				<Log classname='Bool'>
+																					<value>true</value>
+																				</Log>
+																				<Dimension classname='Num'>
+																					<value representation='UInt64'>0</value>
+																				</Dimension>
+																				<Type classname='Str'>
+																					<value>TypeDouble</value>
+																				</Type>
+																				<ID classname='Num'>
+																					<value representation='Int64'>1</value>
+																				</ID>
+																				<TypeSpecialization classname='Str'>
+																					<value>None</value>
+																				</TypeSpecialization>
+																			</subprops>
+																		</Obj>
+																	</value>
+																	<value>
+																		<Obj typename='NI_MeasurementParameter' name=''>
+																			<subprops>
+																				<Name classname='Str'>
+																					<value>signal_out_of_range</value>
+																				</Name>
+																				<ArgumentValue classname='ExprValue'>
+																					<value/>
+																				</ArgumentValue>
+																				<Direction classname='Str'>
+																					<value>Out</value>
+																				</Direction>
+																				<Log classname='Bool'>
+																					<value>true</value>
+																				</Log>
+																				<Dimension classname='Num'>
+																					<value representation='UInt64'>0</value>
+																				</Dimension>
+																				<Type classname='Str'>
+																					<value>TypeBool</value>
+																				</Type>
+																				<ID classname='Num'>
+																					<value representation='Int64'>2</value>
+																				</ID>
+																				<TypeSpecialization classname='Str'>
+																					<value>None</value>
+																				</TypeSpecialization>
+																			</subprops>
+																		</Obj>
+																	</value>
+																	<value>
+																		<Obj typename='NI_MeasurementParameter' name=''>
+																			<subprops>
+																				<Name classname='Str'>
+																					<value>absolute_resolution</value>
+																				</Name>
+																				<ArgumentValue classname='ExprValue'>
+																					<value/>
+																				</ArgumentValue>
+																				<Direction classname='Str'>
+																					<value>Out</value>
+																				</Direction>
+																				<Log classname='Bool'>
+																					<value>true</value>
+																				</Log>
+																				<Dimension classname='Num'>
+																					<value representation='UInt64'>0</value>
+																				</Dimension>
+																				<Type classname='Str'>
+																					<value>TypeDouble</value>
+																				</Type>
+																				<ID classname='Num'>
+																					<value representation='Int64'>3</value>
+																				</ID>
+																				<TypeSpecialization classname='Str'>
+																					<value>None</value>
+																				</TypeSpecialization>
+																			</subprops>
+																		</Obj>
+																	</value>
+																</value>
+															</Parameters>
+														</subprops>
+													</Measurement>
+												</subprops>
+											</Step>
+										</value>
+									</value>
+								</Main>
+								<Setup classname='Objs' valueflags='4194304'>
+									<value lbound='[0]' ubound='[2]'>
+										<value>
+											<Step typename='Action' xsi:type='Action' name='Update pin map'>
+												<subprops>
+													<TS classname='Obj'>
+														<subprops>
+															<Id classname='Str'>
+																<value>ID#:+fh2fubm7RGhzZiQlrVX7C</value>
+															</Id>
+															<Icon classname='Str'>
+																<value/>
+															</Icon>
+															<SData typename='PythonStepAdditions' xsi:type='PythonStepAdditions' classname='CPythonModule'>
+																<subprops>
+																	<PythonCall classname='CPythonCall'>
+																		<subprops>
+																			<UseAdapterSettingsForInterpreterSession classname='Bool'>
+																				<value>false</value>
+																			</UseAdapterSettingsForInterpreterSession>
+																			<InterpreterSessionScope classname='Num'>
+																				<value>2</value>
+																			</InterpreterSessionScope>
+																			<PythonVersion classname='Str'>
+																				<value>3.9</value>
+																			</PythonVersion>
+																			<PythonVirtualEnvironmentPath classname='Str'>
+																				<value>.venv</value>
+																			</PythonVirtualEnvironmentPath>
+																			<InterpreterLocation classname='ExprValue'>
+																				<value/>
+																			</InterpreterLocation>
+																			<CreateIfInterpreterDoesNotExist classname='Bool'>
+																				<value>true</value>
+																			</CreateIfInterpreterDoesNotExist>
+																			<ModulePath classname='PathValue'>
+																				<value>teststand_pin_map.py</value>
+																			</ModulePath>
+																			<OperationType classname='Num'>
+																				<value>1</value>
+																			</OperationType>
+																			<OperationScope classname='Num'>
+																				<value>0</value>
+																			</OperationScope>
+																			<ClassName classname='Str'>
+																				<value/>
+																			</ClassName>
+																			<ClassInstanceLocation classname='ExprValue'>
+																				<value/>
+																			</ClassInstanceLocation>
+																			<FunctionOrAttributeName classname='Str'>
+																				<value>update_pin_map</value>
+																			</FunctionOrAttributeName>
+																			<Parameters classname='Objs'>
+																				<value lbound='[0]' ubound='[2]'>
+																					<elemproto>
+																						<_NAME_IN_ATTRIBUTE_ name='' classname='CPythonParameter' structureflags='0'/>
+																					</elemproto>
+																					<value>
+																						<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
+																							<subprops>
+																								<Name classname='Str'>
+																									<value>Return Value</value>
+																								</Name>
+																								<Type classname='Num'>
+																									<value>7</value>
+																								</Type>
+																								<ArgumentValue classname='ExprValue'>
+																									<value/>
+																								</ArgumentValue>
+																								<ArgumentDisplayValue classname='ExprValue'>
+																									<value/>
+																								</ArgumentDisplayValue>
+																								<AdditionalResults classname='Obj'>
+																									<subprops>
+																										<Input classname='PythonParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
+																													<value>1</value>
+																												</CheckedState>
+																											</subprops>
+																										</Input>
+																										<Output classname='PythonParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
+																													<value>1</value>
+																												</CheckedState>
+																											</subprops>
+																										</Output>
+																									</subprops>
+																								</AdditionalResults>
+																							</subprops>
+																						</CPythonParameter>
+																					</value>
+																					<value>
+																						<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
+																							<subprops>
+																								<Name classname='Str'>
+																									<value>pin_map_path</value>
+																								</Name>
+																								<Type classname='Num'>
+																									<value>7</value>
+																								</Type>
+																								<ArgumentValue classname='ExprValue'>
+																									<value>FileGlobals.MeasurementLink.PinMapPath</value>
+																								</ArgumentValue>
+																								<ArgumentDisplayValue classname='ExprValue'>
+																									<value/>
+																								</ArgumentDisplayValue>
+																								<AdditionalResults classname='Obj'>
+																									<subprops>
+																										<Input classname='PythonParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
+																													<value>1</value>
+																												</CheckedState>
+																											</subprops>
+																										</Input>
+																										<Output classname='PythonParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
+																													<value>1</value>
+																												</CheckedState>
+																											</subprops>
+																										</Output>
+																									</subprops>
+																								</AdditionalResults>
+																							</subprops>
+																						</CPythonParameter>
+																					</value>
+																					<value>
+																						<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
+																							<subprops>
+																								<Name classname='Str'>
+																									<value>sequence_context</value>
+																								</Name>
+																								<Type classname='Num'>
+																									<value>7</value>
+																								</Type>
+																								<ArgumentValue classname='ExprValue'>
+																									<value>ThisContext</value>
+																								</ArgumentValue>
+																								<ArgumentDisplayValue classname='ExprValue'>
+																									<value/>
+																								</ArgumentDisplayValue>
+																								<AdditionalResults classname='Obj'>
+																									<subprops>
+																										<Input classname='PythonParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
+																													<value>1</value>
+																												</CheckedState>
+																											</subprops>
+																										</Input>
+																										<Output classname='PythonParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
+																													<value>1</value>
+																												</CheckedState>
+																											</subprops>
+																										</Output>
+																									</subprops>
+																								</AdditionalResults>
+																							</subprops>
+																						</CPythonParameter>
+																					</value>
+																				</value>
+																			</Parameters>
+																			<DefaultParamCategoryForArray classname='Num'>
+																				<value>5</value>
+																			</DefaultParamCategoryForArray>
+																		</subprops>
+																	</PythonCall>
+																</subprops>
+															</SData>
+															<PreCond classname='ExprValue'>
+																<value/>
+															</PreCond>
+															<LoadOpt classname='Str'>
+																<value>PreloadWhenExecuted</value>
+															</LoadOpt>
+															<UnloadOpt classname='Str'>
+																<value>UnloadWithFile</value>
+															</UnloadOpt>
+															<Mode classname='Str'>
+																<value>Normal</value>
+															</Mode>
+															<WindowActivation classname='Str'>
+																<value>None</value>
+															</WindowActivation>
+															<ResultOption classname='Num'>
+																<value>1</value>
+															</ResultOption>
+															<StepFCSeqF classname='Bool'>
+																<value>true</value>
+															</StepFCSeqF>
+															<IgnoreRTE classname='Bool'>
+																<value>false</value>
+															</IgnoreRTE>
+															<UseMutex classname='Bool'>
+																<value>false</value>
+															</UseMutex>
+															<MutexNameOrRef classname='ExprValue'>
+																<value/>
+															</MutexNameOrRef>
+															<BatchSyncOpt classname='Num'>
+																<value>0</value>
+															</BatchSyncOpt>
+															<SwitchEnabled classname='Bool'>
+																<value>false</value>
+															</SwitchEnabled>
+															<VirtualDeviceName classname='ExprValue'>
+																<value/>
+															</VirtualDeviceName>
+															<SwitchOperation classname='Num'>
+																<value>1</value>
+															</SwitchOperation>
+															<RouteGroupConnect classname='ExprValue'>
+																<value/>
+															</RouteGroupConnect>
+															<RouteGroupDisconnect classname='ExprValue'>
+																<value/>
+															</RouteGroupDisconnect>
+															<MulticonnectMode classname='Num'>
+																<value>1</value>
+															</MulticonnectMode>
+															<OperationOrder classname='Num'>
+																<value>2</value>
+															</OperationOrder>
+															<ConnectionLifetime classname='Num'>
+																<value>0</value>
+															</ConnectionLifetime>
+															<WaitForDebounce classname='Bool'>
+																<value>true</value>
+															</WaitForDebounce>
+															<PassAct classname='Str'>
+																<value>Next</value>
+															</PassAct>
+															<FailAct classname='Str'>
+																<value>Next</value>
+															</FailAct>
+															<PassActTarget classname='ExprValue'>
+																<value/>
+															</PassActTarget>
+															<FailActTarget classname='ExprValue'>
+																<value/>
+															</FailActTarget>
+															<CustExpr classname='ExprValue'>
+																<value/>
+															</CustExpr>
+															<CustTrueAct classname='Str'>
+																<value>Next</value>
+															</CustTrueAct>
+															<CustFalseAct classname='Str'>
+																<value>Next</value>
+															</CustFalseAct>
+															<CustTrueActTarget classname='ExprValue'>
+																<value/>
+															</CustTrueActTarget>
+															<CustFalseActTarget classname='ExprValue'>
+																<value/>
+															</CustFalseActTarget>
+															<LoopType classname='Str'>
+																<value>NoLooping</value>
+															</LoopType>
+															<LoopWhile classname='ExprValue'>
+																<value/>
+															</LoopWhile>
+															<LoopStatus classname='ExprValue'>
+																<value/>
+															</LoopStatus>
+															<LoopIncrement classname='ExprValue'>
+																<value>RunState.LoopIndex += 1</value>
+															</LoopIncrement>
+															<LoopInitialize classname='ExprValue'>
+																<value>RunState.LoopIndex = 0</value>
+															</LoopInitialize>
+															<LoopOpt classname='Num'>
+																<value>0</value>
+															</LoopOpt>
+															<PreExpr classname='ExprValue'>
+																<value/>
+															</PreExpr>
+															<PostExpr classname='ExprValue'>
+																<value/>
+															</PostExpr>
+															<StatusExpr classname='ExprValue'>
+																<value/>
+															</StatusExpr>
+															<CanSpecifyModule classname='Bool'>
+																<value>true</value>
+															</CanSpecifyModule>
+															<CanEditCode classname='Bool'>
+																<value>true</value>
+															</CanEditCode>
+															<CanEditModulePrototype classname='Bool'>
+																<value>true</value>
+															</CanEditModulePrototype>
+															<CanEditParameterAdditionalResults classname='Bool'>
+																<value>true</value>
+															</CanEditParameterAdditionalResults>
+															<PrecondIntExe classname='Num'>
+																<value>0</value>
+															</PrecondIntExe>
+															<CustomResults classname='Objs'>
+																<value lbound='[0]' ubound='[]'>
+																	<elemproto>
+																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+																			<subprops>
+																				<Name classname='ExprValue'>
+																					<value/>
+																				</Name>
+																				<ValueToLog classname='ExprValue'>
+																					<value/>
+																				</ValueToLog>
+																				<Condition classname='ExprValue'>
+																					<value/>
+																				</Condition>
+																				<Flags classname='Num'>
+																					<value>8192</value>
+																				</Flags>
+																				<CheckedState classname='Num'>
+																					<value>2</value>
+																				</CheckedState>
+																				<Type classname='PropertyObjectType'>
+																					<subprops>
+																						<ValueType classname='Num'>
+																							<value>3</value>
+																						</ValueType>
+																						<IsObject classname='Bool'>
+																							<value>true</value>
+																						</IsObject>
+																						<TypeName classname='Str'>
+																							<value/>
+																						</TypeName>
+																						<ElementType classname='Objs'>
+																							<value lbound='[0]' ubound='[]'/>
+																						</ElementType>
+																						<ArrayDimensions classname='ArrayDimensions'>
+																							<subprops>
+																								<LowerBounds classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</LowerBounds>
+																								<UpperBounds classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</UpperBounds>
+																							</subprops>
+																						</ArrayDimensions>
+																						<Representation classname='Num'>
+																							<value>1</value>
+																						</Representation>
+																						<ClassName classname='Str'>
+																							<value/>
+																						</ClassName>
+																					</subprops>
+																				</Type>
+																				<Elements classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</Elements>
+																				<IsAnyType classname='Bool'>
+																					<value>true</value>
+																				</IsAnyType>
+																			</subprops>
+																		</_NAME_IN_ATTRIBUTE_>
+																	</elemproto>
+																</value>
+															</CustomResults>
+															<AdditionalResultsHints classname='Objs'>
+																<value lbound='[0]' ubound='[]'>
+																	<elemproto>
+																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+																			<subprops>
+																				<Name classname='ExprValue'>
+																					<value/>
+																				</Name>
+																				<ValueToLog classname='ExprValue'>
+																					<value/>
+																				</ValueToLog>
+																				<Condition classname='ExprValue'>
+																					<value/>
+																				</Condition>
+																				<Flags classname='Num'>
+																					<value>8192</value>
+																				</Flags>
+																				<CheckedState classname='Num'>
+																					<value>2</value>
+																				</CheckedState>
+																				<Type classname='PropertyObjectType'>
+																					<subprops>
+																						<ValueType classname='Num'>
+																							<value>3</value>
+																						</ValueType>
+																						<IsObject classname='Bool'>
+																							<value>true</value>
+																						</IsObject>
+																						<TypeName classname='Str'>
+																							<value/>
+																						</TypeName>
+																						<ElementType classname='Objs'>
+																							<value lbound='[0]' ubound='[]'/>
+																						</ElementType>
+																						<ArrayDimensions classname='ArrayDimensions'>
+																							<subprops>
+																								<LowerBounds classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</LowerBounds>
+																								<UpperBounds classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</UpperBounds>
+																							</subprops>
+																						</ArrayDimensions>
+																						<Representation classname='Num'>
+																							<value>1</value>
+																						</Representation>
+																						<ClassName classname='Str'>
+																							<value/>
+																						</ClassName>
+																					</subprops>
+																				</Type>
+																				<Elements classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</Elements>
+																				<IsAnyType classname='Bool'>
+																					<value>true</value>
+																				</IsAnyType>
+																			</subprops>
+																		</_NAME_IN_ATTRIBUTE_>
+																	</elemproto>
+																</value>
+															</AdditionalResultsHints>
+														</subprops>
+													</TS>
+													<Result classname='Obj'>
+														<subprops>
+															<Error classname='Obj'>
+																<subprops>
+																	<Code classname='Num'>
+																		<value>0</value>
+																	</Code>
+																	<Msg classname='Str'>
+																		<value/>
+																	</Msg>
+																	<Occurred classname='Bool'>
+																		<value>false</value>
+																	</Occurred>
+																</subprops>
+															</Error>
+															<Status classname='Str'>
+																<value/>
+															</Status>
+															<ReportText classname='Str'>
+																<value/>
+															</ReportText>
+															<Common classname='Obj'/>
+														</subprops>
+													</Result>
+												</subprops>
+											</Step>
+										</value>
+										<value>
+											<Step typename='Action' xsi:type='Action' name='Create and register NI-DCPower Sessions'>
+												<subprops>
+													<TS classname='Obj'>
+														<subprops>
+															<Id classname='Str'>
+																<value>ID#:ian4cOjm7RGhzZiQlrVX7C</value>
+															</Id>
+															<Icon classname='Str'>
+																<value/>
+															</Icon>
+															<SData typename='PythonStepAdditions' xsi:type='PythonStepAdditions' classname='CPythonModule'>
+																<subprops>
+																	<PythonCall classname='CPythonCall'>
+																		<subprops>
+																			<UseAdapterSettingsForInterpreterSession classname='Bool'>
+																				<value>false</value>
+																			</UseAdapterSettingsForInterpreterSession>
+																			<InterpreterSessionScope classname='Num'>
+																				<value>2</value>
+																			</InterpreterSessionScope>
+																			<PythonVersion classname='Str'>
+																				<value>3.9</value>
+																			</PythonVersion>
+																			<PythonVirtualEnvironmentPath classname='Str'>
+																				<value>.venv</value>
+																			</PythonVirtualEnvironmentPath>
+																			<InterpreterLocation classname='ExprValue'>
+																				<value/>
+																			</InterpreterLocation>
+																			<CreateIfInterpreterDoesNotExist classname='Bool'>
+																				<value>true</value>
+																			</CreateIfInterpreterDoesNotExist>
+																			<ModulePath classname='PathValue'>
+																				<value>teststand_nidcpower.py</value>
+																			</ModulePath>
+																			<OperationType classname='Num'>
+																				<value>1</value>
+																			</OperationType>
+																			<OperationScope classname='Num'>
+																				<value>0</value>
+																			</OperationScope>
+																			<ClassName classname='Str'>
+																				<value/>
+																			</ClassName>
+																			<ClassInstanceLocation classname='ExprValue'>
+																				<value/>
+																			</ClassInstanceLocation>
+																			<FunctionOrAttributeName classname='Str'>
+																				<value>create_nidcpower_sessions</value>
+																			</FunctionOrAttributeName>
+																			<Parameters classname='Objs'>
+																				<value lbound='[0]' ubound='[1]'>
+																					<elemproto>
+																						<_NAME_IN_ATTRIBUTE_ name='' classname='CPythonParameter' structureflags='0'/>
+																					</elemproto>
+																					<value>
+																						<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
+																							<subprops>
+																								<Name classname='Str'>
+																									<value>Return Value</value>
+																								</Name>
+																								<Type classname='Num'>
+																									<value>7</value>
+																								</Type>
+																								<ArgumentValue classname='ExprValue'>
+																									<value/>
+																								</ArgumentValue>
+																								<ArgumentDisplayValue classname='ExprValue'>
+																									<value/>
+																								</ArgumentDisplayValue>
+																								<AdditionalResults classname='Obj'>
+																									<subprops>
+																										<Input classname='PythonParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
+																													<value>1</value>
+																												</CheckedState>
+																											</subprops>
+																										</Input>
+																										<Output classname='PythonParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
+																													<value>1</value>
+																												</CheckedState>
+																											</subprops>
+																										</Output>
+																									</subprops>
+																								</AdditionalResults>
+																							</subprops>
+																						</CPythonParameter>
+																					</value>
+																					<value>
+																						<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
+																							<subprops>
+																								<Name classname='Str'>
+																									<value>sequence_context</value>
+																								</Name>
+																								<Type classname='Num'>
+																									<value>7</value>
+																								</Type>
+																								<ArgumentValue classname='ExprValue'>
+																									<value>ThisContext</value>
+																								</ArgumentValue>
+																								<ArgumentDisplayValue classname='ExprValue'>
+																									<value/>
+																								</ArgumentDisplayValue>
+																								<AdditionalResults classname='Obj'>
+																									<subprops>
+																										<Input classname='PythonParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
+																													<value>1</value>
+																												</CheckedState>
+																											</subprops>
+																										</Input>
+																										<Output classname='PythonParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
+																													<value>1</value>
+																												</CheckedState>
+																											</subprops>
+																										</Output>
+																									</subprops>
+																								</AdditionalResults>
+																							</subprops>
+																						</CPythonParameter>
+																					</value>
+																				</value>
+																			</Parameters>
+																			<DefaultParamCategoryForArray classname='Num'>
+																				<value>5</value>
+																			</DefaultParamCategoryForArray>
+																		</subprops>
+																	</PythonCall>
+																</subprops>
+															</SData>
+															<PreCond classname='ExprValue'>
+																<value/>
+															</PreCond>
+															<LoadOpt classname='Str'>
+																<value>PreloadWhenExecuted</value>
+															</LoadOpt>
+															<UnloadOpt classname='Str'>
+																<value>UnloadWithFile</value>
+															</UnloadOpt>
+															<Mode classname='Str'>
+																<value>Normal</value>
+															</Mode>
+															<WindowActivation classname='Str'>
+																<value>None</value>
+															</WindowActivation>
+															<ResultOption classname='Num'>
+																<value>1</value>
+															</ResultOption>
+															<StepFCSeqF classname='Bool'>
+																<value>true</value>
+															</StepFCSeqF>
+															<IgnoreRTE classname='Bool'>
+																<value>false</value>
+															</IgnoreRTE>
+															<UseMutex classname='Bool'>
+																<value>false</value>
+															</UseMutex>
+															<MutexNameOrRef classname='ExprValue'>
+																<value/>
+															</MutexNameOrRef>
+															<BatchSyncOpt classname='Num'>
+																<value>0</value>
+															</BatchSyncOpt>
+															<SwitchEnabled classname='Bool'>
+																<value>false</value>
+															</SwitchEnabled>
+															<VirtualDeviceName classname='ExprValue'>
+																<value/>
+															</VirtualDeviceName>
+															<SwitchOperation classname='Num'>
+																<value>1</value>
+															</SwitchOperation>
+															<RouteGroupConnect classname='ExprValue'>
+																<value/>
+															</RouteGroupConnect>
+															<RouteGroupDisconnect classname='ExprValue'>
+																<value/>
+															</RouteGroupDisconnect>
+															<MulticonnectMode classname='Num'>
+																<value>1</value>
+															</MulticonnectMode>
+															<OperationOrder classname='Num'>
+																<value>2</value>
+															</OperationOrder>
+															<ConnectionLifetime classname='Num'>
+																<value>0</value>
+															</ConnectionLifetime>
+															<WaitForDebounce classname='Bool'>
+																<value>true</value>
+															</WaitForDebounce>
+															<PassAct classname='Str'>
+																<value>Next</value>
+															</PassAct>
+															<FailAct classname='Str'>
+																<value>Next</value>
+															</FailAct>
+															<PassActTarget classname='ExprValue'>
+																<value/>
+															</PassActTarget>
+															<FailActTarget classname='ExprValue'>
+																<value/>
+															</FailActTarget>
+															<CustExpr classname='ExprValue'>
+																<value/>
+															</CustExpr>
+															<CustTrueAct classname='Str'>
+																<value>Next</value>
+															</CustTrueAct>
+															<CustFalseAct classname='Str'>
+																<value>Next</value>
+															</CustFalseAct>
+															<CustTrueActTarget classname='ExprValue'>
+																<value/>
+															</CustTrueActTarget>
+															<CustFalseActTarget classname='ExprValue'>
+																<value/>
+															</CustFalseActTarget>
+															<LoopType classname='Str'>
+																<value>NoLooping</value>
+															</LoopType>
+															<LoopWhile classname='ExprValue'>
+																<value/>
+															</LoopWhile>
+															<LoopStatus classname='ExprValue'>
+																<value/>
+															</LoopStatus>
+															<LoopIncrement classname='ExprValue'>
+																<value>RunState.LoopIndex += 1</value>
+															</LoopIncrement>
+															<LoopInitialize classname='ExprValue'>
+																<value>RunState.LoopIndex = 0</value>
+															</LoopInitialize>
+															<LoopOpt classname='Num'>
+																<value>0</value>
+															</LoopOpt>
+															<PreExpr classname='ExprValue'>
+																<value/>
+															</PreExpr>
+															<PostExpr classname='ExprValue'>
+																<value/>
+															</PostExpr>
+															<StatusExpr classname='ExprValue'>
+																<value/>
+															</StatusExpr>
+															<CanSpecifyModule classname='Bool'>
+																<value>true</value>
+															</CanSpecifyModule>
+															<CanEditCode classname='Bool'>
+																<value>true</value>
+															</CanEditCode>
+															<CanEditModulePrototype classname='Bool'>
+																<value>true</value>
+															</CanEditModulePrototype>
+															<CanEditParameterAdditionalResults classname='Bool'>
+																<value>true</value>
+															</CanEditParameterAdditionalResults>
+															<PrecondIntExe classname='Num'>
+																<value>0</value>
+															</PrecondIntExe>
+															<CustomResults classname='Objs'>
+																<value lbound='[0]' ubound='[]'>
+																	<elemproto>
+																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+																			<subprops>
+																				<Name classname='ExprValue'>
+																					<value/>
+																				</Name>
+																				<ValueToLog classname='ExprValue'>
+																					<value/>
+																				</ValueToLog>
+																				<Condition classname='ExprValue'>
+																					<value/>
+																				</Condition>
+																				<Flags classname='Num'>
+																					<value>8192</value>
+																				</Flags>
+																				<CheckedState classname='Num'>
+																					<value>2</value>
+																				</CheckedState>
+																				<Type classname='PropertyObjectType'>
+																					<subprops>
+																						<ValueType classname='Num'>
+																							<value>3</value>
+																						</ValueType>
+																						<IsObject classname='Bool'>
+																							<value>true</value>
+																						</IsObject>
+																						<TypeName classname='Str'>
+																							<value/>
+																						</TypeName>
+																						<ElementType classname='Objs'>
+																							<value lbound='[0]' ubound='[]'/>
+																						</ElementType>
+																						<ArrayDimensions classname='ArrayDimensions'>
+																							<subprops>
+																								<LowerBounds classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</LowerBounds>
+																								<UpperBounds classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</UpperBounds>
+																							</subprops>
+																						</ArrayDimensions>
+																						<Representation classname='Num'>
+																							<value>1</value>
+																						</Representation>
+																						<ClassName classname='Str'>
+																							<value/>
+																						</ClassName>
+																					</subprops>
+																				</Type>
+																				<Elements classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</Elements>
+																				<IsAnyType classname='Bool'>
+																					<value>true</value>
+																				</IsAnyType>
+																			</subprops>
+																		</_NAME_IN_ATTRIBUTE_>
+																	</elemproto>
+																</value>
+															</CustomResults>
+															<AdditionalResultsHints classname='Objs'>
+																<value lbound='[0]' ubound='[]'>
+																	<elemproto>
+																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+																			<subprops>
+																				<Name classname='ExprValue'>
+																					<value/>
+																				</Name>
+																				<ValueToLog classname='ExprValue'>
+																					<value/>
+																				</ValueToLog>
+																				<Condition classname='ExprValue'>
+																					<value/>
+																				</Condition>
+																				<Flags classname='Num'>
+																					<value>8192</value>
+																				</Flags>
+																				<CheckedState classname='Num'>
+																					<value>2</value>
+																				</CheckedState>
+																				<Type classname='PropertyObjectType'>
+																					<subprops>
+																						<ValueType classname='Num'>
+																							<value>3</value>
+																						</ValueType>
+																						<IsObject classname='Bool'>
+																							<value>true</value>
+																						</IsObject>
+																						<TypeName classname='Str'>
+																							<value/>
+																						</TypeName>
+																						<ElementType classname='Objs'>
+																							<value lbound='[0]' ubound='[]'/>
+																						</ElementType>
+																						<ArrayDimensions classname='ArrayDimensions'>
+																							<subprops>
+																								<LowerBounds classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</LowerBounds>
+																								<UpperBounds classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</UpperBounds>
+																							</subprops>
+																						</ArrayDimensions>
+																						<Representation classname='Num'>
+																							<value>1</value>
+																						</Representation>
+																						<ClassName classname='Str'>
+																							<value/>
+																						</ClassName>
+																					</subprops>
+																				</Type>
+																				<Elements classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</Elements>
+																				<IsAnyType classname='Bool'>
+																					<value>true</value>
+																				</IsAnyType>
+																			</subprops>
+																		</_NAME_IN_ATTRIBUTE_>
+																	</elemproto>
+																</value>
+															</AdditionalResultsHints>
+														</subprops>
+													</TS>
+													<Result classname='Obj'>
+														<subprops>
+															<Error classname='Obj'>
+																<subprops>
+																	<Code classname='Num'>
+																		<value>0</value>
+																	</Code>
+																	<Msg classname='Str'>
+																		<value/>
+																	</Msg>
+																	<Occurred classname='Bool'>
+																		<value>false</value>
+																	</Occurred>
+																</subprops>
+															</Error>
+															<Status classname='Str'>
+																<value/>
+															</Status>
+															<ReportText classname='Str'>
+																<value/>
+															</ReportText>
+															<Common classname='Obj'/>
+														</subprops>
+													</Result>
+												</subprops>
+											</Step>
+										</value>
+										<value>
+											<Step typename='Action' xsi:type='Action' name='Create and register NI-DMM Sessions'>
+												<subprops>
+													<TS classname='Obj'>
+														<subprops>
+															<Id classname='Str'>
+																<value>ID#:+vh2fubm7RGhzZiQlrVX7C</value>
+															</Id>
+															<Icon classname='Str'>
+																<value/>
+															</Icon>
+															<SData typename='PythonStepAdditions' xsi:type='PythonStepAdditions' classname='CPythonModule'>
+																<subprops>
+																	<PythonCall classname='CPythonCall'>
+																		<subprops>
+																			<UseAdapterSettingsForInterpreterSession classname='Bool'>
+																				<value>false</value>
+																			</UseAdapterSettingsForInterpreterSession>
+																			<InterpreterSessionScope classname='Num'>
+																				<value>2</value>
+																			</InterpreterSessionScope>
+																			<PythonVersion classname='Str'>
+																				<value>3.9</value>
+																			</PythonVersion>
+																			<PythonVirtualEnvironmentPath classname='Str'>
+																				<value>.venv</value>
+																			</PythonVirtualEnvironmentPath>
+																			<InterpreterLocation classname='ExprValue'>
+																				<value/>
+																			</InterpreterLocation>
+																			<CreateIfInterpreterDoesNotExist classname='Bool'>
+																				<value>true</value>
+																			</CreateIfInterpreterDoesNotExist>
+																			<ModulePath classname='PathValue'>
+																				<value>teststand_nidmm.py</value>
+																			</ModulePath>
+																			<OperationType classname='Num'>
+																				<value>1</value>
+																			</OperationType>
+																			<OperationScope classname='Num'>
+																				<value>0</value>
+																			</OperationScope>
+																			<ClassName classname='Str'>
+																				<value/>
+																			</ClassName>
+																			<ClassInstanceLocation classname='ExprValue'>
+																				<value/>
+																			</ClassInstanceLocation>
+																			<FunctionOrAttributeName classname='Str'>
+																				<value>create_nidmm_sessions</value>
+																			</FunctionOrAttributeName>
+																			<Parameters classname='Objs'>
+																				<value lbound='[0]' ubound='[1]'>
+																					<elemproto>
+																						<_NAME_IN_ATTRIBUTE_ name='' classname='CPythonParameter' structureflags='0'/>
+																					</elemproto>
+																					<value>
+																						<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
+																							<subprops>
+																								<Name classname='Str'>
+																									<value>Return Value</value>
+																								</Name>
+																								<Type classname='Num'>
+																									<value>7</value>
+																								</Type>
+																								<ArgumentValue classname='ExprValue'>
+																									<value/>
+																								</ArgumentValue>
+																								<ArgumentDisplayValue classname='ExprValue'>
+																									<value/>
+																								</ArgumentDisplayValue>
+																								<AdditionalResults classname='Obj'>
+																									<subprops>
+																										<Input classname='PythonParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
+																													<value>1</value>
+																												</CheckedState>
+																											</subprops>
+																										</Input>
+																										<Output classname='PythonParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
+																													<value>1</value>
+																												</CheckedState>
+																											</subprops>
+																										</Output>
+																									</subprops>
+																								</AdditionalResults>
+																							</subprops>
+																						</CPythonParameter>
+																					</value>
+																					<value>
+																						<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
+																							<subprops>
+																								<Name classname='Str'>
+																									<value>sequence_context</value>
+																								</Name>
+																								<Type classname='Num'>
+																									<value>7</value>
+																								</Type>
+																								<ArgumentValue classname='ExprValue'>
+																									<value>ThisContext</value>
+																								</ArgumentValue>
+																								<ArgumentDisplayValue classname='ExprValue'>
+																									<value/>
+																								</ArgumentDisplayValue>
+																								<AdditionalResults classname='Obj'>
+																									<subprops>
+																										<Input classname='PythonParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
+																													<value>1</value>
+																												</CheckedState>
+																											</subprops>
+																										</Input>
+																										<Output classname='PythonParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
+																													<value>1</value>
+																												</CheckedState>
+																											</subprops>
+																										</Output>
+																									</subprops>
+																								</AdditionalResults>
+																							</subprops>
+																						</CPythonParameter>
+																					</value>
+																				</value>
+																			</Parameters>
+																			<DefaultParamCategoryForArray classname='Num'>
+																				<value>5</value>
+																			</DefaultParamCategoryForArray>
+																		</subprops>
+																	</PythonCall>
+																</subprops>
+															</SData>
+															<PreCond classname='ExprValue'>
+																<value/>
+															</PreCond>
+															<LoadOpt classname='Str'>
+																<value>PreloadWhenExecuted</value>
+															</LoadOpt>
+															<UnloadOpt classname='Str'>
+																<value>UnloadWithFile</value>
+															</UnloadOpt>
+															<Mode classname='Str'>
+																<value>Normal</value>
+															</Mode>
+															<WindowActivation classname='Str'>
+																<value>None</value>
+															</WindowActivation>
+															<ResultOption classname='Num'>
+																<value>1</value>
+															</ResultOption>
+															<StepFCSeqF classname='Bool'>
+																<value>true</value>
+															</StepFCSeqF>
+															<IgnoreRTE classname='Bool'>
+																<value>false</value>
+															</IgnoreRTE>
+															<UseMutex classname='Bool'>
+																<value>false</value>
+															</UseMutex>
+															<MutexNameOrRef classname='ExprValue'>
+																<value/>
+															</MutexNameOrRef>
+															<BatchSyncOpt classname='Num'>
+																<value>0</value>
+															</BatchSyncOpt>
+															<SwitchEnabled classname='Bool'>
+																<value>false</value>
+															</SwitchEnabled>
+															<VirtualDeviceName classname='ExprValue'>
+																<value/>
+															</VirtualDeviceName>
+															<SwitchOperation classname='Num'>
+																<value>1</value>
+															</SwitchOperation>
+															<RouteGroupConnect classname='ExprValue'>
+																<value/>
+															</RouteGroupConnect>
+															<RouteGroupDisconnect classname='ExprValue'>
+																<value/>
+															</RouteGroupDisconnect>
+															<MulticonnectMode classname='Num'>
+																<value>1</value>
+															</MulticonnectMode>
+															<OperationOrder classname='Num'>
+																<value>2</value>
+															</OperationOrder>
+															<ConnectionLifetime classname='Num'>
+																<value>0</value>
+															</ConnectionLifetime>
+															<WaitForDebounce classname='Bool'>
+																<value>true</value>
+															</WaitForDebounce>
+															<PassAct classname='Str'>
+																<value>Next</value>
+															</PassAct>
+															<FailAct classname='Str'>
+																<value>Next</value>
+															</FailAct>
+															<PassActTarget classname='ExprValue'>
+																<value/>
+															</PassActTarget>
+															<FailActTarget classname='ExprValue'>
+																<value/>
+															</FailActTarget>
+															<CustExpr classname='ExprValue'>
+																<value/>
+															</CustExpr>
+															<CustTrueAct classname='Str'>
+																<value>Next</value>
+															</CustTrueAct>
+															<CustFalseAct classname='Str'>
+																<value>Next</value>
+															</CustFalseAct>
+															<CustTrueActTarget classname='ExprValue'>
+																<value/>
+															</CustTrueActTarget>
+															<CustFalseActTarget classname='ExprValue'>
+																<value/>
+															</CustFalseActTarget>
+															<LoopType classname='Str'>
+																<value>NoLooping</value>
+															</LoopType>
+															<LoopWhile classname='ExprValue'>
+																<value/>
+															</LoopWhile>
+															<LoopStatus classname='ExprValue'>
+																<value/>
+															</LoopStatus>
+															<LoopIncrement classname='ExprValue'>
+																<value>RunState.LoopIndex += 1</value>
+															</LoopIncrement>
+															<LoopInitialize classname='ExprValue'>
+																<value>RunState.LoopIndex = 0</value>
+															</LoopInitialize>
+															<LoopOpt classname='Num'>
+																<value>0</value>
+															</LoopOpt>
+															<PreExpr classname='ExprValue'>
+																<value/>
+															</PreExpr>
+															<PostExpr classname='ExprValue'>
+																<value/>
+															</PostExpr>
+															<StatusExpr classname='ExprValue'>
+																<value/>
+															</StatusExpr>
+															<CanSpecifyModule classname='Bool'>
+																<value>true</value>
+															</CanSpecifyModule>
+															<CanEditCode classname='Bool'>
+																<value>true</value>
+															</CanEditCode>
+															<CanEditModulePrototype classname='Bool'>
+																<value>true</value>
+															</CanEditModulePrototype>
+															<CanEditParameterAdditionalResults classname='Bool'>
+																<value>true</value>
+															</CanEditParameterAdditionalResults>
+															<PrecondIntExe classname='Num'>
+																<value>0</value>
+															</PrecondIntExe>
+															<CustomResults classname='Objs'>
+																<value lbound='[0]' ubound='[]'>
+																	<elemproto>
+																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+																			<subprops>
+																				<Name classname='ExprValue'>
+																					<value/>
+																				</Name>
+																				<ValueToLog classname='ExprValue'>
+																					<value/>
+																				</ValueToLog>
+																				<Condition classname='ExprValue'>
+																					<value/>
+																				</Condition>
+																				<Flags classname='Num'>
+																					<value>8192</value>
+																				</Flags>
+																				<CheckedState classname='Num'>
+																					<value>2</value>
+																				</CheckedState>
+																				<Type classname='PropertyObjectType'>
+																					<subprops>
+																						<ValueType classname='Num'>
+																							<value>3</value>
+																						</ValueType>
+																						<IsObject classname='Bool'>
+																							<value>true</value>
+																						</IsObject>
+																						<TypeName classname='Str'>
+																							<value/>
+																						</TypeName>
+																						<ElementType classname='Objs'>
+																							<value lbound='[0]' ubound='[]'/>
+																						</ElementType>
+																						<ArrayDimensions classname='ArrayDimensions'>
+																							<subprops>
+																								<LowerBounds classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</LowerBounds>
+																								<UpperBounds classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</UpperBounds>
+																							</subprops>
+																						</ArrayDimensions>
+																						<Representation classname='Num'>
+																							<value>1</value>
+																						</Representation>
+																						<ClassName classname='Str'>
+																							<value/>
+																						</ClassName>
+																					</subprops>
+																				</Type>
+																				<Elements classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</Elements>
+																				<IsAnyType classname='Bool'>
+																					<value>true</value>
+																				</IsAnyType>
+																			</subprops>
+																		</_NAME_IN_ATTRIBUTE_>
+																	</elemproto>
+																</value>
+															</CustomResults>
+															<AdditionalResultsHints classname='Objs'>
+																<value lbound='[0]' ubound='[]'>
+																	<elemproto>
+																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+																			<subprops>
+																				<Name classname='ExprValue'>
+																					<value/>
+																				</Name>
+																				<ValueToLog classname='ExprValue'>
+																					<value/>
+																				</ValueToLog>
+																				<Condition classname='ExprValue'>
+																					<value/>
+																				</Condition>
+																				<Flags classname='Num'>
+																					<value>8192</value>
+																				</Flags>
+																				<CheckedState classname='Num'>
+																					<value>2</value>
+																				</CheckedState>
+																				<Type classname='PropertyObjectType'>
+																					<subprops>
+																						<ValueType classname='Num'>
+																							<value>3</value>
+																						</ValueType>
+																						<IsObject classname='Bool'>
+																							<value>true</value>
+																						</IsObject>
+																						<TypeName classname='Str'>
+																							<value/>
+																						</TypeName>
+																						<ElementType classname='Objs'>
+																							<value lbound='[0]' ubound='[]'/>
+																						</ElementType>
+																						<ArrayDimensions classname='ArrayDimensions'>
+																							<subprops>
+																								<LowerBounds classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</LowerBounds>
+																								<UpperBounds classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</UpperBounds>
+																							</subprops>
+																						</ArrayDimensions>
+																						<Representation classname='Num'>
+																							<value>1</value>
+																						</Representation>
+																						<ClassName classname='Str'>
+																							<value/>
+																						</ClassName>
+																					</subprops>
+																				</Type>
+																				<Elements classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</Elements>
+																				<IsAnyType classname='Bool'>
+																					<value>true</value>
+																				</IsAnyType>
+																			</subprops>
+																		</_NAME_IN_ATTRIBUTE_>
+																	</elemproto>
+																</value>
+															</AdditionalResultsHints>
+														</subprops>
+													</TS>
+													<Result classname='Obj'>
+														<subprops>
+															<Error classname='Obj'>
+																<subprops>
+																	<Code classname='Num'>
+																		<value>0</value>
+																	</Code>
+																	<Msg classname='Str'>
+																		<value/>
+																	</Msg>
+																	<Occurred classname='Bool'>
+																		<value>false</value>
+																	</Occurred>
+																</subprops>
+															</Error>
+															<Status classname='Str'>
+																<value/>
+															</Status>
+															<ReportText classname='Str'>
+																<value/>
+															</ReportText>
+															<Common classname='Obj'/>
+														</subprops>
+													</Result>
+												</subprops>
+											</Step>
+										</value>
+									</value>
+								</Setup>
+								<Cleanup classname='Objs' valueflags='4194304'>
+									<value lbound='[0]' ubound='[2]'>
+										<value>
+											<Step typename='Statement' xsi:type='Statement' name='Unregister active PinMapId'>
+												<subprops>
+													<TS classname='Obj'>
+														<subprops>
+															<Id classname='Str'>
+																<value>ID#:64R8h+bm7RGhzZiQlrVX7C</value>
+															</Id>
+															<Icon classname='Str'>
+																<value>StatementStep.ico</value>
+															</Icon>
+															<PreCond classname='ExprValue'>
+																<value/>
+															</PreCond>
+															<LoadOpt classname='Str'>
+																<value>PreloadWhenExecuted</value>
+															</LoadOpt>
+															<UnloadOpt classname='Str'>
+																<value>UnloadWithFile</value>
+															</UnloadOpt>
+															<Mode classname='Str'>
+																<value>Normal</value>
+															</Mode>
+															<WindowActivation classname='Str'>
+																<value>None</value>
+															</WindowActivation>
+															<ResultOption classname='Num'>
+																<value>1</value>
+															</ResultOption>
+															<StepFCSeqF classname='Bool'>
+																<value>true</value>
+															</StepFCSeqF>
+															<IgnoreRTE classname='Bool'>
+																<value>false</value>
+															</IgnoreRTE>
+															<UseMutex classname='Bool'>
+																<value>false</value>
+															</UseMutex>
+															<MutexNameOrRef classname='ExprValue'>
+																<value/>
+															</MutexNameOrRef>
+															<BatchSyncOpt classname='Num'>
+																<value>0</value>
+															</BatchSyncOpt>
+															<SwitchEnabled classname='Bool'>
+																<value>false</value>
+															</SwitchEnabled>
+															<VirtualDeviceName classname='ExprValue'>
+																<value/>
+															</VirtualDeviceName>
+															<SwitchOperation classname='Num'>
+																<value>1</value>
+															</SwitchOperation>
+															<RouteGroupConnect classname='ExprValue'>
+																<value/>
+															</RouteGroupConnect>
+															<RouteGroupDisconnect classname='ExprValue'>
+																<value/>
+															</RouteGroupDisconnect>
+															<MulticonnectMode classname='Num'>
+																<value>1</value>
+															</MulticonnectMode>
+															<OperationOrder classname='Num'>
+																<value>2</value>
+															</OperationOrder>
+															<ConnectionLifetime classname='Num'>
+																<value>0</value>
+															</ConnectionLifetime>
+															<WaitForDebounce classname='Bool'>
+																<value>true</value>
+															</WaitForDebounce>
+															<PassAct classname='Str'>
+																<value>Next</value>
+															</PassAct>
+															<FailAct classname='Str'>
+																<value>Next</value>
+															</FailAct>
+															<PassActTarget classname='ExprValue'>
+																<value/>
+															</PassActTarget>
+															<FailActTarget classname='ExprValue'>
+																<value/>
+															</FailActTarget>
+															<CustExpr classname='ExprValue'>
+																<value/>
+															</CustExpr>
+															<CustTrueAct classname='Str'>
+																<value>Next</value>
+															</CustTrueAct>
+															<CustFalseAct classname='Str'>
+																<value>Next</value>
+															</CustFalseAct>
+															<CustTrueActTarget classname='ExprValue'>
+																<value/>
+															</CustTrueActTarget>
+															<CustFalseActTarget classname='ExprValue'>
+																<value/>
+															</CustFalseActTarget>
+															<LoopType classname='Str'>
+																<value>NoLooping</value>
+															</LoopType>
+															<LoopWhile classname='ExprValue'>
+																<value/>
+															</LoopWhile>
+															<LoopStatus classname='ExprValue'>
+																<value/>
+															</LoopStatus>
+															<LoopIncrement classname='ExprValue'>
+																<value>RunState.LoopIndex += 1</value>
+															</LoopIncrement>
+															<LoopInitialize classname='ExprValue'>
+																<value>RunState.LoopIndex = 0</value>
+															</LoopInitialize>
+															<LoopOpt classname='Num'>
+																<value>0</value>
+															</LoopOpt>
+															<PreExpr classname='ExprValue'>
+																<value/>
+															</PreExpr>
+															<PostExpr classname='ExprValue'>
+																<value>RunState.Engine.TemporaryGlobals.DeleteSubProperty("NI.MeasurementLink.PinMapId", 0x2)</value>
+															</PostExpr>
+															<StatusExpr classname='ExprValue'>
+																<value/>
+															</StatusExpr>
+															<CanSpecifyModule classname='Bool'>
+																<value>false</value>
+															</CanSpecifyModule>
+															<CanEditCode classname='Bool'>
+																<value>true</value>
+															</CanEditCode>
+															<CanEditModulePrototype classname='Bool'>
+																<value>true</value>
+															</CanEditModulePrototype>
+															<CanEditParameterAdditionalResults classname='Bool'>
+																<value>true</value>
+															</CanEditParameterAdditionalResults>
+															<PrecondIntExe classname='Num'>
+																<value>0</value>
+															</PrecondIntExe>
+															<CustomResults classname='Objs'>
+																<value lbound='[0]' ubound='[]'>
+																	<elemproto>
+																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+																			<subprops>
+																				<Name classname='ExprValue'>
+																					<value/>
+																				</Name>
+																				<ValueToLog classname='ExprValue'>
+																					<value/>
+																				</ValueToLog>
+																				<Condition classname='ExprValue'>
+																					<value/>
+																				</Condition>
+																				<Flags classname='Num'>
+																					<value>8192</value>
+																				</Flags>
+																				<CheckedState classname='Num'>
+																					<value>2</value>
+																				</CheckedState>
+																				<Type classname='PropertyObjectType'>
+																					<subprops>
+																						<ValueType classname='Num'>
+																							<value>3</value>
+																						</ValueType>
+																						<IsObject classname='Bool'>
+																							<value>true</value>
+																						</IsObject>
+																						<TypeName classname='Str'>
+																							<value/>
+																						</TypeName>
+																						<ElementType classname='Objs'>
+																							<value lbound='[0]' ubound='[]'/>
+																						</ElementType>
+																						<ArrayDimensions classname='ArrayDimensions'>
+																							<subprops>
+																								<LowerBounds classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</LowerBounds>
+																								<UpperBounds classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</UpperBounds>
+																							</subprops>
+																						</ArrayDimensions>
+																						<Representation classname='Num'>
+																							<value>1</value>
+																						</Representation>
+																						<ClassName classname='Str'>
+																							<value/>
+																						</ClassName>
+																					</subprops>
+																				</Type>
+																				<Elements classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</Elements>
+																				<IsAnyType classname='Bool'>
+																					<value>true</value>
+																				</IsAnyType>
+																			</subprops>
+																		</_NAME_IN_ATTRIBUTE_>
+																	</elemproto>
+																</value>
+															</CustomResults>
+															<AdditionalResultsHints classname='Objs'>
+																<value lbound='[0]' ubound='[]'>
+																	<elemproto>
+																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+																			<subprops>
+																				<Name classname='ExprValue'>
+																					<value/>
+																				</Name>
+																				<ValueToLog classname='ExprValue'>
+																					<value/>
+																				</ValueToLog>
+																				<Condition classname='ExprValue'>
+																					<value/>
+																				</Condition>
+																				<Flags classname='Num'>
+																					<value>8192</value>
+																				</Flags>
+																				<CheckedState classname='Num'>
+																					<value>2</value>
+																				</CheckedState>
+																				<Type classname='PropertyObjectType'>
+																					<subprops>
+																						<ValueType classname='Num'>
+																							<value>3</value>
+																						</ValueType>
+																						<IsObject classname='Bool'>
+																							<value>true</value>
+																						</IsObject>
+																						<TypeName classname='Str'>
+																							<value/>
+																						</TypeName>
+																						<ElementType classname='Objs'>
+																							<value lbound='[0]' ubound='[]'/>
+																						</ElementType>
+																						<ArrayDimensions classname='ArrayDimensions'>
+																							<subprops>
+																								<LowerBounds classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</LowerBounds>
+																								<UpperBounds classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</UpperBounds>
+																							</subprops>
+																						</ArrayDimensions>
+																						<Representation classname='Num'>
+																							<value>1</value>
+																						</Representation>
+																						<ClassName classname='Str'>
+																							<value/>
+																						</ClassName>
+																					</subprops>
+																				</Type>
+																				<Elements classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</Elements>
+																				<IsAnyType classname='Bool'>
+																					<value>true</value>
+																				</IsAnyType>
+																			</subprops>
+																		</_NAME_IN_ATTRIBUTE_>
+																	</elemproto>
+																</value>
+															</AdditionalResultsHints>
+														</subprops>
+													</TS>
+													<Result classname='Obj'>
+														<subprops>
+															<Error classname='Obj'>
+																<subprops>
+																	<Code classname='Num'>
+																		<value>0</value>
+																	</Code>
+																	<Msg classname='Str'>
+																		<value/>
+																	</Msg>
+																	<Occurred classname='Bool'>
+																		<value>false</value>
+																	</Occurred>
+																</subprops>
+															</Error>
+															<Status classname='Str'>
+																<value/>
+															</Status>
+															<ReportText classname='Str'>
+																<value/>
+															</ReportText>
+															<Common classname='Obj'/>
+														</subprops>
+													</Result>
+												</subprops>
+											</Step>
+										</value>
+										<value>
+											<Step typename='Action' xsi:type='Action' name='Destroy and unregister NI-DCPower sessions'>
+												<subprops>
+													<TS classname='Obj'>
+														<subprops>
+															<Id classname='Str'>
+																<value>ID#:iqn4cOjm7RGhzZiQlrVX7C</value>
+															</Id>
+															<Icon classname='Str'>
+																<value/>
+															</Icon>
+															<SData typename='PythonStepAdditions' xsi:type='PythonStepAdditions' classname='CPythonModule'>
+																<subprops>
+																	<PythonCall classname='CPythonCall'>
+																		<subprops>
+																			<UseAdapterSettingsForInterpreterSession classname='Bool'>
+																				<value>false</value>
+																			</UseAdapterSettingsForInterpreterSession>
+																			<InterpreterSessionScope classname='Num'>
+																				<value>2</value>
+																			</InterpreterSessionScope>
+																			<PythonVersion classname='Str'>
+																				<value>3.9</value>
+																			</PythonVersion>
+																			<PythonVirtualEnvironmentPath classname='Str'>
+																				<value>.venv</value>
+																			</PythonVirtualEnvironmentPath>
+																			<InterpreterLocation classname='ExprValue'>
+																				<value/>
+																			</InterpreterLocation>
+																			<CreateIfInterpreterDoesNotExist classname='Bool'>
+																				<value>true</value>
+																			</CreateIfInterpreterDoesNotExist>
+																			<ModulePath classname='PathValue'>
+																				<value>teststand_nidcpower.py</value>
+																			</ModulePath>
+																			<OperationType classname='Num'>
+																				<value>1</value>
+																			</OperationType>
+																			<OperationScope classname='Num'>
+																				<value>0</value>
+																			</OperationScope>
+																			<ClassName classname='Str'>
+																				<value/>
+																			</ClassName>
+																			<ClassInstanceLocation classname='ExprValue'>
+																				<value/>
+																			</ClassInstanceLocation>
+																			<FunctionOrAttributeName classname='Str'>
+																				<value>destroy_nidcpower_sessions</value>
+																			</FunctionOrAttributeName>
+																			<Parameters classname='Objs'>
+																				<value lbound='[0]' ubound='[0]'>
+																					<elemproto>
+																						<_NAME_IN_ATTRIBUTE_ name='' classname='CPythonParameter' structureflags='0'/>
+																					</elemproto>
+																					<value>
+																						<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
+																							<subprops>
+																								<Name classname='Str'>
+																									<value>Return Value</value>
+																								</Name>
+																								<Type classname='Num'>
+																									<value>7</value>
+																								</Type>
+																								<ArgumentValue classname='ExprValue'>
+																									<value/>
+																								</ArgumentValue>
+																								<ArgumentDisplayValue classname='ExprValue'>
+																									<value/>
+																								</ArgumentDisplayValue>
+																								<AdditionalResults classname='Obj'>
+																									<subprops>
+																										<Input classname='PythonParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
+																													<value>1</value>
+																												</CheckedState>
+																											</subprops>
+																										</Input>
+																										<Output classname='PythonParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
+																													<value>1</value>
+																												</CheckedState>
+																											</subprops>
+																										</Output>
+																									</subprops>
+																								</AdditionalResults>
+																							</subprops>
+																						</CPythonParameter>
+																					</value>
+																				</value>
+																			</Parameters>
+																			<DefaultParamCategoryForArray classname='Num'>
+																				<value>5</value>
+																			</DefaultParamCategoryForArray>
+																		</subprops>
+																	</PythonCall>
+																</subprops>
+															</SData>
+															<PreCond classname='ExprValue'>
+																<value/>
+															</PreCond>
+															<LoadOpt classname='Str'>
+																<value>PreloadWhenExecuted</value>
+															</LoadOpt>
+															<UnloadOpt classname='Str'>
+																<value>UnloadWithFile</value>
+															</UnloadOpt>
+															<Mode classname='Str'>
+																<value>Normal</value>
+															</Mode>
+															<WindowActivation classname='Str'>
+																<value>None</value>
+															</WindowActivation>
+															<ResultOption classname='Num'>
+																<value>1</value>
+															</ResultOption>
+															<StepFCSeqF classname='Bool'>
+																<value>true</value>
+															</StepFCSeqF>
+															<IgnoreRTE classname='Bool'>
+																<value>false</value>
+															</IgnoreRTE>
+															<UseMutex classname='Bool'>
+																<value>false</value>
+															</UseMutex>
+															<MutexNameOrRef classname='ExprValue'>
+																<value/>
+															</MutexNameOrRef>
+															<BatchSyncOpt classname='Num'>
+																<value>0</value>
+															</BatchSyncOpt>
+															<SwitchEnabled classname='Bool'>
+																<value>false</value>
+															</SwitchEnabled>
+															<VirtualDeviceName classname='ExprValue'>
+																<value/>
+															</VirtualDeviceName>
+															<SwitchOperation classname='Num'>
+																<value>1</value>
+															</SwitchOperation>
+															<RouteGroupConnect classname='ExprValue'>
+																<value/>
+															</RouteGroupConnect>
+															<RouteGroupDisconnect classname='ExprValue'>
+																<value/>
+															</RouteGroupDisconnect>
+															<MulticonnectMode classname='Num'>
+																<value>1</value>
+															</MulticonnectMode>
+															<OperationOrder classname='Num'>
+																<value>2</value>
+															</OperationOrder>
+															<ConnectionLifetime classname='Num'>
+																<value>0</value>
+															</ConnectionLifetime>
+															<WaitForDebounce classname='Bool'>
+																<value>true</value>
+															</WaitForDebounce>
+															<PassAct classname='Str'>
+																<value>Next</value>
+															</PassAct>
+															<FailAct classname='Str'>
+																<value>Next</value>
+															</FailAct>
+															<PassActTarget classname='ExprValue'>
+																<value/>
+															</PassActTarget>
+															<FailActTarget classname='ExprValue'>
+																<value/>
+															</FailActTarget>
+															<CustExpr classname='ExprValue'>
+																<value/>
+															</CustExpr>
+															<CustTrueAct classname='Str'>
+																<value>Next</value>
+															</CustTrueAct>
+															<CustFalseAct classname='Str'>
+																<value>Next</value>
+															</CustFalseAct>
+															<CustTrueActTarget classname='ExprValue'>
+																<value/>
+															</CustTrueActTarget>
+															<CustFalseActTarget classname='ExprValue'>
+																<value/>
+															</CustFalseActTarget>
+															<LoopType classname='Str'>
+																<value>NoLooping</value>
+															</LoopType>
+															<LoopWhile classname='ExprValue'>
+																<value/>
+															</LoopWhile>
+															<LoopStatus classname='ExprValue'>
+																<value/>
+															</LoopStatus>
+															<LoopIncrement classname='ExprValue'>
+																<value>RunState.LoopIndex += 1</value>
+															</LoopIncrement>
+															<LoopInitialize classname='ExprValue'>
+																<value>RunState.LoopIndex = 0</value>
+															</LoopInitialize>
+															<LoopOpt classname='Num'>
+																<value>0</value>
+															</LoopOpt>
+															<PreExpr classname='ExprValue'>
+																<value/>
+															</PreExpr>
+															<PostExpr classname='ExprValue'>
+																<value/>
+															</PostExpr>
+															<StatusExpr classname='ExprValue'>
+																<value/>
+															</StatusExpr>
+															<CanSpecifyModule classname='Bool'>
+																<value>true</value>
+															</CanSpecifyModule>
+															<CanEditCode classname='Bool'>
+																<value>true</value>
+															</CanEditCode>
+															<CanEditModulePrototype classname='Bool'>
+																<value>true</value>
+															</CanEditModulePrototype>
+															<CanEditParameterAdditionalResults classname='Bool'>
+																<value>true</value>
+															</CanEditParameterAdditionalResults>
+															<PrecondIntExe classname='Num'>
+																<value>0</value>
+															</PrecondIntExe>
+															<CustomResults classname='Objs'>
+																<value lbound='[0]' ubound='[]'>
+																	<elemproto>
+																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+																			<subprops>
+																				<Name classname='ExprValue'>
+																					<value/>
+																				</Name>
+																				<ValueToLog classname='ExprValue'>
+																					<value/>
+																				</ValueToLog>
+																				<Condition classname='ExprValue'>
+																					<value/>
+																				</Condition>
+																				<Flags classname='Num'>
+																					<value>8192</value>
+																				</Flags>
+																				<CheckedState classname='Num'>
+																					<value>2</value>
+																				</CheckedState>
+																				<Type classname='PropertyObjectType'>
+																					<subprops>
+																						<ValueType classname='Num'>
+																							<value>3</value>
+																						</ValueType>
+																						<IsObject classname='Bool'>
+																							<value>true</value>
+																						</IsObject>
+																						<TypeName classname='Str'>
+																							<value/>
+																						</TypeName>
+																						<ElementType classname='Objs'>
+																							<value lbound='[0]' ubound='[]'/>
+																						</ElementType>
+																						<ArrayDimensions classname='ArrayDimensions'>
+																							<subprops>
+																								<LowerBounds classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</LowerBounds>
+																								<UpperBounds classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</UpperBounds>
+																							</subprops>
+																						</ArrayDimensions>
+																						<Representation classname='Num'>
+																							<value>1</value>
+																						</Representation>
+																						<ClassName classname='Str'>
+																							<value/>
+																						</ClassName>
+																					</subprops>
+																				</Type>
+																				<Elements classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</Elements>
+																				<IsAnyType classname='Bool'>
+																					<value>true</value>
+																				</IsAnyType>
+																			</subprops>
+																		</_NAME_IN_ATTRIBUTE_>
+																	</elemproto>
+																</value>
+															</CustomResults>
+															<AdditionalResultsHints classname='Objs'>
+																<value lbound='[0]' ubound='[]'>
+																	<elemproto>
+																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+																			<subprops>
+																				<Name classname='ExprValue'>
+																					<value/>
+																				</Name>
+																				<ValueToLog classname='ExprValue'>
+																					<value/>
+																				</ValueToLog>
+																				<Condition classname='ExprValue'>
+																					<value/>
+																				</Condition>
+																				<Flags classname='Num'>
+																					<value>8192</value>
+																				</Flags>
+																				<CheckedState classname='Num'>
+																					<value>2</value>
+																				</CheckedState>
+																				<Type classname='PropertyObjectType'>
+																					<subprops>
+																						<ValueType classname='Num'>
+																							<value>3</value>
+																						</ValueType>
+																						<IsObject classname='Bool'>
+																							<value>true</value>
+																						</IsObject>
+																						<TypeName classname='Str'>
+																							<value/>
+																						</TypeName>
+																						<ElementType classname='Objs'>
+																							<value lbound='[0]' ubound='[]'/>
+																						</ElementType>
+																						<ArrayDimensions classname='ArrayDimensions'>
+																							<subprops>
+																								<LowerBounds classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</LowerBounds>
+																								<UpperBounds classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</UpperBounds>
+																							</subprops>
+																						</ArrayDimensions>
+																						<Representation classname='Num'>
+																							<value>1</value>
+																						</Representation>
+																						<ClassName classname='Str'>
+																							<value/>
+																						</ClassName>
+																					</subprops>
+																				</Type>
+																				<Elements classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</Elements>
+																				<IsAnyType classname='Bool'>
+																					<value>true</value>
+																				</IsAnyType>
+																			</subprops>
+																		</_NAME_IN_ATTRIBUTE_>
+																	</elemproto>
+																</value>
+															</AdditionalResultsHints>
+														</subprops>
+													</TS>
+													<Result classname='Obj'>
+														<subprops>
+															<Error classname='Obj'>
+																<subprops>
+																	<Code classname='Num'>
+																		<value>0</value>
+																	</Code>
+																	<Msg classname='Str'>
+																		<value/>
+																	</Msg>
+																	<Occurred classname='Bool'>
+																		<value>false</value>
+																	</Occurred>
+																</subprops>
+															</Error>
+															<Status classname='Str'>
+																<value/>
+															</Status>
+															<ReportText classname='Str'>
+																<value/>
+															</ReportText>
+															<Common classname='Obj'/>
+														</subprops>
+													</Result>
+												</subprops>
+											</Step>
+										</value>
+										<value>
+											<Step typename='Action' xsi:type='Action' name='Destroy and unregister NI-DMM sessions'>
+												<subprops>
+													<TS classname='Obj'>
+														<subprops>
+															<Id classname='Str'>
+																<value>ID#:7IR8h+bm7RGhzZiQlrVX7C</value>
+															</Id>
+															<Icon classname='Str'>
+																<value/>
+															</Icon>
+															<SData typename='PythonStepAdditions' xsi:type='PythonStepAdditions' classname='CPythonModule'>
+																<subprops>
+																	<PythonCall classname='CPythonCall'>
+																		<subprops>
+																			<UseAdapterSettingsForInterpreterSession classname='Bool'>
+																				<value>false</value>
+																			</UseAdapterSettingsForInterpreterSession>
+																			<InterpreterSessionScope classname='Num'>
+																				<value>2</value>
+																			</InterpreterSessionScope>
+																			<PythonVersion classname='Str'>
+																				<value>3.9</value>
+																			</PythonVersion>
+																			<PythonVirtualEnvironmentPath classname='Str'>
+																				<value>.venv</value>
+																			</PythonVirtualEnvironmentPath>
+																			<InterpreterLocation classname='ExprValue'>
+																				<value/>
+																			</InterpreterLocation>
+																			<CreateIfInterpreterDoesNotExist classname='Bool'>
+																				<value>true</value>
+																			</CreateIfInterpreterDoesNotExist>
+																			<ModulePath classname='PathValue'>
+																				<value>teststand_nidmm.py</value>
+																			</ModulePath>
+																			<OperationType classname='Num'>
+																				<value>1</value>
+																			</OperationType>
+																			<OperationScope classname='Num'>
+																				<value>0</value>
+																			</OperationScope>
+																			<ClassName classname='Str'>
+																				<value/>
+																			</ClassName>
+																			<ClassInstanceLocation classname='ExprValue'>
+																				<value/>
+																			</ClassInstanceLocation>
+																			<FunctionOrAttributeName classname='Str'>
+																				<value>destroy_nidmm_sessions</value>
+																			</FunctionOrAttributeName>
+																			<Parameters classname='Objs'>
+																				<value lbound='[0]' ubound='[0]'>
+																					<elemproto>
+																						<_NAME_IN_ATTRIBUTE_ name='' classname='CPythonParameter' structureflags='0'/>
+																					</elemproto>
+																					<value>
+																						<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
+																							<subprops>
+																								<Name classname='Str'>
+																									<value>Return Value</value>
+																								</Name>
+																								<Type classname='Num'>
+																									<value>7</value>
+																								</Type>
+																								<ArgumentValue classname='ExprValue'>
+																									<value/>
+																								</ArgumentValue>
+																								<ArgumentDisplayValue classname='ExprValue'>
+																									<value/>
+																								</ArgumentDisplayValue>
+																								<AdditionalResults classname='Obj'>
+																									<subprops>
+																										<Input classname='PythonParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
+																													<value>1</value>
+																												</CheckedState>
+																											</subprops>
+																										</Input>
+																										<Output classname='PythonParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
+																													<value>1</value>
+																												</CheckedState>
+																											</subprops>
+																										</Output>
+																									</subprops>
+																								</AdditionalResults>
+																							</subprops>
+																						</CPythonParameter>
+																					</value>
+																				</value>
+																			</Parameters>
+																			<DefaultParamCategoryForArray classname='Num'>
+																				<value>5</value>
+																			</DefaultParamCategoryForArray>
+																		</subprops>
+																	</PythonCall>
+																</subprops>
+															</SData>
+															<PreCond classname='ExprValue'>
+																<value/>
+															</PreCond>
+															<LoadOpt classname='Str'>
+																<value>PreloadWhenExecuted</value>
+															</LoadOpt>
+															<UnloadOpt classname='Str'>
+																<value>UnloadWithFile</value>
+															</UnloadOpt>
+															<Mode classname='Str'>
+																<value>Normal</value>
+															</Mode>
+															<WindowActivation classname='Str'>
+																<value>None</value>
+															</WindowActivation>
+															<ResultOption classname='Num'>
+																<value>1</value>
+															</ResultOption>
+															<StepFCSeqF classname='Bool'>
+																<value>true</value>
+															</StepFCSeqF>
+															<IgnoreRTE classname='Bool'>
+																<value>false</value>
+															</IgnoreRTE>
+															<UseMutex classname='Bool'>
+																<value>false</value>
+															</UseMutex>
+															<MutexNameOrRef classname='ExprValue'>
+																<value/>
+															</MutexNameOrRef>
+															<BatchSyncOpt classname='Num'>
+																<value>0</value>
+															</BatchSyncOpt>
+															<SwitchEnabled classname='Bool'>
+																<value>false</value>
+															</SwitchEnabled>
+															<VirtualDeviceName classname='ExprValue'>
+																<value/>
+															</VirtualDeviceName>
+															<SwitchOperation classname='Num'>
+																<value>1</value>
+															</SwitchOperation>
+															<RouteGroupConnect classname='ExprValue'>
+																<value/>
+															</RouteGroupConnect>
+															<RouteGroupDisconnect classname='ExprValue'>
+																<value/>
+															</RouteGroupDisconnect>
+															<MulticonnectMode classname='Num'>
+																<value>1</value>
+															</MulticonnectMode>
+															<OperationOrder classname='Num'>
+																<value>2</value>
+															</OperationOrder>
+															<ConnectionLifetime classname='Num'>
+																<value>0</value>
+															</ConnectionLifetime>
+															<WaitForDebounce classname='Bool'>
+																<value>true</value>
+															</WaitForDebounce>
+															<PassAct classname='Str'>
+																<value>Next</value>
+															</PassAct>
+															<FailAct classname='Str'>
+																<value>Next</value>
+															</FailAct>
+															<PassActTarget classname='ExprValue'>
+																<value/>
+															</PassActTarget>
+															<FailActTarget classname='ExprValue'>
+																<value/>
+															</FailActTarget>
+															<CustExpr classname='ExprValue'>
+																<value/>
+															</CustExpr>
+															<CustTrueAct classname='Str'>
+																<value>Next</value>
+															</CustTrueAct>
+															<CustFalseAct classname='Str'>
+																<value>Next</value>
+															</CustFalseAct>
+															<CustTrueActTarget classname='ExprValue'>
+																<value/>
+															</CustTrueActTarget>
+															<CustFalseActTarget classname='ExprValue'>
+																<value/>
+															</CustFalseActTarget>
+															<LoopType classname='Str'>
+																<value>NoLooping</value>
+															</LoopType>
+															<LoopWhile classname='ExprValue'>
+																<value/>
+															</LoopWhile>
+															<LoopStatus classname='ExprValue'>
+																<value/>
+															</LoopStatus>
+															<LoopIncrement classname='ExprValue'>
+																<value>RunState.LoopIndex += 1</value>
+															</LoopIncrement>
+															<LoopInitialize classname='ExprValue'>
+																<value>RunState.LoopIndex = 0</value>
+															</LoopInitialize>
+															<LoopOpt classname='Num'>
+																<value>0</value>
+															</LoopOpt>
+															<PreExpr classname='ExprValue'>
+																<value/>
+															</PreExpr>
+															<PostExpr classname='ExprValue'>
+																<value/>
+															</PostExpr>
+															<StatusExpr classname='ExprValue'>
+																<value/>
+															</StatusExpr>
+															<CanSpecifyModule classname='Bool'>
+																<value>true</value>
+															</CanSpecifyModule>
+															<CanEditCode classname='Bool'>
+																<value>true</value>
+															</CanEditCode>
+															<CanEditModulePrototype classname='Bool'>
+																<value>true</value>
+															</CanEditModulePrototype>
+															<CanEditParameterAdditionalResults classname='Bool'>
+																<value>true</value>
+															</CanEditParameterAdditionalResults>
+															<PrecondIntExe classname='Num'>
+																<value>0</value>
+															</PrecondIntExe>
+															<CustomResults classname='Objs'>
+																<value lbound='[0]' ubound='[]'>
+																	<elemproto>
+																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+																			<subprops>
+																				<Name classname='ExprValue'>
+																					<value/>
+																				</Name>
+																				<ValueToLog classname='ExprValue'>
+																					<value/>
+																				</ValueToLog>
+																				<Condition classname='ExprValue'>
+																					<value/>
+																				</Condition>
+																				<Flags classname='Num'>
+																					<value>8192</value>
+																				</Flags>
+																				<CheckedState classname='Num'>
+																					<value>2</value>
+																				</CheckedState>
+																				<Type classname='PropertyObjectType'>
+																					<subprops>
+																						<ValueType classname='Num'>
+																							<value>3</value>
+																						</ValueType>
+																						<IsObject classname='Bool'>
+																							<value>true</value>
+																						</IsObject>
+																						<TypeName classname='Str'>
+																							<value/>
+																						</TypeName>
+																						<ElementType classname='Objs'>
+																							<value lbound='[0]' ubound='[]'/>
+																						</ElementType>
+																						<ArrayDimensions classname='ArrayDimensions'>
+																							<subprops>
+																								<LowerBounds classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</LowerBounds>
+																								<UpperBounds classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</UpperBounds>
+																							</subprops>
+																						</ArrayDimensions>
+																						<Representation classname='Num'>
+																							<value>1</value>
+																						</Representation>
+																						<ClassName classname='Str'>
+																							<value/>
+																						</ClassName>
+																					</subprops>
+																				</Type>
+																				<Elements classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</Elements>
+																				<IsAnyType classname='Bool'>
+																					<value>true</value>
+																				</IsAnyType>
+																			</subprops>
+																		</_NAME_IN_ATTRIBUTE_>
+																	</elemproto>
+																</value>
+															</CustomResults>
+															<AdditionalResultsHints classname='Objs'>
+																<value lbound='[0]' ubound='[]'>
+																	<elemproto>
+																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+																			<subprops>
+																				<Name classname='ExprValue'>
+																					<value/>
+																				</Name>
+																				<ValueToLog classname='ExprValue'>
+																					<value/>
+																				</ValueToLog>
+																				<Condition classname='ExprValue'>
+																					<value/>
+																				</Condition>
+																				<Flags classname='Num'>
+																					<value>8192</value>
+																				</Flags>
+																				<CheckedState classname='Num'>
+																					<value>2</value>
+																				</CheckedState>
+																				<Type classname='PropertyObjectType'>
+																					<subprops>
+																						<ValueType classname='Num'>
+																							<value>3</value>
+																						</ValueType>
+																						<IsObject classname='Bool'>
+																							<value>true</value>
+																						</IsObject>
+																						<TypeName classname='Str'>
+																							<value/>
+																						</TypeName>
+																						<ElementType classname='Objs'>
+																							<value lbound='[0]' ubound='[]'/>
+																						</ElementType>
+																						<ArrayDimensions classname='ArrayDimensions'>
+																							<subprops>
+																								<LowerBounds classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</LowerBounds>
+																								<UpperBounds classname='Nums'>
+																									<value lbound='[0]' ubound='[]'/>
+																								</UpperBounds>
+																							</subprops>
+																						</ArrayDimensions>
+																						<Representation classname='Num'>
+																							<value>1</value>
+																						</Representation>
+																						<ClassName classname='Str'>
+																							<value/>
+																						</ClassName>
+																					</subprops>
+																				</Type>
+																				<Elements classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</Elements>
+																				<IsAnyType classname='Bool'>
+																					<value>true</value>
+																				</IsAnyType>
+																			</subprops>
+																		</_NAME_IN_ATTRIBUTE_>
+																	</elemproto>
+																</value>
+															</AdditionalResultsHints>
+														</subprops>
+													</TS>
+													<Result classname='Obj'>
+														<subprops>
+															<Error classname='Obj'>
+																<subprops>
+																	<Code classname='Num'>
+																		<value>0</value>
+																	</Code>
+																	<Msg classname='Str'>
+																		<value/>
+																	</Msg>
+																	<Occurred classname='Bool'>
+																		<value>false</value>
+																	</Occurred>
+																</subprops>
+															</Error>
+															<Status classname='Str'>
+																<value/>
+															</Status>
+															<ReportText classname='Str'>
+																<value/>
+															</ReportText>
+															<Common classname='Obj'/>
+														</subprops>
+													</Result>
+												</subprops>
+											</Step>
+										</value>
+									</value>
+								</Cleanup>
+								<RecordResults classname='Bool' valueflags='4194312'>
+									<value>true</value>
+								</RecordResults>
+								<RTS classname='Obj' valueflags='4456456'>
+									<subprops>
+										<Type classname='Num' valueflags='4194304'>
+											<value>0</value>
+										</Type>
+										<OptimizeNonReentrantCalls classname='Bool' valueflags='4194304'>
+											<value>true</value>
+										</OptimizeNonReentrantCalls>
+										<EPNameExpr classname='Str' valueflags='4194304'>
+											<value>"Unnamed Entry Point"</value>
+										</EPNameExpr>
+										<EPEnabledExpr classname='Str' valueflags='4194304'>
+											<value>True</value>
+										</EPEnabledExpr>
+										<EPMenuHint classname='Str' valueflags='4194304'>
+											<value/>
+										</EPMenuHint>
+										<EPIgnoreClient classname='Bool' valueflags='4194304'>
+											<value>false</value>
+										</EPIgnoreClient>
+										<EPInitiallyHidden classname='Bool' valueflags='4194304'>
+											<value>false</value>
+										</EPInitiallyHidden>
+										<EPCheckToSaveTitledFile classname='Bool' valueflags='4194304'>
+											<value>true</value>
+										</EPCheckToSaveTitledFile>
+										<ShowEPAlways classname='Bool' valueflags='4194304'>
+											<value>false</value>
+										</ShowEPAlways>
+										<ShowEPForFileWin classname='Bool' valueflags='4194304'>
+											<value>true</value>
+										</ShowEPForFileWin>
+										<ShowEPForExeWin classname='Bool' valueflags='4194304'>
+											<value>false</value>
+										</ShowEPForExeWin>
+										<ShowEPForEditorOnly classname='Bool' valueflags='4194304'>
+											<value>false</value>
+										</ShowEPForEditorOnly>
+										<AllowIntExeOfEP classname='Bool' valueflags='4194304'>
+											<value>false</value>
+										</AllowIntExeOfEP>
+										<CopyStepsOnOverriding classname='Bool' valueflags='4194304'>
+											<value>true</value>
+										</CopyStepsOnOverriding>
+										<Priority classname='Num' valueflags='4194304'>
+											<value>2953567917</value>
+										</Priority>
+									</subprops>
+								</RTS>
+								<Requirements classname='Obj' valueflags='4456456'>
+									<subprops>
+										<Links classname='Strs' valueflags='71303168'>
+											<value lbound='[0]' ubound='[]'/>
+										</Links>
+									</subprops>
+								</Requirements>
+								<FailureAction classname='Num' valueflags='4194312'>
+									<value>2</value>
+								</FailureAction>
+							</subprops>
+						</Sequence>
+					</value>
+				</value>
+			</Seq>
+			<FileGlobalDefaults classname='Obj' valueflags='4194304'>
+				<subprops>
+					<MeasurementLink classname='Obj'>
+						<subprops>
+							<EnableMonitoring classname='Bool'>
+								<value>false</value>
+							</EnableMonitoring>
+							<PinMapPath typename='Path' xsi:type='Path' classname='PathValue'>
+								<value>MultipleMeasurements.pinmap</value>
+							</PinMapPath>
+						</subprops>
+					</MeasurementLink>
+				</subprops>
+			</FileGlobalDefaults>
+			<ModelFile typename='Path' xsi:type='Path' classname='PathValue' valueflags='4194312'>
+				<value/>
+			</ModelFile>
+			<LoadOpt classname='Str' valueflags='4194312'>
+				<value>UseStepLoadOpt</value>
+			</LoadOpt>
+			<UnloadOpt classname='Str' valueflags='4194312'>
+				<value>UseStepUnloadOpt</value>
+			</UnloadOpt>
+			<Version classname='Str' valueflags='4194312'>
+				<value>0.0.0.0</value>
+			</Version>
+			<BatchSync classname='Num' valueflags='4194312'>
+				<value>1</value>
+			</BatchSync>
+			<SFGlobalsScope classname='Num' valueflags='4194312'>
+				<value>0</value>
+			</SFGlobalsScope>
+			<Type classname='Num' valueflags='4194312'>
+				<value>0</value>
+			</Type>
+			<ModelOption classname='Num' valueflags='4194312'>
+				<value>0</value>
+			</ModelOption>
+			<Requirements classname='Obj' valueflags='4194305'>
+				<subprops>
+					<Links classname='Strs' valueflags='71303168'>
+						<value lbound='[0]' ubound='[]'/>
+					</Links>
+				</subprops>
+			</Requirements>
+		</subprops>
+	</Data>
+</teststandfileheader>

--- a/examples/multiple_measurements/README.md
+++ b/examples/multiple_measurements/README.md
@@ -1,0 +1,35 @@
+## Multiple Measurements
+
+This is a MeasurementLink example demonstrating how to interact with multiple measurement services
+from TestStand.
+
+### Features
+
+- Uses the `nidcpower_source_dc_voltage` and `nidmm_measurement` example measurements
+- Uses the `nidcpower` and `nidmm` packages to access NI-DCPower and NI-DMM from Python
+- Includes a TestStand sequence showing how to configure the pin map, register
+  instrument sessions with the session management service, and run multiple measurements
+- Uses the NI gRPC Device Server to allow sharing instrument sessions with other
+  measurement services when running measurements from TestStand
+
+### Required Driver Software
+
+- NI-DCPower
+- NI-DMM
+
+### Required Measurement Services
+
+Before running this example TestStand sequence, you must run or statically register the following
+measurement services:
+
+- [nidcpower_source_dc_voltage](../nidcpower_source_dc_voltage/)
+- [nidmm_mesaurement](../nidmm_measurement/)
+
+### Required Hardware
+
+This example requires an NI SMU that is supported by NI-DCPower (e.g. PXIe-4141) and an NI DMM
+(e.g. PXI-4072).
+
+To simulate an NI SMU or DMM in software: open `NI MAX`, right-click `Devices and Interfaces`,
+select `Create New...`, and select `Simulated NI-DAQmx Device or Modular Instrument`.
+SMUs are in the `Power Supplies` category. DMMs are in the `Digital Multimeters` category.

--- a/examples/multiple_measurements/_helpers.py
+++ b/examples/multiple_measurements/_helpers.py
@@ -1,0 +1,172 @@
+"""Helper classes and functions for MeasurementLink examples."""
+
+import logging
+import pathlib
+from typing import Any, Dict, NamedTuple, TypeVar
+
+import grpc
+
+from ni_measurementlink_service import session_management
+from ni_measurementlink_service._internal.discovery_client import DiscoveryClient
+from ni_measurementlink_service._internal.stubs.ni.measurementlink.pinmap.v1 import (
+    pin_map_service_pb2,
+    pin_map_service_pb2_grpc,
+)
+from ni_measurementlink_service.measurement.service import GrpcChannelPool
+
+
+class ServiceOptions(NamedTuple):
+    """Service options specified on the command line."""
+
+    use_grpc_device: bool = False
+    grpc_device_address: str = ""
+
+    use_simulation: bool = False
+
+
+T = TypeVar("T")
+
+
+def str_to_enum(mapping: Dict[str, T], value: str) -> T:
+    """Convert a string to an enum (with improved error reporting)."""
+    try:
+        return mapping[value]
+    except KeyError as e:
+        logging.error("Unsupported enum value %s", value)
+        raise grpc.RpcError(
+            grpc.StatusCode.INVALID_ARGUMENT,
+            f'Unsupported enum value "{value}"',
+        ) from e
+
+
+class PinMapClient(object):
+    """Class that communicates with the pin map service."""
+
+    def __init__(self, *, grpc_channel: grpc.Channel):
+        """Initialize pin map client."""
+        self._client: pin_map_service_pb2_grpc.PinMapServiceStub = (
+            pin_map_service_pb2_grpc.PinMapServiceStub(grpc_channel)
+        )
+
+    def update_pin_map(self, pin_map_path: str) -> str:
+        """Update registered pin map contents.
+
+        Create and register a pin map if a pin map resource for the specified pin map id is not
+        found.
+
+        Args:
+            pin_map_path: The file path of the pin map to register as a pin map resource.
+
+        Returns:
+            The resource id of the pin map that is registered to the pin map service.
+        """
+        pin_map_path_obj = pathlib.Path(pin_map_path)
+        # By convention, the pin map id is the .pinmap file path.
+        request = pin_map_service_pb2.UpdatePinMapFromXmlRequest(
+            pin_map_id=pin_map_path, pin_map_xml=pin_map_path_obj.read_text(encoding="utf-8")
+        )
+        response: pin_map_service_pb2.PinMap = self._client.UpdatePinMapFromXml(request)
+        return response.pin_map_id
+
+
+class GrpcChannelPoolHelper(GrpcChannelPool):
+    """Class that manages gRPC channel lifetimes."""
+
+    def __init__(self):
+        """Initialize the GrpcChannelPool object."""
+        super().__init__()
+        self._discovery_client = DiscoveryClient()
+
+    @property
+    def pin_map_channel(self) -> grpc.Channel:
+        """Return gRPC channel to pin map service."""
+        return self.get_channel(
+            self._discovery_client.resolve_service(
+                provided_interface="ni.measurementlink.pinmap.v1.PinMapService",
+                service_class="ni.measurementlink.pinmap.v1.PinMapService",
+            ).insecure_address
+        )
+
+    @property
+    def session_management_channel(self) -> grpc.Channel:
+        """Return gRPC channel to session management service."""
+        return self.get_channel(
+            self._discovery_client.resolve_service(
+                provided_interface=session_management.GRPC_SERVICE_INTERFACE_NAME,
+                service_class=session_management.GRPC_SERVICE_CLASS,
+            ).insecure_address
+        )
+
+    def get_grpc_device_channel(self, provided_interface: str) -> grpc.Channel:
+        """Return gRPC channel to specified NI gRPC Device service.
+
+        Args:
+            provided_interface (str): The gRPC Full Name of the service.
+
+        """
+        return self.get_channel(
+            self._discovery_client.resolve_service(
+                provided_interface=provided_interface,
+                service_class="ni.measurementlink.v1.grpcdeviceserver",
+            ).insecure_address
+        )
+
+
+class TestStandSupport(object):
+    """Class that communicates with TestStand."""
+
+    def __init__(self, sequence_context: Any) -> None:
+        """Initialize the TestStandSupport object.
+
+        Args:
+            sequence_context:
+                The SequenceContext COM object from the TestStand sequence execution.
+                (Dynamically typed.)
+        """
+        self._sequence_context = sequence_context
+
+    def get_active_pin_map_id(self) -> str:
+        """Get the active pin map id from the NI.MeasurementLink.PinMapId temporary global variable.
+
+        Returns:
+            The resource id of the pin map that is registered to the pin map service.
+        """
+        return self._sequence_context.Engine.TemporaryGlobals.GetValString(
+            "NI.MeasurementLink.PinMapId", 0x0
+        )
+
+    def set_active_pin_map_id(self, pin_map_id: str) -> None:
+        """Set the NI.MeasurementLink.PinMapId temporary global variable to the specified id.
+
+        Args:
+            pin_map_id:
+                The resource id of the pin map that is registered to the pin map service.
+        """
+        self._sequence_context.Engine.TemporaryGlobals.SetValString(
+            "NI.MeasurementLink.PinMapId", 0x1, pin_map_id
+        )
+
+    def resolve_file_path(self, file_path: str) -> str:
+        """Resolve the absolute path to a file using the TestStand search directories.
+
+        Args:
+            file_path:
+                An absolute or relative path to the file. If this is a relative path, this function
+                searches the TestStand search directories for it.
+
+        Returns:
+            The absolute path to the file.
+        """
+        if pathlib.Path(file_path).is_absolute():
+            return file_path
+        (_, absolute_path, _, _, user_canceled) = self._sequence_context.Engine.FindFileEx(
+            fileToFind=file_path,
+            absolutePath=None,
+            srchDirType=None,
+            searchDirectoryIndex=None,
+            userCancelled=None,  # Must match spelling used by TestStand
+            searchContext=self._sequence_context.SequenceFile,
+        )
+        if user_canceled:
+            raise RuntimeError("File lookup canceled by user.")
+        return absolute_path

--- a/examples/multiple_measurements/poetry.toml
+++ b/examples/multiple_measurements/poetry.toml
@@ -1,0 +1,2 @@
+[virtualenvs]
+in-project = true

--- a/examples/multiple_measurements/pyproject.toml
+++ b/examples/multiple_measurements/pyproject.toml
@@ -1,0 +1,33 @@
+[tool.poetry]
+name = "multiple_measurements"
+version = "0.5.0"
+description = "MeasurementLink example demonstrating how to interact with multiple measurement services from TestStand."
+authors = ["National Instruments"]
+
+[tool.poetry.dependencies]
+python = "^3.8"
+nidcpower = ">=1.4.3"
+nidmm = ">=1.4.3"
+ni-measurementlink-service = "^1.0.0"
+click = ">=7.1.2"
+grpcio = "*"
+
+[tool.poetry.group.dev.dependencies]
+mypy = ">=1.0"
+# Uncomment to use prerelease dependencies (requires poetry>=1.2).
+# nidcpower = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/nidcpower"}
+# nidmm = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/nidmm"}
+# ni-measurementlink-service = {path = "../..", develop = true}
+
+[build-system]
+requires = ["poetry-core>=1.2.0"]
+build-backend = "poetry.core.masonry.api"
+
+[[tool.mypy.overrides]]
+module = [
+    "grpc.*",
+    "ni_measurementlink_service.*", # TODO: remove after 1.0.2 is released with py.typed marker
+    "nidcpower.*",
+    "nidmm.*",
+]
+ignore_missing_imports = true

--- a/examples/multiple_measurements/teststand_nidcpower.py
+++ b/examples/multiple_measurements/teststand_nidcpower.py
@@ -1,0 +1,76 @@
+"""TestStand code module for setting up NI-DCPower sessions with MeasurementLink."""
+from typing import Any
+
+import nidcpower
+from _helpers import GrpcChannelPoolHelper, TestStandSupport
+
+import ni_measurementlink_service as nims
+
+
+def create_nidcpower_sessions(sequence_context: Any) -> None:
+    """Create and register all NI-DCPower sessions.
+
+    Args:
+        sequence_context:
+            The SequenceContext COM object from the TestStand sequence execution.
+            (Dynamically typed.)
+    """
+    with GrpcChannelPoolHelper() as grpc_channel_pool:
+        session_management_client = nims.session_management.Client(
+            grpc_channel=grpc_channel_pool.session_management_channel
+        )
+
+        teststand_support = TestStandSupport(sequence_context)
+        pin_map_id = teststand_support.get_active_pin_map_id()
+
+        pin_map_context = nims.session_management.PinMapContext(pin_map_id=pin_map_id, sites=None)
+        with session_management_client.reserve_sessions(
+            context=pin_map_context,
+            instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_DCPOWER,
+            # This code module sets up the sessions, so error immediately if they are in use.
+            timeout=0,
+        ) as reservation:
+            for session_info in reservation.session_info:
+                grpc_options = nidcpower.GrpcSessionOptions(
+                    grpc_channel_pool.get_grpc_device_channel(
+                        nidcpower.GRPC_SERVICE_INTERFACE_NAME
+                    ),
+                    session_name=session_info.session_name,
+                    initialization_behavior=nidcpower.SessionInitializationBehavior.INITIALIZE_SERVER_SESSION,
+                )
+
+                # Leave session open
+                nidcpower.Session(
+                    resource_name=session_info.resource_name, grpc_options=grpc_options
+                )
+
+            session_management_client.register_sessions(reservation.session_info)
+
+
+def destroy_nidcpower_sessions() -> None:
+    """Destroy and unregister all NI-DCPower sessions."""
+    with GrpcChannelPoolHelper() as grpc_channel_pool:
+        session_management_client = nims.session_management.Client(
+            grpc_channel=grpc_channel_pool.session_management_channel
+        )
+
+        with session_management_client.reserve_all_registered_sessions(
+            instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_DCPOWER,
+            # This code module sets up the sessions, so error immediately if they are in use.
+            timeout=0,
+        ) as reservation:
+            session_management_client.unregister_sessions(reservation.session_info)
+
+            for session_info in reservation.session_info:
+                grpc_options = nidcpower.GrpcSessionOptions(
+                    grpc_channel_pool.get_grpc_device_channel(
+                        nidcpower.GRPC_SERVICE_INTERFACE_NAME
+                    ),
+                    session_name=session_info.session_name,
+                    initialization_behavior=nidcpower.SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION,
+                )
+
+                session = nidcpower.Session(
+                    resource_name=session_info.resource_name, grpc_options=grpc_options
+                )
+                session.close()

--- a/examples/multiple_measurements/teststand_nidmm.py
+++ b/examples/multiple_measurements/teststand_nidmm.py
@@ -1,0 +1,70 @@
+"""TestStand code module for setting up NI-DMM sessions with MeasurementLink."""
+from typing import Any
+
+import nidmm
+from _helpers import GrpcChannelPoolHelper, TestStandSupport
+
+import ni_measurementlink_service as nims
+
+
+def create_nidmm_sessions(sequence_context: Any) -> None:
+    """Create and register all NI-DMM sessions.
+        
+    Args:
+        sequence_context:
+            The SequenceContext COM object from the TestStand sequence execution.
+            (Dynamically typed.)
+    """
+    with GrpcChannelPoolHelper() as grpc_channel_pool:
+        session_management_client = nims.session_management.Client(
+            grpc_channel=grpc_channel_pool.session_management_channel
+        )
+
+        teststand_support = TestStandSupport(sequence_context)
+        pin_map_id = teststand_support.get_active_pin_map_id()
+
+        pin_map_context = nims.session_management.PinMapContext(pin_map_id=pin_map_id, sites=None)
+        with session_management_client.reserve_sessions(
+            context=pin_map_context,
+            instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_DMM,
+            # This code module sets up the sessions, so error immediately if they are in use.
+            timeout=0,
+        ) as reservation:
+            for session_info in reservation.session_info:
+                grpc_options = nidmm.GrpcSessionOptions(
+                    grpc_channel_pool.get_grpc_device_channel(nidmm.GRPC_SERVICE_INTERFACE_NAME),
+                    session_name=session_info.session_name,
+                    initialization_behavior=nidmm.SessionInitializationBehavior.INITIALIZE_SERVER_SESSION,
+                )
+
+                # Leave session open
+                nidmm.Session(resource_name=session_info.resource_name, grpc_options=grpc_options)
+
+            session_management_client.register_sessions(reservation.session_info)
+
+
+def destroy_nidmm_sessions() -> None:
+    """Destroy and unregister all NI-DMM sessions."""
+    with GrpcChannelPoolHelper() as grpc_channel_pool:
+        session_management_client = nims.session_management.Client(
+            grpc_channel=grpc_channel_pool.session_management_channel
+        )
+
+        with session_management_client.reserve_all_registered_sessions(
+            instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_DMM,
+            # This code module sets up the sessions, so error immediately if they are in use.
+            timeout=0,
+        ) as reservation:
+            session_management_client.unregister_sessions(reservation.session_info)
+
+            for session_info in reservation.session_info:
+                grpc_options = nidmm.GrpcSessionOptions(
+                    grpc_channel_pool.get_grpc_device_channel(nidmm.GRPC_SERVICE_INTERFACE_NAME),
+                    session_name=session_info.session_name,
+                    initialization_behavior=nidmm.SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION,
+                )
+
+                session = nidmm.Session(
+                    resource_name=session_info.resource_name, grpc_options=grpc_options
+                )
+                session.close()

--- a/examples/multiple_measurements/teststand_pin_map.py
+++ b/examples/multiple_measurements/teststand_pin_map.py
@@ -1,0 +1,27 @@
+"""TestStand code module for setting up pin maps with MeasurementLink."""
+from typing import Any
+
+from _helpers import GrpcChannelPoolHelper, PinMapClient, TestStandSupport
+
+
+def update_pin_map(pin_map_path: str, sequence_context: Any) -> str:
+    """Update registered pin map contents.
+
+    Create and register a pin map if a pin map resource for the specified pin map id is not found.
+
+    Args:
+        pin_map_path:
+            An absolute or relative path to the pin map file.
+        sequence_context:
+            The SequenceContext COM object from the TestStand sequence execution.
+            (Dynamically typed.)
+    """
+    teststand_support = TestStandSupport(sequence_context)
+    pin_map_abs_path = teststand_support.resolve_file_path(pin_map_path)
+
+    with GrpcChannelPoolHelper() as grpc_channel_pool:
+        pin_map_client = PinMapClient(grpc_channel=grpc_channel_pool.pin_map_channel)
+        pin_map_id = pin_map_client.update_pin_map(pin_map_abs_path)
+
+    teststand_support.set_active_pin_map_id(pin_map_id)
+    return pin_map_id

--- a/examples/nidcpower_source_dc_voltage/NIDCPowerSourceDCVoltage.seq
+++ b/examples/nidcpower_source_dc_voltage/NIDCPowerSourceDCVoltage.seq
@@ -4959,7 +4959,7 @@
 																				<value>true</value>
 																			</CreateIfInterpreterDoesNotExist>
 																			<ModulePath classname='PathValue'>
-																				<value>teststand_fixture.py</value>
+																				<value>teststand_pin_map.py</value>
 																			</ModulePath>
 																			<OperationType classname='Num'>
 																				<value>1</value>
@@ -5452,7 +5452,7 @@
 																				<value>true</value>
 																			</CreateIfInterpreterDoesNotExist>
 																			<ModulePath classname='PathValue'>
-																				<value>teststand_fixture.py</value>
+																				<value>teststand_nidcpower.py</value>
 																			</ModulePath>
 																			<OperationType classname='Num'>
 																				<value>1</value>
@@ -6196,7 +6196,7 @@
 																				<value>true</value>
 																			</CreateIfInterpreterDoesNotExist>
 																			<ModulePath classname='PathValue'>
-																				<value>teststand_fixture.py</value>
+																				<value>teststand_nidcpower.py</value>
 																			</ModulePath>
 																			<OperationType classname='Num'>
 																				<value>1</value>

--- a/examples/nidcpower_source_dc_voltage/teststand_nidcpower.py
+++ b/examples/nidcpower_source_dc_voltage/teststand_nidcpower.py
@@ -1,33 +1,10 @@
-"""Functions to set up and tear down sessions of NI-DCPower devices in NI TestStand."""
+"""TestStand code module for setting up NI-DCPower sessions with MeasurementLink."""
 from typing import Any
 
 import nidcpower
-from _helpers import GrpcChannelPoolHelper, PinMapClient, TestStandSupport
+from _helpers import GrpcChannelPoolHelper, TestStandSupport
 
 import ni_measurementlink_service as nims
-
-
-def update_pin_map(pin_map_path: str, sequence_context: Any) -> str:
-    """Update registered pin map contents.
-
-    Create and register a pin map if a pin map resource for the specified pin map id is not found.
-
-    Args:
-        pin_map_path:
-            An absolute or relative path to the pin map file.
-        sequence_context:
-            The SequenceContext COM object from the TestStand sequence execution.
-            (Dynamically typed.)
-    """
-    teststand_support = TestStandSupport(sequence_context)
-    pin_map_abs_path = teststand_support.resolve_file_path(pin_map_path)
-
-    with GrpcChannelPoolHelper() as grpc_channel_pool:
-        pin_map_client = PinMapClient(grpc_channel=grpc_channel_pool.pin_map_channel)
-        pin_map_id = pin_map_client.update_pin_map(pin_map_abs_path)
-
-    teststand_support.set_active_pin_map_id(pin_map_id)
-    return pin_map_id
 
 
 def create_nidcpower_sessions(sequence_context: Any) -> None:

--- a/examples/nidcpower_source_dc_voltage/teststand_pin_map.py
+++ b/examples/nidcpower_source_dc_voltage/teststand_pin_map.py
@@ -1,0 +1,27 @@
+"""TestStand code module for setting up pin maps with MeasurementLink."""
+from typing import Any
+
+from _helpers import GrpcChannelPoolHelper, PinMapClient, TestStandSupport
+
+
+def update_pin_map(pin_map_path: str, sequence_context: Any) -> str:
+    """Update registered pin map contents.
+
+    Create and register a pin map if a pin map resource for the specified pin map id is not found.
+
+    Args:
+        pin_map_path:
+            An absolute or relative path to the pin map file.
+        sequence_context:
+            The SequenceContext COM object from the TestStand sequence execution.
+            (Dynamically typed.)
+    """
+    teststand_support = TestStandSupport(sequence_context)
+    pin_map_abs_path = teststand_support.resolve_file_path(pin_map_path)
+
+    with GrpcChannelPoolHelper() as grpc_channel_pool:
+        pin_map_client = PinMapClient(grpc_channel=grpc_channel_pool.pin_map_channel)
+        pin_map_id = pin_map_client.update_pin_map(pin_map_abs_path)
+
+    teststand_support.set_active_pin_map_id(pin_map_id)
+    return pin_map_id

--- a/examples/nidmm_measurement/NIDmmMeasurement.seq
+++ b/examples/nidmm_measurement/NIDmmMeasurement.seq
@@ -1670,6 +1670,647 @@
 		</typedef>
 		<protected>E@=3DJC4100hYLECF=_K@0@mKCYo_1KN:&lt;Ta239hF9[gHbEVFDfRINZfQ01CkaUMk5=k`[c;[42MMF9aiNliecVfMFCLXi_`f2H7c\G\X50M=Z4S4aT2QI&gt;A^D:d1\PCI`L11RlV5bM5AIZTc9STI5Mkg&lt;bHlle[O=CL_KEgb?8RiVHS7QmPY@S4X^7I58A@kPaKcPWCOC1;DBf61lViY=]`28BC\B_mEf20ZJS@W@GDDRffLe\Ci;aKbN&gt;i5P_4ScVVBTjIIfn0j8l&lt;e6IcMbZHgCI;n8CRlR7&lt;YcK0@cY[8aDHj=GGkNK;C?KC?b=]mMejoc1gGol1&gt;hL6lf5fZ92?Ia@l1;QL024f^NSm2MhNlcFg_YR[l5kclo:einXehbR&gt;98[4?GC:CX[3hm\UMob2aIMT0eJmgI@\;njRK9]fIl_8f=d]n4bQcRXDEl&lt;o=@Yiik\3Md@?k1=0Joj&gt;?Je`&lt;RUd&lt;JYmeOnOgB3G@Ub\FoGFgIQmQli8nGH=QjKD9i`2nf41XEKj;oDB8iZU`@XP^KWoAKEbOf:ViVAl=_I37KJSec7Ea\nJ5]NZj\OnJF;ASQemRIDbbdglb\U&gt;H[O^bDHO?XMLaOoeVCf=a^CC`d8^TX2B</protected>
 		<protected>E@=3@J\4110h]L]Mg[cK3fBoj\Kifo1C[KY_3VgFm3_6n&gt;DfdTDgjaSF_LdVUJaY::FII@T:GB9LaYOo80OP^053LBBVb1G?:50k4;P1c\^`03ffoj9S72=AOm;a2oh?Na\lC7TUOXcNfaSdfIbVCC_ao20aN9bmo_&lt;R_S=&gt;KV;lhbmh89SY[:2UflXcmGIlnngoE]\\ad_6_gW8X9GAXJSPJYin&gt;C71=c74a79JN&lt;`GPK]_\&gt;2`h9IOC]VA5BU4AMW1Qc`j?lJ\aR4__&gt;R4SI_`[_mmnM33ONg`3P[g4N5aSF;ce]^eVffg6&gt;cIRLhI]7CjE^W[jW`kZkGEWHk1=RR;gTe:O[H;k[bAd7UCaTVXgjlho3Af&gt;?oIJdjMo&gt;3=o;aTo\ZZnG9_cgcO7mjV^k&gt;\:gkoOkSn1jkfm@MgLnb&lt;Amg;\Nmj8klk3llhhnW&gt;nn^GCW_fW_&gt;ji]:Va&gt;TNnNQdK5LolNX?M@\6jN2ddlIHh=MT1E^[o4Q7I54R=RlVg[S\KmOe9GM:Qeh9OnUhWTeC^ZM7SAGP1V=LZ4[i\cOmoH[RS6YBL2L\PAg][JQ&lt;Eo?8;D9Mk3M]&gt;N^6&gt;HgJ]KP^a&gt;cfBkkmZ33RdU`]jB_NIOShWL4oDlbn3lNOCL??R7GCmKaTDhekoi_En`9oJKe&lt;e1`lBjmjXJ&lt;^4_^_^&gt;?7O?nEE_WTY:VYEc]3^eJm^cdC7;LcK_]Ei&gt;b&lt;^`9HR6YcO&gt;l@Amg&gt;PLXQbSb^=?FXRUZd&lt;[n&lt;SGjgCQ`mhTl;7NUbgaRQBkXNY4iX5iAJX6C`gdG[d3d&gt;`Uj3DPMF7h71WBBLLR&gt;Tk9dZlFCYSi__fNBBT`C;A&gt;jeP2CdONN52i5^eBEIEI=8EMHBBe^G^1ohD6&gt;LRiJgM\IPYE8Wn`T9W@jf8iEfN:@L3&lt;Ha_l0CCE&lt;HOJjXBRll_NLReo_^K7CQWihL&lt;B1::YXdSaG&lt;XFnCP94dQXb;^6V07F&gt;TkPem&gt;4QI;?9JkF`g80:`G?AULFSY^XW;4XL^_D=GZV9VVODS^[=]dL]b=N;O[ib6]2aLATM7\AcX=JH&lt;\1j8_?I9_VUO]5;PKjdi^o&gt;Kn=FbmhAmF3EXh?dAPF?cWPU;NHFT9YBblF15fj0n]RK9&gt;d;@lD9HXLGTZOAa;gEd6:MElAPOkOoMom`hnaYko^ne_;PeC\`kMYOoCalP3DR_^NADNSV6R1Nk4f?=Lo;VQ&gt;7&gt;fR@=2j8C:;D@3fk&gt;^=YHE^PQ1fU&gt;TFoNH&gt;GnfRGNMNW`[okK`S56RJfM4Zmo^6E9ZYc&gt;FNEO3PO=T9eK0:bgljYdR7WooKS9eTjd@bcImNVZ8UXa:AC_F_WCj]4\6ST&lt;:ie_AbZFIL7UmlIne:BcTQ5T2U]O2goYWXRN5F8oeQT^`HXPD=2LV[h;ibbNNj1kU]lXlnX4ACO5aRA@TfHY77@P?L=_N@4^cJG;Wi2@3M5OQ:^@&gt;2K9_9W:4Vn1LGaRN@WL9AFFVg1oYHdi`54XIa5G[\i&gt;iPT4506XA7h2^c_T`3d[ARdFICaAS2RM:1KgT7B&gt;MhXVaI&lt;kA^@CX2aS^I:B&gt;=W&lt;U?l&lt;DWU&lt;Jd7^cKe2R]EdIBcBQZni_K1JPCEhV&gt;VH]FBZ&lt;5413k[U]MAFA`Ohma2g2NoU0@E;FI93Yi;RjnlScC;`glEaH^X@K[NY9Y1EUZc6V6\3?FKC0APU0^[aP:_GMI=eeWnJ&lt;6e2]@;AXaAE&lt;S[lhAb`XFjPP@dTXNYS=&lt;568je\`W3?@gn9HDaM84^&gt;SDl0&lt;Ba6YNKCeYZ\CUU?WGnR4=m^aN[KTlFG\?VZ[MC:3HfflAagl\jZUG@ScZW:2K\FU9TQa&lt;h;?iYb&lt;RJI66IEg&lt;WHgdkU:\KFIZG\BDU=9W&gt;:\:W7nM3NIjXT;2YV[@dDaY3bhOQY^af&lt;UVo:ZV^^@0d_M5ObRQ2PIHZ9bbbGm;4Z\KEfEYI=M];D@9j1kZ@2@FIkf9:\CYe5KnKANXH7R@eMc2M;Pl]PZG]@4h2Q7OY:=QFh@\Y6]E6X1bL6mjS76a`JS=H=XQReG6Djb7[c&lt;h@S5UCX4`ABLQ4:ZZ7=JF9JejC5\[T:meE5_[:`Qm=DfI0EDQLRH6o]LAPRXlbTgXSbnW7ZTN?N]lH02JKm;Z4hn&lt;A[89:C8lM5hC]Ab^\\WNK7JGS]XainLm:PWFF3EmC15\]YC\D;I6a&lt;NiIhd2GMIG`A9\[]T00fP:UXIXSHk2jI&gt;XFG&gt;I521bbKDA`Xb]h&gt;oAl&gt;IolbRB7j=i9_H89&lt;FR=U572U\LjNhnkeeemHDJJ\GHX\;J51M&lt;?QV2DneREAR3in6&lt;M75M_Re=Ci3gEOQ2VO`4P8_hfhSO\dZ7m]n\hlV6gSlSC@PoZSe8WUaY3d0_;Z=9H:I6Gf2PVG`mf8CC87@DBlT62^h6QFFhZF64BJ46@Dh&lt;T1=C]0_9J?073S@61ADIUT31&lt;mVE&lt;W?R@RBUJP`@;50X2Bh618KM^bf033T033D?NM@P`?0\dBA3A8AXF0]@KnP[5&lt;EDfUICcBF^EZT=:cWKBKYTDKXD=&lt;A:mkNB7LFDHC9b7nG57NFZ1]Ubo]8]0MN]YWJJ&gt;eS42I?===3_n_?J=384=Go8e^0mdmBiTjRaf;F@8M4_gCZSGQ3cUUnF6J_R9WJV0PNaTJDk&lt;RiWS6=&gt;Rf9EmM:WgL4LHg5oH[aMbbOlnI6b`9KZ^Z]oAdeH\@YgaV8ChHTKjEVA]a^YN&lt;;71CAbR\&lt;jAYI\\Y&lt;R\`1AOol`j1&gt;53?d8MV_@kAN_W4nIdKc0gRYHEo`]U?HWN?0&lt;?l2h:ZC\&gt;^D]Ug4FNZl123fNoZ7fLRB[_HR6O&gt;BaoomWl_8YS0Q\8;RB]@j=GIIe]J&lt;AT[;1I&lt;5ZJ\?Va5g?&gt;7hXgcbU4V=lT&gt;nV[28JKeQJ5QX4^WD3MfTBIBPKU57e&gt;[FRd&gt;_EeSHJhDa4hM9S9TUlOR=KWn]eAJ]W5VROh9ak`n5&lt;LV6L9d&lt;0`?fk]J8FW52OlL2i&lt;L1kO=mGBf9e:\`^[_J:F&gt;7o0_9mGc_`=KP@SW_^NU525JcQcEGhR8Da3gf4mJ?R6a2lLPKjL:TlfL8iHOKf:Mjeb\&gt;Xb3&gt;0kM@iNkaifYHDFNIKP\e^;bhg@V&lt;g0Za7F]R=JKPMgdg&gt;nYaMSb8MAV0o05XKjM5&lt;5^V=albT\&lt;868hhl^jHPRa0KcT4i[31chfOeGW&gt;;``&gt;&gt;I;B:YafYW&gt;jW_7D1&gt;9_X14U9VXJ5E_PA2ZPb&gt;n6eBLcN]SU4eSd&lt;IDGD4D5WHMlFCU0DeARScb:h\?EC1&gt;IBWead&gt;7F&gt;FeBea\oCS]jf@kE47ZHcB?TlP6_K[QC2@_N&gt;ilNn0VdgZE&gt;Z98hXCHa4bNUM16M74Q;DhldmcZ&gt;V?_TG1J?NI:F8&lt;aomhdPX5^AEe6BRYle4clf_gSb6D9LaD2h]ij8SAH@[`J@cb2G7ee@iZWl2A&gt;`Ga95FDhJo7Xo&gt;Zd3[jL&lt;DQ4OILX9a;0T\SUDWY:Bh&gt;WGNb:dHQ[S`[8:1L:F@&gt;H[49RQ6_3QV&lt;UT0oIITF^H_\X=:&lt;42`N``YjM75HWEd]5O`&lt;EX89FTP`^oN:QHgED5k:\CaYbA2GbD1;X5:N;?SoLhVhR`R_9lg3hU4n:I`2Gn:IjDHED]5i=2fcTklTK1H6k4HjK;HBM&gt;;c]9;i[MFD?WaY1O]oS293kLd9S3N6He?:_QKEcBGLOc:jB6H@fR]h]HGB5;:&lt;RE&lt;`3K4Ibi29dR;nU&lt;&lt;TKBRnTdK[ZTT6oiOVVXKgaP6&lt;lMTO_JC\0&lt;RY5NkR352&lt;FbcCB&lt;_3?0XjQ`BJP;OJR::8eHFb3&lt;;M\9FOC8T:MkD:Z;C=eb^0:AMSbSY_^Lc=SGbD5WDh@6j]PCDc@;\X1Nb\[`Z0W_Th5&lt;HD4CafYghb`T95Ko571]SZJDHF2eE&lt;7jViL_\8TQ@dFRo]`G[h3&gt;862l:2F[UU6dVbFjU?NI&gt;OHOk&gt;JNcFNU[mXi]iJ[neWQ\mWa]i[e?IkO^Mf]LHTP[G3?43M8g^Wh``lW3kBT7ADM6b_IUCIPO=C8g5@?9R3&lt;hilXNY7_&lt;THNN&lt;KMLm;eGM6_A6AUDB\c5Q;S2POniP9[mdEeIDnO7;T7Nia2nFN\L2XZIP?ZJKW\2cK0U5fb[dLn?[C&gt;YAMXfVFic02OQA\6LHEk0oBd0f;`kR1hImAUl:@I;^:oFJUF?mDgPlLokm]OIgenn9;n5[Oh3g7@W7OWBCk9X1mYDPF9AQ4LOGeM_D_WR?I7QRlVEmN_0QlA9^lO[HjnfngGjkHokO\A35=_4hVU^jKm;\?Y9^B=RkTG1I&lt;6nI`AQ_kJ;of[GmIi[g0]1\UG_FKUnX]ZcGmoI;NUdDFOolHn;NbMLkT`1GEo;j63N_8b_O`PQ[KRjb&lt;NDHW4;\lT[Ila;nMd`56_c\C25fJLUS;9fn@6[[SMIBBMFK\8d;ZIRSI;fJ5_cojWSIfcY2kNd1jkS0f9A3BNfk8W1m4H0gRbfA3J6Q726nmNm4PQYcWZ___NEf_FmmmOm40IZ1mf4PmS?H8k&gt;=J3g&lt;\1K6j;CNTGZ8kY61mk30RLUO`T`_H`Hg&lt;`\K67=HJ3g&lt;\3K6iGRVO9``_1H`L`\K6`f=371ikY61mf30S&lt;W]K86enT`_H`Hg&lt;=fbaLQO`c@&lt;hK;Rmmf&gt;KT=]4\mm;NkW]^mcFgV[_]l=8aHk_j]MgIEYV5XJkiW]l^^CKnYn2OgNJ0g&lt;fR\mWo;?JNcFN^cfL_eWZ[Eff[LeWebL[d?YfWFm3O0neW6m3NP3nGQ@G_M?lS61c3KG?`NUXHYTJ?j1SoC7V&gt;RGj_]d[blRO_M^Qg&gt;f_[0oQJWgg`CkhXXJ\hG;1Ujg`4MNjIg_6l3GG;oohYSNBallm3eZnFmebBeaLSDIS17WJfDBN9nUo^n2oC_;Q\;4O3WWk7mAZI17;2]ChHfZeJ;I\fY;^dB\J;NW@cEDj]HE]B8GSiKJgN9M6f4UIKhV02kFjYnXXBH9lF?3gDC&lt;EC`d=4l&lt;aIYa?]YS&lt;9Zl8]AkXcPg:6L69WWX^8R2;YXfC&lt;Xg6AQg@oOoChH=41ln]AG?J3U0Wn&gt;8[8cdWGUnL2Z&gt;Ll4HaNcI&lt;f]SiWCVXSMeP?^a7:Tf&lt;`L3cKdmDl7?Uj&gt;FnPG5NSQBkHE`Yj&gt;ZNQ^;UbDk0kCT]3]YV&lt;50o&lt;2&lt;aTY7THb5hg;3^hl@GYRZE@mbL?5gdHJNW5`6W8[eho^38?;R459L4WN1Jg[egNX[3[_&gt;lAAY&gt;L9Z_H5YN]9:KZMj\cPGZco]??=ig[hH7YShgPS8:44leI:@9R?fLHKlH6UZ]nlAXHFAFUn7AdT=;FK^oZgocoK[2W_=Aj]T;2mBd8`7h`B0K&gt;IP&lt;04@S6]dA9N`8Q8YBk19T@8RFF4T29OB1V7TX7QM01@hI@3`QJ=4@H\nBkS2d5P1BDgN8?4B230Y8lb8ONC@?IPH0A@OMPD?HZ@1`&gt;mj`5N5c60PN06hNI1c8`@k6b0M9IN3`QM68;M1l5Bl&gt;6cX&gt;XD78V@S2j5Ad;C&lt;0cA7OX0nM8&lt;iaN3K0@0Kil664BNSOe:0@R=6NA66f9@PX0d0dHb:LL\6@1aSJl[5h6I38X&lt;0`;0&lt;Al748MXb84H=@Y&lt;lI\5@GNMD;RJd?DeY0Ac1J230g&gt;d1e00LP8d;&gt;V@59CQA1BG&lt;@2[2A45hE8CX:H0A=a\KRAC&lt;Q0YPRb5D&lt;IR63P1QX&lt;JXCS9a3FQ&gt;daQVRjO4I;1da1URZ;LZ444@R2PX2XAXA9Te@FngkoKI_ea&gt;NZN^m\`1H5CMhX9Bn1?ZYS0WAbR2RD8F3W@XajF1=AXS6&lt;TS4i09PN?`gPUG9G3J26`2GbAW]jGY5&lt;AGn^iZAjM_;W5&lt;g^kKMC]B[X13GZm3mmNffKMhb:cJ]DAT&gt;a?_4H8jZX2PIja6[DFTFC:]l]=1AN=PD`VJ&gt;HX2k?Pj7:bQ`W[XWe0\38&lt;V=I\:]2HOl74S6e0a;ZmCFf:3FnRcED67[hUWZPU7ZZKLUVD\PFX_FVE23Q7WUaWV=U&gt;&lt;ZRLQB8LDd0hS94OC1D?6J9N:\\`US2k:iaJY8jY]eTVWO0KLeICMh3dn\dH86aYA7eY]eZZ3=d6WJLE7IPEWIe=_c4FYLEhdA\b5XoJQE;n[HFdKI7C3oK`RFK6l`B8RhhCXhP8XnP3841548PB6P6B[DKHS41JU&lt;Qne:U\ARQ=B[VDHSOT307XA07Qhn2d8RBoajKU&gt;9P@S2lYle3RId0IIf072nP8&gt;;NUah=0ilGD:G5\RN_\=;5jTD@iTfQNGIfmQJ2oJl[SBFC]DLncWBE4mFZe6d_Ob&gt;3YC4APEA@D_mOFNI8ALek79bT&gt;:a8]EjYToY&lt;]8C`FV4Z``X`1aB@L&lt;?V9ARCQ4c:K71jA4o8X@_N2@;?hf9D0M0]D;:A]?]T5@Y1`&gt;Vi=L5H`I25YCYJTF@F?fd@VbI9Pf6?dDZY8JdAcR`QM5&gt;MT&lt;aOnO7&lt;DiRiB;\k?RRIHVCkC&lt;FWi=5fXF\he2n@Q&gt;2TEkZIo6kBK3\C@]3\oE]=7UY8knVi7O5=^_a6d;G^?DaLI=YY]ARAc7NRDMhAYZlK90=KQlem6G@;;lecBDFecfKNA=H&gt;mJl3I59=NFgn`nf[B1:05f5E[`fiTPQ4EDe1H=4ZRWkf3TWlOP&gt;Ela5hZDn]cQJC=UBXIIJdWiR@KZe]DHRbmfI;]VYoi&gt;o?3K1h=6</protected>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='21'>
+			<Action classname='StepType' isroottypedef='true' typecategory='1' timestamp='1618215606' typeversion='21.0.0.2' typelastmodversion='21.0.0.0' typeminprodversion='21.0.0.0' typeflags='33554446'>
+				<subprops>
+					<Substeps typename='StepTypeSubstepsArray' xsi:type='StepTypeSubstepsArray' classname='Objs' flagsforinstances='524312' instanceoverrideflags='655384'>
+						<value lbound='[0]' ubound='[]'/>
+					</Substeps>
+					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
+						<value>ResStr("NI_STEPTYPES", "ACTION_DESCRIPTION_NAME") + (("%ModuleDescription" == "") ? "" : ",  %ModuleDescription")</value>
+					</DescriptionFormat>
+					<DefaultNameFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
+						<value>ResStr("NI_STEPTYPES", "ACTION_DEF_STEP_NAME")</value>
+					</DefaultNameFormat>
+					<Menu typename='StepTypeMenu' xsi:type='StepTypeMenu' classname='Obj' flagsforinstances='524312' instanceoverrideflags='524312'>
+						<subprops>
+							<CanBeSubstepType classname='Bool'>
+								<value>false</value>
+							</CanBeSubstepType>
+							<CanOnlyBeSubstepType classname='Bool'>
+								<value>false</value>
+							</CanOnlyBeSubstepType>
+							<Category classname='Str'>
+								<value>""</value>
+							</Category>
+							<ItemName classname='ExprValue'>
+								<value>ResStr("NI_STEPTYPES", "ACTION_MENU_ITEM_NAME")</value>
+							</ItemName>
+							<SingularItemName classname='Str'>
+								<value>""</value>
+							</SingularItemName>
+							<SeparatorBeforeCategory classname='Bool'>
+								<value>false</value>
+							</SeparatorBeforeCategory>
+							<SeparatorBeforeItemName classname='Bool'>
+								<value>false</value>
+							</SeparatorBeforeItemName>
+							<Group classname='Str'>
+								<value>Action</value>
+							</Group>
+						</subprops>
+					</Menu>
+					<AdditionalResultsHints classname='Objs' valueflags='4194328' structureflags='524288'>
+						<value lbound='[0]' ubound='[]'>
+							<elemproto>
+								<_NAME_IN_ATTRIBUTE_ typename='NI_CustomResult' xsi:type='NI_CustomResult' name='' classname='CustomResult'>
+									<subprops>
+										<Name classname='ExprValue'>
+											<value/>
+										</Name>
+										<ValueToLog classname='ExprValue'>
+											<value/>
+										</ValueToLog>
+										<Condition classname='ExprValue'>
+											<value/>
+										</Condition>
+										<Flags classname='Num'>
+											<value>8192</value>
+										</Flags>
+										<CheckedState classname='Num'>
+											<value>2</value>
+										</CheckedState>
+										<Type classname='PropertyObjectType'>
+											<subprops>
+												<ValueType classname='Num'>
+													<value>3</value>
+												</ValueType>
+												<IsObject classname='Bool'>
+													<value>true</value>
+												</IsObject>
+												<TypeName classname='Str'>
+													<value/>
+												</TypeName>
+												<ElementType classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</ElementType>
+												<ArrayDimensions classname='ArrayDimensions'>
+													<subprops>
+														<LowerBounds classname='Nums'>
+															<value lbound='[0]' ubound='[]'/>
+														</LowerBounds>
+														<UpperBounds classname='Nums'>
+															<value lbound='[0]' ubound='[]'/>
+														</UpperBounds>
+													</subprops>
+												</ArrayDimensions>
+												<Representation classname='Num'>
+													<value>1</value>
+												</Representation>
+												<ClassName classname='Str'>
+													<value/>
+												</ClassName>
+											</subprops>
+										</Type>
+										<Elements classname='Objs'>
+											<value lbound='[0]' ubound='[]'/>
+										</Elements>
+										<IsAnyType classname='Bool'>
+											<value>true</value>
+										</IsAnyType>
+									</subprops>
+								</_NAME_IN_ATTRIBUTE_>
+							</elemproto>
+						</value>
+					</AdditionalResultsHints>
+					<TS typename='TEInf' xsi:type='TEInf' classname='Obj' flagsforinstances='262168' instanceoverrideflags='4456472'>
+						<subprops>
+							<Id classname='Str'>
+								<value/>
+							</Id>
+							<Icon classname='Str'>
+								<value/>
+							</Icon>
+							<SData classname='Obj' flagsforinstances='2097152' instanceoverrideflags='7143448' structureflags='2097152'/>
+							<PreCond classname='ExprValue'>
+								<value/>
+							</PreCond>
+							<LoadOpt classname='Str'>
+								<value>PreloadWhenExecuted</value>
+							</LoadOpt>
+							<UnloadOpt classname='Str'>
+								<value>UnloadWithFile</value>
+							</UnloadOpt>
+							<Mode classname='Str'>
+								<value>Normal</value>
+							</Mode>
+							<WindowActivation classname='Str'>
+								<value>None</value>
+							</WindowActivation>
+							<ResultOption classname='Num'>
+								<value>1</value>
+							</ResultOption>
+							<StepFCSeqF classname='Bool'>
+								<value>true</value>
+							</StepFCSeqF>
+							<IgnoreRTE classname='Bool'>
+								<value>false</value>
+							</IgnoreRTE>
+							<UseMutex classname='Bool'>
+								<value>false</value>
+							</UseMutex>
+							<MutexNameOrRef classname='ExprValue'>
+								<value/>
+							</MutexNameOrRef>
+							<BatchSyncOpt classname='Num'>
+								<value>0</value>
+							</BatchSyncOpt>
+							<SwitchEnabled classname='Bool'>
+								<value>false</value>
+							</SwitchEnabled>
+							<VirtualDeviceName classname='ExprValue'>
+								<value/>
+							</VirtualDeviceName>
+							<SwitchOperation classname='Num'>
+								<value>1</value>
+							</SwitchOperation>
+							<RouteGroupConnect classname='ExprValue'>
+								<value/>
+							</RouteGroupConnect>
+							<RouteGroupDisconnect classname='ExprValue'>
+								<value/>
+							</RouteGroupDisconnect>
+							<MulticonnectMode classname='Num'>
+								<value>1</value>
+							</MulticonnectMode>
+							<OperationOrder classname='Num'>
+								<value>2</value>
+							</OperationOrder>
+							<ConnectionLifetime classname='Num'>
+								<value>0</value>
+							</ConnectionLifetime>
+							<WaitForDebounce classname='Bool'>
+								<value>true</value>
+							</WaitForDebounce>
+							<PassAct classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
+								<value>Next</value>
+							</PassAct>
+							<FailAct classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
+								<value>Next</value>
+							</FailAct>
+							<PassActTarget classname='ExprValue' flagsforinstances='1' instanceoverrideflags='5046297'>
+								<value/>
+							</PassActTarget>
+							<FailActTarget classname='ExprValue' flagsforinstances='1' instanceoverrideflags='5046297'>
+								<value/>
+							</FailActTarget>
+							<CustExpr classname='ExprValue'>
+								<value/>
+							</CustExpr>
+							<CustTrueAct classname='Str'>
+								<value>Next</value>
+							</CustTrueAct>
+							<CustFalseAct classname='Str'>
+								<value>Next</value>
+							</CustFalseAct>
+							<CustTrueActTarget classname='ExprValue'>
+								<value/>
+							</CustTrueActTarget>
+							<CustFalseActTarget classname='ExprValue'>
+								<value/>
+							</CustFalseActTarget>
+							<LoopType classname='Str'>
+								<value>NoLooping</value>
+							</LoopType>
+							<LoopWhile classname='ExprValue'>
+								<value/>
+							</LoopWhile>
+							<LoopStatus classname='ExprValue'>
+								<value/>
+							</LoopStatus>
+							<LoopIncrement classname='ExprValue'>
+								<value>RunState.LoopIndex += 1</value>
+							</LoopIncrement>
+							<LoopInitialize classname='ExprValue'>
+								<value>RunState.LoopIndex = 0</value>
+							</LoopInitialize>
+							<LoopOpt classname='Num'>
+								<value>0</value>
+							</LoopOpt>
+							<PreExpr classname='ExprValue'>
+								<value/>
+							</PreExpr>
+							<PostExpr classname='ExprValue'>
+								<value/>
+							</PostExpr>
+							<StatusExpr classname='ExprValue'>
+								<value/>
+							</StatusExpr>
+							<CanSpecifyModule classname='Bool'>
+								<value>true</value>
+							</CanSpecifyModule>
+							<CanEditCode classname='Bool'>
+								<value>true</value>
+							</CanEditCode>
+							<CanEditModulePrototype classname='Bool'>
+								<value>true</value>
+							</CanEditModulePrototype>
+							<CanEditParameterAdditionalResults classname='Bool'>
+								<value>true</value>
+							</CanEditParameterAdditionalResults>
+							<PrecondIntExe classname='Num'>
+								<value>0</value>
+							</PrecondIntExe>
+							<Requirements classname='Obj' flagsforinstances='1' valueflags='1' structureflags='2097152'>
+								<subprops>
+									<Links classname='Strs' flagsforinstances='71303168' instanceoverrideflags='72286233' valueflags='71303168'>
+										<value lbound='[0]' ubound='[]'/>
+									</Links>
+								</subprops>
+							</Requirements>
+							<CustomResults classname='Objs'>
+								<value lbound='[0]' ubound='[]'>
+									<elemproto>
+										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+											<subprops>
+												<Name classname='ExprValue'>
+													<value/>
+												</Name>
+												<ValueToLog classname='ExprValue'>
+													<value/>
+												</ValueToLog>
+												<Condition classname='ExprValue'>
+													<value/>
+												</Condition>
+												<Flags classname='Num'>
+													<value>8192</value>
+												</Flags>
+												<CheckedState classname='Num'>
+													<value>2</value>
+												</CheckedState>
+												<Type classname='PropertyObjectType'>
+													<subprops>
+														<ValueType classname='Num'>
+															<value>3</value>
+														</ValueType>
+														<IsObject classname='Bool'>
+															<value>true</value>
+														</IsObject>
+														<TypeName classname='Str'>
+															<value/>
+														</TypeName>
+														<ElementType classname='Objs'>
+															<value lbound='[0]' ubound='[]'/>
+														</ElementType>
+														<ArrayDimensions classname='ArrayDimensions'>
+															<subprops>
+																<LowerBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</LowerBounds>
+																<UpperBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</UpperBounds>
+															</subprops>
+														</ArrayDimensions>
+														<Representation classname='Num'>
+															<value>1</value>
+														</Representation>
+														<ClassName classname='Str'>
+															<value/>
+														</ClassName>
+													</subprops>
+												</Type>
+												<Elements classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</Elements>
+												<IsAnyType classname='Bool'>
+													<value>true</value>
+												</IsAnyType>
+											</subprops>
+										</_NAME_IN_ATTRIBUTE_>
+									</elemproto>
+								</value>
+							</CustomResults>
+							<AdditionalResultsHints classname='Objs'>
+								<value lbound='[0]' ubound='[]'>
+									<elemproto>
+										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
+											<subprops>
+												<Name classname='ExprValue'>
+													<value/>
+												</Name>
+												<ValueToLog classname='ExprValue'>
+													<value/>
+												</ValueToLog>
+												<Condition classname='ExprValue'>
+													<value/>
+												</Condition>
+												<Flags classname='Num'>
+													<value>8192</value>
+												</Flags>
+												<CheckedState classname='Num'>
+													<value>2</value>
+												</CheckedState>
+												<Type classname='PropertyObjectType'>
+													<subprops>
+														<ValueType classname='Num'>
+															<value>3</value>
+														</ValueType>
+														<IsObject classname='Bool'>
+															<value>true</value>
+														</IsObject>
+														<TypeName classname='Str'>
+															<value/>
+														</TypeName>
+														<ElementType classname='Objs'>
+															<value lbound='[0]' ubound='[]'/>
+														</ElementType>
+														<ArrayDimensions classname='ArrayDimensions'>
+															<subprops>
+																<LowerBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</LowerBounds>
+																<UpperBounds classname='Nums'>
+																	<value lbound='[0]' ubound='[]'/>
+																</UpperBounds>
+															</subprops>
+														</ArrayDimensions>
+														<Representation classname='Num'>
+															<value>1</value>
+														</Representation>
+														<ClassName classname='Str'>
+															<value/>
+														</ClassName>
+													</subprops>
+												</Type>
+												<Elements classname='Objs'>
+													<value lbound='[0]' ubound='[]'/>
+												</Elements>
+												<IsAnyType classname='Bool'>
+													<value>true</value>
+												</IsAnyType>
+											</subprops>
+										</_NAME_IN_ATTRIBUTE_>
+									</elemproto>
+								</value>
+							</AdditionalResultsHints>
+						</subprops>
+					</TS>
+					<NI_Data typename='StepTypeNIData' xsi:type='StepTypeNIData' classname='Obj'>
+						<subprops>
+							<EditPanels classname='Strs'>
+								<value lbound='[0]' ubound='[]'/>
+							</EditPanels>
+						</subprops>
+					</NI_Data>
+					<Result classname='Obj' flagsforinstances='4194304' valueflags='4194304'>
+						<subprops>
+							<Error typename='Error' xsi:type='Error' classname='Obj' flagsforinstances='4194304' instanceoverrideflags='4194304' valueflags='4194304'>
+								<subprops>
+									<Code classname='Num'>
+										<value>0</value>
+									</Code>
+									<Msg classname='Str'>
+										<value/>
+									</Msg>
+									<Occurred classname='Bool'>
+										<value>false</value>
+									</Occurred>
+								</subprops>
+							</Error>
+							<Status classname='Str' flagsforinstances='4194304' valueflags='4194304'>
+								<value/>
+							</Status>
+							<ReportText classname='Str' flagsforinstances='4194304' valueflags='4194304'>
+								<value/>
+							</ReportText>
+							<Common typename='CommonResults' xsi:type='CommonResults' classname='Obj' instanceoverrideflags='4194304'/>
+						</subprops>
+					</Result>
+					<CodeTemplates classname='Str' valueflags='4194328' structureflags='524288'>
+						<value>DefaultLabVIEW|DefaultLabVIEWNXG|DefaultCVI|DefaultVB.NET|DefaultCSharp.NET|DefaultC++.NET|DefaultVC++_Template|DefaultHTB72_Template|DefaultHTB80_Template|Default_Template</value>
+					</CodeTemplates>
+					<BlockStartTypes classname='Str' valueflags='4194328' structureflags='524288'>
+						<value/>
+					</BlockStartTypes>
+					<BlockEndTypes classname='Str' valueflags='4194328' structureflags='524288'>
+						<value/>
+					</BlockEndTypes>
+					<AppliesToBlockStructure classname='Bool' valueflags='4194328' structureflags='524288'>
+						<value>false</value>
+					</AppliesToBlockStructure>
+					<CanEncapsulate classname='Bool' valueflags='4194328' structureflags='524288'>
+						<value>false</value>
+					</CanEncapsulate>
+					<Category classname='Str' valueflags='24' structureflags='524288'>
+						<value>Action</value>
+					</Category>
+				</subprops>
+			</Action>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='29'>
+			<NI_PythonParameterResult classname='PythonParameterResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+				<subprops>
+					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</Condition>
+					<Flags classname='Num'>
+						<value>8192</value>
+						<numericfmt>%#x</numericfmt>
+					</Flags>
+					<CheckedState classname='Num'>
+						<value>1</value>
+					</CheckedState>
+				</subprops>
+			</NI_PythonParameterResult>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='28'>
+			<NI_PythonParameter classname='CPythonParameter' isroottypedef='true' typecategory='3' timestamp='1650060872' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+				<subprops>
+					<Name classname='Str'>
+						<value>_notNamed</value>
+					</Name>
+					<Type classname='Num'>
+						<value>7</value>
+					</Type>
+					<ArgumentValue typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</ArgumentValue>
+					<ArgumentDisplayValue typename='Expression' xsi:type='Expression' classname='ExprValue'>
+						<value/>
+					</ArgumentDisplayValue>
+					<AdditionalResults classname='Obj'>
+						<subprops>
+							<Input typename='NI_PythonParameterResult' xsi:type='NI_PythonParameterResult' classname='PythonParameterResult'>
+								<subprops>
+									<Condition classname='ExprValue'>
+										<value/>
+									</Condition>
+									<Flags classname='Num'>
+										<value>8192</value>
+									</Flags>
+									<CheckedState classname='Num'>
+										<value>1</value>
+									</CheckedState>
+								</subprops>
+							</Input>
+							<Output typename='NI_PythonParameterResult' xsi:type='NI_PythonParameterResult' classname='PythonParameterResult'>
+								<subprops>
+									<Condition classname='ExprValue'>
+										<value/>
+									</Condition>
+									<Flags classname='Num'>
+										<value>8192</value>
+									</Flags>
+									<CheckedState classname='Num'>
+										<value>1</value>
+									</CheckedState>
+								</subprops>
+							</Output>
+						</subprops>
+					</AdditionalResults>
+				</subprops>
+			</NI_PythonParameter>
+		</typedef>
+		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='27'>
+			<PythonStepAdditions classname='CPythonModule' isroottypedef='true' typecategory='3' timestamp='1650060872' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+				<subprops>
+					<PythonCall classname='CPythonCall'>
+						<subprops>
+							<UseAdapterSettingsForInterpreterSession classname='Bool'>
+								<value>true</value>
+							</UseAdapterSettingsForInterpreterSession>
+							<InterpreterSessionScope classname='Num'>
+								<value>3</value>
+							</InterpreterSessionScope>
+							<PythonVersion classname='Str'>
+								<value/>
+							</PythonVersion>
+							<PythonVirtualEnvironmentPath classname='Str'>
+								<value/>
+							</PythonVirtualEnvironmentPath>
+							<InterpreterLocation typename='Expression' xsi:type='Expression' classname='ExprValue'>
+								<value/>
+							</InterpreterLocation>
+							<CreateIfInterpreterDoesNotExist classname='Bool'>
+								<value>true</value>
+							</CreateIfInterpreterDoesNotExist>
+							<ModulePath typename='Path' xsi:type='Path' classname='PathValue'>
+								<value/>
+							</ModulePath>
+							<OperationType classname='Num'>
+								<value>1</value>
+							</OperationType>
+							<OperationScope classname='Num'>
+								<value>0</value>
+							</OperationScope>
+							<ClassName classname='Str'>
+								<value/>
+							</ClassName>
+							<ClassInstanceLocation typename='Expression' xsi:type='Expression' classname='ExprValue'>
+								<value/>
+							</ClassInstanceLocation>
+							<FunctionOrAttributeName classname='Str'>
+								<value/>
+							</FunctionOrAttributeName>
+							<Parameters classname='Objs'>
+								<value lbound='[0]' ubound='[0]'>
+									<elemproto>
+										<_NAME_IN_ATTRIBUTE_ typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name='' classname='CPythonParameter' structureflags='131072'>
+											<subprops>
+												<Name classname='Str'>
+													<value>_notNamed</value>
+												</Name>
+												<Type classname='Num'>
+													<value>7</value>
+												</Type>
+												<ArgumentValue classname='ExprValue'>
+													<value/>
+												</ArgumentValue>
+												<ArgumentDisplayValue classname='ExprValue'>
+													<value/>
+												</ArgumentDisplayValue>
+												<AdditionalResults classname='Obj'>
+													<subprops>
+														<Input classname='PythonParameterResult'>
+															<subprops>
+																<Condition classname='ExprValue'>
+																	<value/>
+																</Condition>
+																<Flags classname='Num'>
+																	<value>8192</value>
+																</Flags>
+																<CheckedState classname='Num'>
+																	<value>1</value>
+																</CheckedState>
+															</subprops>
+														</Input>
+														<Output classname='PythonParameterResult'>
+															<subprops>
+																<Condition classname='ExprValue'>
+																	<value/>
+																</Condition>
+																<Flags classname='Num'>
+																	<value>8192</value>
+																</Flags>
+																<CheckedState classname='Num'>
+																	<value>1</value>
+																</CheckedState>
+															</subprops>
+														</Output>
+													</subprops>
+												</AdditionalResults>
+											</subprops>
+										</_NAME_IN_ATTRIBUTE_>
+									</elemproto>
+									<value>
+										<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
+											<subprops>
+												<Name classname='Str'>
+													<value>Return Value</value>
+												</Name>
+												<Type classname='Num'>
+													<value>7</value>
+												</Type>
+												<ArgumentValue classname='ExprValue'>
+													<value/>
+												</ArgumentValue>
+												<ArgumentDisplayValue classname='ExprValue'>
+													<value/>
+												</ArgumentDisplayValue>
+												<AdditionalResults classname='Obj'>
+													<subprops>
+														<Input classname='PythonParameterResult'>
+															<subprops>
+																<Condition classname='ExprValue'>
+																	<value/>
+																</Condition>
+																<Flags classname='Num'>
+																	<value>8192</value>
+																</Flags>
+																<CheckedState classname='Num'>
+																	<value>1</value>
+																</CheckedState>
+															</subprops>
+														</Input>
+														<Output classname='PythonParameterResult'>
+															<subprops>
+																<Condition classname='ExprValue'>
+																	<value/>
+																</Condition>
+																<Flags classname='Num'>
+																	<value>8192</value>
+																</Flags>
+																<CheckedState classname='Num'>
+																	<value>1</value>
+																</CheckedState>
+															</subprops>
+														</Output>
+													</subprops>
+												</AdditionalResults>
+											</subprops>
+										</CPythonParameter>
+									</value>
+								</value>
+							</Parameters>
+							<DefaultParamCategoryForArray classname='Num'>
+								<value>5</value>
+							</DefaultParamCategoryForArray>
+						</subprops>
+					</PythonCall>
+				</subprops>
+			</PythonStepAdditions>
+		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='22'>
 			<EditSubstep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
 				<subprops>
@@ -3592,652 +4233,11 @@
 				</subprops>
 			</Statement>
 		</typedef>
-		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='21'>
-			<Action classname='StepType' isroottypedef='true' typecategory='1' timestamp='1618215606' typeversion='21.0.0.2' typelastmodversion='21.0.0.0' typeminprodversion='21.0.0.0' typeflags='33554446'>
-				<subprops>
-					<Substeps typename='StepTypeSubstepsArray' xsi:type='StepTypeSubstepsArray' classname='Objs' flagsforinstances='524312' instanceoverrideflags='655384'>
-						<value lbound='[0]' ubound='[]'/>
-					</Substeps>
-					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
-						<value>ResStr("NI_STEPTYPES", "ACTION_DESCRIPTION_NAME") + (("%ModuleDescription" == "") ? "" : ",  %ModuleDescription")</value>
-					</DescriptionFormat>
-					<DefaultNameFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
-						<value>ResStr("NI_STEPTYPES", "ACTION_DEF_STEP_NAME")</value>
-					</DefaultNameFormat>
-					<Menu typename='StepTypeMenu' xsi:type='StepTypeMenu' classname='Obj' flagsforinstances='524312' instanceoverrideflags='524312'>
-						<subprops>
-							<CanBeSubstepType classname='Bool'>
-								<value>false</value>
-							</CanBeSubstepType>
-							<CanOnlyBeSubstepType classname='Bool'>
-								<value>false</value>
-							</CanOnlyBeSubstepType>
-							<Category classname='Str'>
-								<value>""</value>
-							</Category>
-							<ItemName classname='ExprValue'>
-								<value>ResStr("NI_STEPTYPES", "ACTION_MENU_ITEM_NAME")</value>
-							</ItemName>
-							<SingularItemName classname='Str'>
-								<value>""</value>
-							</SingularItemName>
-							<SeparatorBeforeCategory classname='Bool'>
-								<value>false</value>
-							</SeparatorBeforeCategory>
-							<SeparatorBeforeItemName classname='Bool'>
-								<value>false</value>
-							</SeparatorBeforeItemName>
-							<Group classname='Str'>
-								<value>Action</value>
-							</Group>
-						</subprops>
-					</Menu>
-					<AdditionalResultsHints classname='Objs' valueflags='4194328' structureflags='524288'>
-						<value lbound='[0]' ubound='[]'>
-							<elemproto>
-								<_NAME_IN_ATTRIBUTE_ typename='NI_CustomResult' xsi:type='NI_CustomResult' name='' classname='CustomResult'>
-									<subprops>
-										<Name classname='ExprValue'>
-											<value/>
-										</Name>
-										<ValueToLog classname='ExprValue'>
-											<value/>
-										</ValueToLog>
-										<Condition classname='ExprValue'>
-											<value/>
-										</Condition>
-										<Flags classname='Num'>
-											<value>8192</value>
-										</Flags>
-										<CheckedState classname='Num'>
-											<value>2</value>
-										</CheckedState>
-										<Type classname='PropertyObjectType'>
-											<subprops>
-												<ValueType classname='Num'>
-													<value>3</value>
-												</ValueType>
-												<IsObject classname='Bool'>
-													<value>true</value>
-												</IsObject>
-												<TypeName classname='Str'>
-													<value/>
-												</TypeName>
-												<ElementType classname='Objs'>
-													<value lbound='[0]' ubound='[]'/>
-												</ElementType>
-												<ArrayDimensions classname='ArrayDimensions'>
-													<subprops>
-														<LowerBounds classname='Nums'>
-															<value lbound='[0]' ubound='[]'/>
-														</LowerBounds>
-														<UpperBounds classname='Nums'>
-															<value lbound='[0]' ubound='[]'/>
-														</UpperBounds>
-													</subprops>
-												</ArrayDimensions>
-												<Representation classname='Num'>
-													<value>1</value>
-												</Representation>
-												<ClassName classname='Str'>
-													<value/>
-												</ClassName>
-											</subprops>
-										</Type>
-										<Elements classname='Objs'>
-											<value lbound='[0]' ubound='[]'/>
-										</Elements>
-										<IsAnyType classname='Bool'>
-											<value>true</value>
-										</IsAnyType>
-									</subprops>
-								</_NAME_IN_ATTRIBUTE_>
-							</elemproto>
-						</value>
-					</AdditionalResultsHints>
-					<TS typename='TEInf' xsi:type='TEInf' classname='Obj' flagsforinstances='262168' instanceoverrideflags='4456472'>
-						<subprops>
-							<Id classname='Str'>
-								<value/>
-							</Id>
-							<Icon classname='Str'>
-								<value/>
-							</Icon>
-							<SData classname='Obj' flagsforinstances='2097152' instanceoverrideflags='7143448' structureflags='2097152'/>
-							<PreCond classname='ExprValue'>
-								<value/>
-							</PreCond>
-							<LoadOpt classname='Str'>
-								<value>PreloadWhenExecuted</value>
-							</LoadOpt>
-							<UnloadOpt classname='Str'>
-								<value>UnloadWithFile</value>
-							</UnloadOpt>
-							<Mode classname='Str'>
-								<value>Normal</value>
-							</Mode>
-							<WindowActivation classname='Str'>
-								<value>None</value>
-							</WindowActivation>
-							<ResultOption classname='Num'>
-								<value>1</value>
-							</ResultOption>
-							<StepFCSeqF classname='Bool'>
-								<value>true</value>
-							</StepFCSeqF>
-							<IgnoreRTE classname='Bool'>
-								<value>false</value>
-							</IgnoreRTE>
-							<UseMutex classname='Bool'>
-								<value>false</value>
-							</UseMutex>
-							<MutexNameOrRef classname='ExprValue'>
-								<value/>
-							</MutexNameOrRef>
-							<BatchSyncOpt classname='Num'>
-								<value>0</value>
-							</BatchSyncOpt>
-							<SwitchEnabled classname='Bool'>
-								<value>false</value>
-							</SwitchEnabled>
-							<VirtualDeviceName classname='ExprValue'>
-								<value/>
-							</VirtualDeviceName>
-							<SwitchOperation classname='Num'>
-								<value>1</value>
-							</SwitchOperation>
-							<RouteGroupConnect classname='ExprValue'>
-								<value/>
-							</RouteGroupConnect>
-							<RouteGroupDisconnect classname='ExprValue'>
-								<value/>
-							</RouteGroupDisconnect>
-							<MulticonnectMode classname='Num'>
-								<value>1</value>
-							</MulticonnectMode>
-							<OperationOrder classname='Num'>
-								<value>2</value>
-							</OperationOrder>
-							<ConnectionLifetime classname='Num'>
-								<value>0</value>
-							</ConnectionLifetime>
-							<WaitForDebounce classname='Bool'>
-								<value>true</value>
-							</WaitForDebounce>
-							<PassAct classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
-								<value>Next</value>
-							</PassAct>
-							<FailAct classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
-								<value>Next</value>
-							</FailAct>
-							<PassActTarget classname='ExprValue' flagsforinstances='1' instanceoverrideflags='5046297'>
-								<value/>
-							</PassActTarget>
-							<FailActTarget classname='ExprValue' flagsforinstances='1' instanceoverrideflags='5046297'>
-								<value/>
-							</FailActTarget>
-							<CustExpr classname='ExprValue'>
-								<value/>
-							</CustExpr>
-							<CustTrueAct classname='Str'>
-								<value>Next</value>
-							</CustTrueAct>
-							<CustFalseAct classname='Str'>
-								<value>Next</value>
-							</CustFalseAct>
-							<CustTrueActTarget classname='ExprValue'>
-								<value/>
-							</CustTrueActTarget>
-							<CustFalseActTarget classname='ExprValue'>
-								<value/>
-							</CustFalseActTarget>
-							<LoopType classname='Str'>
-								<value>NoLooping</value>
-							</LoopType>
-							<LoopWhile classname='ExprValue'>
-								<value/>
-							</LoopWhile>
-							<LoopStatus classname='ExprValue'>
-								<value/>
-							</LoopStatus>
-							<LoopIncrement classname='ExprValue'>
-								<value>RunState.LoopIndex += 1</value>
-							</LoopIncrement>
-							<LoopInitialize classname='ExprValue'>
-								<value>RunState.LoopIndex = 0</value>
-							</LoopInitialize>
-							<LoopOpt classname='Num'>
-								<value>0</value>
-							</LoopOpt>
-							<PreExpr classname='ExprValue'>
-								<value/>
-							</PreExpr>
-							<PostExpr classname='ExprValue'>
-								<value/>
-							</PostExpr>
-							<StatusExpr classname='ExprValue'>
-								<value/>
-							</StatusExpr>
-							<CanSpecifyModule classname='Bool'>
-								<value>true</value>
-							</CanSpecifyModule>
-							<CanEditCode classname='Bool'>
-								<value>true</value>
-							</CanEditCode>
-							<CanEditModulePrototype classname='Bool'>
-								<value>true</value>
-							</CanEditModulePrototype>
-							<CanEditParameterAdditionalResults classname='Bool'>
-								<value>true</value>
-							</CanEditParameterAdditionalResults>
-							<PrecondIntExe classname='Num'>
-								<value>0</value>
-							</PrecondIntExe>
-							<Requirements classname='Obj' flagsforinstances='1' valueflags='1' structureflags='2097152'>
-								<subprops>
-									<Links classname='Strs' flagsforinstances='71303168' instanceoverrideflags='72286233' valueflags='71303168'>
-										<value lbound='[0]' ubound='[]'/>
-									</Links>
-								</subprops>
-							</Requirements>
-							<CustomResults classname='Objs'>
-								<value lbound='[0]' ubound='[]'>
-									<elemproto>
-										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-											<subprops>
-												<Name classname='ExprValue'>
-													<value/>
-												</Name>
-												<ValueToLog classname='ExprValue'>
-													<value/>
-												</ValueToLog>
-												<Condition classname='ExprValue'>
-													<value/>
-												</Condition>
-												<Flags classname='Num'>
-													<value>8192</value>
-												</Flags>
-												<CheckedState classname='Num'>
-													<value>2</value>
-												</CheckedState>
-												<Type classname='PropertyObjectType'>
-													<subprops>
-														<ValueType classname='Num'>
-															<value>3</value>
-														</ValueType>
-														<IsObject classname='Bool'>
-															<value>true</value>
-														</IsObject>
-														<TypeName classname='Str'>
-															<value/>
-														</TypeName>
-														<ElementType classname='Objs'>
-															<value lbound='[0]' ubound='[]'/>
-														</ElementType>
-														<ArrayDimensions classname='ArrayDimensions'>
-															<subprops>
-																<LowerBounds classname='Nums'>
-																	<value lbound='[0]' ubound='[]'/>
-																</LowerBounds>
-																<UpperBounds classname='Nums'>
-																	<value lbound='[0]' ubound='[]'/>
-																</UpperBounds>
-															</subprops>
-														</ArrayDimensions>
-														<Representation classname='Num'>
-															<value>1</value>
-														</Representation>
-														<ClassName classname='Str'>
-															<value/>
-														</ClassName>
-													</subprops>
-												</Type>
-												<Elements classname='Objs'>
-													<value lbound='[0]' ubound='[]'/>
-												</Elements>
-												<IsAnyType classname='Bool'>
-													<value>true</value>
-												</IsAnyType>
-											</subprops>
-										</_NAME_IN_ATTRIBUTE_>
-									</elemproto>
-								</value>
-							</CustomResults>
-							<AdditionalResultsHints classname='Objs'>
-								<value lbound='[0]' ubound='[]'>
-									<elemproto>
-										<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-											<subprops>
-												<Name classname='ExprValue'>
-													<value/>
-												</Name>
-												<ValueToLog classname='ExprValue'>
-													<value/>
-												</ValueToLog>
-												<Condition classname='ExprValue'>
-													<value/>
-												</Condition>
-												<Flags classname='Num'>
-													<value>8192</value>
-												</Flags>
-												<CheckedState classname='Num'>
-													<value>2</value>
-												</CheckedState>
-												<Type classname='PropertyObjectType'>
-													<subprops>
-														<ValueType classname='Num'>
-															<value>3</value>
-														</ValueType>
-														<IsObject classname='Bool'>
-															<value>true</value>
-														</IsObject>
-														<TypeName classname='Str'>
-															<value/>
-														</TypeName>
-														<ElementType classname='Objs'>
-															<value lbound='[0]' ubound='[]'/>
-														</ElementType>
-														<ArrayDimensions classname='ArrayDimensions'>
-															<subprops>
-																<LowerBounds classname='Nums'>
-																	<value lbound='[0]' ubound='[]'/>
-																</LowerBounds>
-																<UpperBounds classname='Nums'>
-																	<value lbound='[0]' ubound='[]'/>
-																</UpperBounds>
-															</subprops>
-														</ArrayDimensions>
-														<Representation classname='Num'>
-															<value>1</value>
-														</Representation>
-														<ClassName classname='Str'>
-															<value/>
-														</ClassName>
-													</subprops>
-												</Type>
-												<Elements classname='Objs'>
-													<value lbound='[0]' ubound='[]'/>
-												</Elements>
-												<IsAnyType classname='Bool'>
-													<value>true</value>
-												</IsAnyType>
-											</subprops>
-										</_NAME_IN_ATTRIBUTE_>
-									</elemproto>
-								</value>
-							</AdditionalResultsHints>
-						</subprops>
-					</TS>
-					<NI_Data typename='StepTypeNIData' xsi:type='StepTypeNIData' classname='Obj'>
-						<subprops>
-							<EditPanels classname='Strs'>
-								<value lbound='[0]' ubound='[]'/>
-							</EditPanels>
-						</subprops>
-					</NI_Data>
-					<Result classname='Obj' flagsforinstances='4194304' valueflags='4194304'>
-						<subprops>
-							<Error typename='Error' xsi:type='Error' classname='Obj' flagsforinstances='4194304' instanceoverrideflags='4194304' valueflags='4194304'>
-								<subprops>
-									<Code classname='Num'>
-										<value>0</value>
-									</Code>
-									<Msg classname='Str'>
-										<value/>
-									</Msg>
-									<Occurred classname='Bool'>
-										<value>false</value>
-									</Occurred>
-								</subprops>
-							</Error>
-							<Status classname='Str' flagsforinstances='4194304' valueflags='4194304'>
-								<value/>
-							</Status>
-							<ReportText classname='Str' flagsforinstances='4194304' valueflags='4194304'>
-								<value/>
-							</ReportText>
-							<Common typename='CommonResults' xsi:type='CommonResults' classname='Obj' instanceoverrideflags='4194304'/>
-						</subprops>
-					</Result>
-					<CodeTemplates classname='Str' valueflags='4194328' structureflags='524288'>
-						<value>DefaultLabVIEW|DefaultLabVIEWNXG|DefaultCVI|DefaultVB.NET|DefaultCSharp.NET|DefaultC++.NET|DefaultVC++_Template|DefaultHTB72_Template|DefaultHTB80_Template|Default_Template</value>
-					</CodeTemplates>
-					<BlockStartTypes classname='Str' valueflags='4194328' structureflags='524288'>
-						<value/>
-					</BlockStartTypes>
-					<BlockEndTypes classname='Str' valueflags='4194328' structureflags='524288'>
-						<value/>
-					</BlockEndTypes>
-					<AppliesToBlockStructure classname='Bool' valueflags='4194328' structureflags='524288'>
-						<value>false</value>
-					</AppliesToBlockStructure>
-					<CanEncapsulate classname='Bool' valueflags='4194328' structureflags='524288'>
-						<value>false</value>
-					</CanEncapsulate>
-					<Category classname='Str' valueflags='24' structureflags='524288'>
-						<value>Action</value>
-					</Category>
-				</subprops>
-			</Action>
-		</typedef>
-		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='29'>
-			<NI_PythonParameterResult classname='PythonParameterResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
-				<subprops>
-					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
-						<value/>
-					</Condition>
-					<Flags classname='Num'>
-						<value>8192</value>
-						<numericfmt>%#x</numericfmt>
-					</Flags>
-					<CheckedState classname='Num'>
-						<value>1</value>
-					</CheckedState>
-				</subprops>
-			</NI_PythonParameterResult>
-		</typedef>
-		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='28'>
-			<NI_PythonParameter classname='CPythonParameter' isroottypedef='true' typecategory='3' timestamp='1650060872' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
-				<subprops>
-					<Name classname='Str'>
-						<value>_notNamed</value>
-					</Name>
-					<Type classname='Num'>
-						<value>7</value>
-					</Type>
-					<ArgumentValue typename='Expression' xsi:type='Expression' classname='ExprValue'>
-						<value/>
-					</ArgumentValue>
-					<ArgumentDisplayValue typename='Expression' xsi:type='Expression' classname='ExprValue'>
-						<value/>
-					</ArgumentDisplayValue>
-					<AdditionalResults classname='Obj'>
-						<subprops>
-							<Input typename='NI_PythonParameterResult' xsi:type='NI_PythonParameterResult' classname='PythonParameterResult'>
-								<subprops>
-									<Condition classname='ExprValue'>
-										<value/>
-									</Condition>
-									<Flags classname='Num'>
-										<value>8192</value>
-									</Flags>
-									<CheckedState classname='Num'>
-										<value>1</value>
-									</CheckedState>
-								</subprops>
-							</Input>
-							<Output typename='NI_PythonParameterResult' xsi:type='NI_PythonParameterResult' classname='PythonParameterResult'>
-								<subprops>
-									<Condition classname='ExprValue'>
-										<value/>
-									</Condition>
-									<Flags classname='Num'>
-										<value>8192</value>
-									</Flags>
-									<CheckedState classname='Num'>
-										<value>1</value>
-									</CheckedState>
-								</subprops>
-							</Output>
-						</subprops>
-					</AdditionalResults>
-				</subprops>
-			</NI_PythonParameter>
-		</typedef>
-		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='27'>
-			<PythonStepAdditions classname='CPythonModule' isroottypedef='true' typecategory='3' timestamp='1650060872' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
-				<subprops>
-					<PythonCall classname='CPythonCall'>
-						<subprops>
-							<UseAdapterSettingsForInterpreterSession classname='Bool'>
-								<value>true</value>
-							</UseAdapterSettingsForInterpreterSession>
-							<InterpreterSessionScope classname='Num'>
-								<value>3</value>
-							</InterpreterSessionScope>
-							<PythonVersion classname='Str'>
-								<value/>
-							</PythonVersion>
-							<PythonVirtualEnvironmentPath classname='Str'>
-								<value/>
-							</PythonVirtualEnvironmentPath>
-							<InterpreterLocation typename='Expression' xsi:type='Expression' classname='ExprValue'>
-								<value/>
-							</InterpreterLocation>
-							<CreateIfInterpreterDoesNotExist classname='Bool'>
-								<value>true</value>
-							</CreateIfInterpreterDoesNotExist>
-							<ModulePath typename='Path' xsi:type='Path' classname='PathValue'>
-								<value/>
-							</ModulePath>
-							<OperationType classname='Num'>
-								<value>1</value>
-							</OperationType>
-							<OperationScope classname='Num'>
-								<value>0</value>
-							</OperationScope>
-							<ClassName classname='Str'>
-								<value/>
-							</ClassName>
-							<ClassInstanceLocation typename='Expression' xsi:type='Expression' classname='ExprValue'>
-								<value/>
-							</ClassInstanceLocation>
-							<FunctionOrAttributeName classname='Str'>
-								<value/>
-							</FunctionOrAttributeName>
-							<Parameters classname='Objs'>
-								<value lbound='[0]' ubound='[0]'>
-									<elemproto>
-										<_NAME_IN_ATTRIBUTE_ typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name='' classname='CPythonParameter' structureflags='131072'>
-											<subprops>
-												<Name classname='Str'>
-													<value>_notNamed</value>
-												</Name>
-												<Type classname='Num'>
-													<value>7</value>
-												</Type>
-												<ArgumentValue classname='ExprValue'>
-													<value/>
-												</ArgumentValue>
-												<ArgumentDisplayValue classname='ExprValue'>
-													<value/>
-												</ArgumentDisplayValue>
-												<AdditionalResults classname='Obj'>
-													<subprops>
-														<Input classname='PythonParameterResult'>
-															<subprops>
-																<Condition classname='ExprValue'>
-																	<value/>
-																</Condition>
-																<Flags classname='Num'>
-																	<value>8192</value>
-																</Flags>
-																<CheckedState classname='Num'>
-																	<value>1</value>
-																</CheckedState>
-															</subprops>
-														</Input>
-														<Output classname='PythonParameterResult'>
-															<subprops>
-																<Condition classname='ExprValue'>
-																	<value/>
-																</Condition>
-																<Flags classname='Num'>
-																	<value>8192</value>
-																</Flags>
-																<CheckedState classname='Num'>
-																	<value>1</value>
-																</CheckedState>
-															</subprops>
-														</Output>
-													</subprops>
-												</AdditionalResults>
-											</subprops>
-										</_NAME_IN_ATTRIBUTE_>
-									</elemproto>
-									<value>
-										<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
-											<subprops>
-												<Name classname='Str'>
-													<value>Return Value</value>
-												</Name>
-												<Type classname='Num'>
-													<value>7</value>
-												</Type>
-												<ArgumentValue classname='ExprValue'>
-													<value/>
-												</ArgumentValue>
-												<ArgumentDisplayValue classname='ExprValue'>
-													<value/>
-												</ArgumentDisplayValue>
-												<AdditionalResults classname='Obj'>
-													<subprops>
-														<Input classname='PythonParameterResult'>
-															<subprops>
-																<Condition classname='ExprValue'>
-																	<value/>
-																</Condition>
-																<Flags classname='Num'>
-																	<value>8192</value>
-																</Flags>
-																<CheckedState classname='Num'>
-																	<value>1</value>
-																</CheckedState>
-															</subprops>
-														</Input>
-														<Output classname='PythonParameterResult'>
-															<subprops>
-																<Condition classname='ExprValue'>
-																	<value/>
-																</Condition>
-																<Flags classname='Num'>
-																	<value>8192</value>
-																</Flags>
-																<CheckedState classname='Num'>
-																	<value>1</value>
-																</CheckedState>
-															</subprops>
-														</Output>
-													</subprops>
-												</AdditionalResults>
-											</subprops>
-										</CPythonParameter>
-									</value>
-								</value>
-							</Parameters>
-							<DefaultParamCategoryForArray classname='Num'>
-								<value>5</value>
-							</DefaultParamCategoryForArray>
-						</subprops>
-					</PythonCall>
-				</subprops>
-			</PythonStepAdditions>
-		</typedef>
 	</typelist>
 	<Data classname='SequenceFileData' valueflags='4194304'>
 		<subprops>
 			<Seq classname='Objs' valueflags='4194304'>
-				<value lbound='[0]' ubound='[2]'>
+				<value lbound='[0]' ubound='[0]'>
 					<value>
 						<Sequence name='MainSequence'>
 							<subprops>
@@ -4801,396 +4801,14 @@
 									</value>
 								</Main>
 								<Setup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
-								</Setup>
-								<Cleanup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
-								</Cleanup>
-								<RecordResults classname='Bool' valueflags='4194312'>
-									<value>true</value>
-								</RecordResults>
-								<RTS classname='Obj' valueflags='4456456'>
-									<subprops>
-										<Type classname='Num' valueflags='4194304'>
-											<value>0</value>
-										</Type>
-										<OptimizeNonReentrantCalls classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</OptimizeNonReentrantCalls>
-										<EPNameExpr classname='Str' valueflags='4194304'>
-											<value>"Unnamed Entry Point"</value>
-										</EPNameExpr>
-										<EPEnabledExpr classname='Str' valueflags='4194304'>
-											<value>True</value>
-										</EPEnabledExpr>
-										<EPMenuHint classname='Str' valueflags='4194304'>
-											<value/>
-										</EPMenuHint>
-										<EPIgnoreClient classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</EPIgnoreClient>
-										<EPInitiallyHidden classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</EPInitiallyHidden>
-										<EPCheckToSaveTitledFile classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</EPCheckToSaveTitledFile>
-										<ShowEPAlways classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPAlways>
-										<ShowEPForFileWin classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</ShowEPForFileWin>
-										<ShowEPForExeWin classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPForExeWin>
-										<ShowEPForEditorOnly classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPForEditorOnly>
-										<AllowIntExeOfEP classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</AllowIntExeOfEP>
-										<CopyStepsOnOverriding classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</CopyStepsOnOverriding>
-										<Priority classname='Num' valueflags='4194304'>
-											<value>2953567917</value>
-										</Priority>
-									</subprops>
-								</RTS>
-								<Requirements classname='Obj' valueflags='4456456'>
-									<subprops>
-										<Links classname='Strs' valueflags='71303168'>
-											<value lbound='[0]' ubound='[]'/>
-										</Links>
-									</subprops>
-								</Requirements>
-								<FailureAction classname='Num' valueflags='4194312'>
-									<value>2</value>
-								</FailureAction>
-							</subprops>
-						</Sequence>
-					</value>
-					<value>
-						<Sequence name='ProcessSetup'>
-							<comment>Test UUTs and Single Pass call this callback in their setup step group. It is empty in the model file.  Override this in the client file to perform an action before any code in the model executes.</comment>
-							<subprops>
-								<Parameters classname='Obj' valueflags='4456448'/>
-								<Locals classname='Obj' valueflags='4194304'>
-									<subprops>
-										<ResultList classname='Objs'>
-											<value lbound='[0]' ubound='[]'>
-												<elemproto>
-													<_NAME_IN_ATTRIBUTE_ name='' classname='TEResult'/>
-												</elemproto>
-											</value>
-										</ResultList>
-									</subprops>
-								</Locals>
-								<Main classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[3]'>
-										<value>
-											<Step typename='Statement' xsi:type='Statement' name='Get absolute path to pinmap file'>
-												<subprops>
-													<TS classname='Obj'>
-														<subprops>
-															<Id classname='Str'>
-																<value>ID#:CHEZyO1w7RGuNrjdh1OqZD</value>
-															</Id>
-															<Icon classname='Str'>
-																<value>StatementStep.ico</value>
-															</Icon>
-															<PreCond classname='ExprValue'>
-																<value/>
-															</PreCond>
-															<LoadOpt classname='Str'>
-																<value>PreloadWhenExecuted</value>
-															</LoadOpt>
-															<UnloadOpt classname='Str'>
-																<value>UnloadWithFile</value>
-															</UnloadOpt>
-															<Mode classname='Str'>
-																<value>Normal</value>
-															</Mode>
-															<WindowActivation classname='Str'>
-																<value>None</value>
-															</WindowActivation>
-															<ResultOption classname='Num'>
-																<value>1</value>
-															</ResultOption>
-															<StepFCSeqF classname='Bool'>
-																<value>true</value>
-															</StepFCSeqF>
-															<IgnoreRTE classname='Bool'>
-																<value>false</value>
-															</IgnoreRTE>
-															<UseMutex classname='Bool'>
-																<value>false</value>
-															</UseMutex>
-															<MutexNameOrRef classname='ExprValue'>
-																<value/>
-															</MutexNameOrRef>
-															<BatchSyncOpt classname='Num'>
-																<value>0</value>
-															</BatchSyncOpt>
-															<SwitchEnabled classname='Bool'>
-																<value>false</value>
-															</SwitchEnabled>
-															<VirtualDeviceName classname='ExprValue'>
-																<value/>
-															</VirtualDeviceName>
-															<SwitchOperation classname='Num'>
-																<value>1</value>
-															</SwitchOperation>
-															<RouteGroupConnect classname='ExprValue'>
-																<value/>
-															</RouteGroupConnect>
-															<RouteGroupDisconnect classname='ExprValue'>
-																<value/>
-															</RouteGroupDisconnect>
-															<MulticonnectMode classname='Num'>
-																<value>1</value>
-															</MulticonnectMode>
-															<OperationOrder classname='Num'>
-																<value>2</value>
-															</OperationOrder>
-															<ConnectionLifetime classname='Num'>
-																<value>0</value>
-															</ConnectionLifetime>
-															<WaitForDebounce classname='Bool'>
-																<value>true</value>
-															</WaitForDebounce>
-															<PassAct classname='Str'>
-																<value>Next</value>
-															</PassAct>
-															<FailAct classname='Str'>
-																<value>Next</value>
-															</FailAct>
-															<PassActTarget classname='ExprValue'>
-																<value/>
-															</PassActTarget>
-															<FailActTarget classname='ExprValue'>
-																<value/>
-															</FailActTarget>
-															<CustExpr classname='ExprValue'>
-																<value/>
-															</CustExpr>
-															<CustTrueAct classname='Str'>
-																<value>Next</value>
-															</CustTrueAct>
-															<CustFalseAct classname='Str'>
-																<value>Next</value>
-															</CustFalseAct>
-															<CustTrueActTarget classname='ExprValue'>
-																<value/>
-															</CustTrueActTarget>
-															<CustFalseActTarget classname='ExprValue'>
-																<value/>
-															</CustFalseActTarget>
-															<LoopType classname='Str'>
-																<value>NoLooping</value>
-															</LoopType>
-															<LoopWhile classname='ExprValue'>
-																<value/>
-															</LoopWhile>
-															<LoopStatus classname='ExprValue'>
-																<value/>
-															</LoopStatus>
-															<LoopIncrement classname='ExprValue'>
-																<value>RunState.LoopIndex += 1</value>
-															</LoopIncrement>
-															<LoopInitialize classname='ExprValue'>
-																<value>RunState.LoopIndex = 0</value>
-															</LoopInitialize>
-															<LoopOpt classname='Num'>
-																<value>0</value>
-															</LoopOpt>
-															<PreExpr classname='ExprValue'>
-																<value/>
-															</PreExpr>
-															<PostExpr classname='ExprValue'>
-																<value>FindFile(FileGlobals.MeasurementLink.PinMapFileName,True,FileGlobals.MeasurementLink.PinMapPath)</value>
-															</PostExpr>
-															<StatusExpr classname='ExprValue'>
-																<value/>
-															</StatusExpr>
-															<CanSpecifyModule classname='Bool'>
-																<value>false</value>
-															</CanSpecifyModule>
-															<CanEditCode classname='Bool'>
-																<value>true</value>
-															</CanEditCode>
-															<CanEditModulePrototype classname='Bool'>
-																<value>true</value>
-															</CanEditModulePrototype>
-															<CanEditParameterAdditionalResults classname='Bool'>
-																<value>true</value>
-															</CanEditParameterAdditionalResults>
-															<PrecondIntExe classname='Num'>
-																<value>0</value>
-															</PrecondIntExe>
-															<CustomResults classname='Objs'>
-																<value lbound='[0]' ubound='[]'>
-																	<elemproto>
-																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-																			<subprops>
-																				<Name classname='ExprValue'>
-																					<value/>
-																				</Name>
-																				<ValueToLog classname='ExprValue'>
-																					<value/>
-																				</ValueToLog>
-																				<Condition classname='ExprValue'>
-																					<value/>
-																				</Condition>
-																				<Flags classname='Num'>
-																					<value>8192</value>
-																				</Flags>
-																				<CheckedState classname='Num'>
-																					<value>2</value>
-																				</CheckedState>
-																				<Type classname='PropertyObjectType'>
-																					<subprops>
-																						<ValueType classname='Num'>
-																							<value>3</value>
-																						</ValueType>
-																						<IsObject classname='Bool'>
-																							<value>true</value>
-																						</IsObject>
-																						<TypeName classname='Str'>
-																							<value/>
-																						</TypeName>
-																						<ElementType classname='Objs'>
-																							<value lbound='[0]' ubound='[]'/>
-																						</ElementType>
-																						<ArrayDimensions classname='ArrayDimensions'>
-																							<subprops>
-																								<LowerBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</LowerBounds>
-																								<UpperBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</UpperBounds>
-																							</subprops>
-																						</ArrayDimensions>
-																						<Representation classname='Num'>
-																							<value>1</value>
-																						</Representation>
-																						<ClassName classname='Str'>
-																							<value/>
-																						</ClassName>
-																					</subprops>
-																				</Type>
-																				<Elements classname='Objs'>
-																					<value lbound='[0]' ubound='[]'/>
-																				</Elements>
-																				<IsAnyType classname='Bool'>
-																					<value>true</value>
-																				</IsAnyType>
-																			</subprops>
-																		</_NAME_IN_ATTRIBUTE_>
-																	</elemproto>
-																</value>
-															</CustomResults>
-															<AdditionalResultsHints classname='Objs'>
-																<value lbound='[0]' ubound='[]'>
-																	<elemproto>
-																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-																			<subprops>
-																				<Name classname='ExprValue'>
-																					<value/>
-																				</Name>
-																				<ValueToLog classname='ExprValue'>
-																					<value/>
-																				</ValueToLog>
-																				<Condition classname='ExprValue'>
-																					<value/>
-																				</Condition>
-																				<Flags classname='Num'>
-																					<value>8192</value>
-																				</Flags>
-																				<CheckedState classname='Num'>
-																					<value>2</value>
-																				</CheckedState>
-																				<Type classname='PropertyObjectType'>
-																					<subprops>
-																						<ValueType classname='Num'>
-																							<value>3</value>
-																						</ValueType>
-																						<IsObject classname='Bool'>
-																							<value>true</value>
-																						</IsObject>
-																						<TypeName classname='Str'>
-																							<value/>
-																						</TypeName>
-																						<ElementType classname='Objs'>
-																							<value lbound='[0]' ubound='[]'/>
-																						</ElementType>
-																						<ArrayDimensions classname='ArrayDimensions'>
-																							<subprops>
-																								<LowerBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</LowerBounds>
-																								<UpperBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</UpperBounds>
-																							</subprops>
-																						</ArrayDimensions>
-																						<Representation classname='Num'>
-																							<value>1</value>
-																						</Representation>
-																						<ClassName classname='Str'>
-																							<value/>
-																						</ClassName>
-																					</subprops>
-																				</Type>
-																				<Elements classname='Objs'>
-																					<value lbound='[0]' ubound='[]'/>
-																				</Elements>
-																				<IsAnyType classname='Bool'>
-																					<value>true</value>
-																				</IsAnyType>
-																			</subprops>
-																		</_NAME_IN_ATTRIBUTE_>
-																	</elemproto>
-																</value>
-															</AdditionalResultsHints>
-														</subprops>
-													</TS>
-													<Result classname='Obj'>
-														<subprops>
-															<Error classname='Obj'>
-																<subprops>
-																	<Code classname='Num'>
-																		<value>0</value>
-																	</Code>
-																	<Msg classname='Str'>
-																		<value/>
-																	</Msg>
-																	<Occurred classname='Bool'>
-																		<value>false</value>
-																	</Occurred>
-																</subprops>
-															</Error>
-															<Status classname='Str'>
-																<value/>
-															</Status>
-															<ReportText classname='Str'>
-																<value/>
-															</ReportText>
-															<Common classname='Obj'/>
-														</subprops>
-													</Result>
-												</subprops>
-											</Step>
-										</value>
+									<value lbound='[0]' ubound='[1]'>
 										<value>
 											<Step typename='Action' xsi:type='Action' name='Update pin map'>
 												<subprops>
 													<TS classname='Obj'>
 														<subprops>
 															<Id classname='Str'>
-																<value>ID#:fhWpfuRw7RGuNrjdh1OqZD</value>
+																<value>ID#:+fh2fubm7RGhzZiQlrVX7C</value>
 															</Id>
 															<Icon classname='Str'>
 																<value/>
@@ -5218,7 +4836,7 @@
 																				<value>true</value>
 																			</CreateIfInterpreterDoesNotExist>
 																			<ModulePath classname='PathValue'>
-																				<value>teststand_fixture.py</value>
+																				<value>teststand_pin_map.py</value>
 																			</ModulePath>
 																			<OperationType classname='Num'>
 																				<value>1</value>
@@ -5236,7 +4854,7 @@
 																				<value>update_pin_map</value>
 																			</FunctionOrAttributeName>
 																			<Parameters classname='Objs'>
-																				<value lbound='[0]' ubound='[1]'>
+																				<value lbound='[0]' ubound='[2]'>
 																					<elemproto>
 																						<_NAME_IN_ATTRIBUTE_ name='' classname='CPythonParameter' structureflags='0'/>
 																					</elemproto>
@@ -5292,13 +4910,61 @@
 																						<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
 																							<subprops>
 																								<Name classname='Str'>
-																									<value>pin_map_id</value>
+																									<value>pin_map_path</value>
 																								</Name>
 																								<Type classname='Num'>
 																									<value>7</value>
 																								</Type>
 																								<ArgumentValue classname='ExprValue'>
 																									<value>FileGlobals.MeasurementLink.PinMapPath</value>
+																								</ArgumentValue>
+																								<ArgumentDisplayValue classname='ExprValue'>
+																									<value/>
+																								</ArgumentDisplayValue>
+																								<AdditionalResults classname='Obj'>
+																									<subprops>
+																										<Input classname='PythonParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
+																													<value>1</value>
+																												</CheckedState>
+																											</subprops>
+																										</Input>
+																										<Output classname='PythonParameterResult'>
+																											<subprops>
+																												<Condition classname='ExprValue'>
+																													<value/>
+																												</Condition>
+																												<Flags classname='Num'>
+																													<value>8192</value>
+																												</Flags>
+																												<CheckedState classname='Num'>
+																													<value>1</value>
+																												</CheckedState>
+																											</subprops>
+																										</Output>
+																									</subprops>
+																								</AdditionalResults>
+																							</subprops>
+																						</CPythonParameter>
+																					</value>
+																					<value>
+																						<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
+																							<subprops>
+																								<Name classname='Str'>
+																									<value>sequence_context</value>
+																								</Name>
+																								<Type classname='Num'>
+																									<value>7</value>
+																								</Type>
+																								<ArgumentValue classname='ExprValue'>
+																									<value>ThisContext</value>
 																								</ArgumentValue>
 																								<ArgumentDisplayValue classname='ExprValue'>
 																									<value/>
@@ -5635,7 +5301,7 @@
 													<TS classname='Obj'>
 														<subprops>
 															<Id classname='Str'>
-																<value>ID#:c5USoqlx7RGuNrjdh1OqZD</value>
+																<value>ID#:+vh2fubm7RGhzZiQlrVX7C</value>
 															</Id>
 															<Icon classname='Str'>
 																<value/>
@@ -5663,7 +5329,7 @@
 																				<value>true</value>
 																			</CreateIfInterpreterDoesNotExist>
 																			<ModulePath classname='PathValue'>
-																				<value>teststand_fixture.py</value>
+																				<value>teststand_nidmm.py</value>
 																			</ModulePath>
 																			<OperationType classname='Num'>
 																				<value>1</value>
@@ -5737,13 +5403,13 @@
 																						<CPythonParameter typename='NI_PythonParameter' xsi:type='NI_PythonParameter' name=''>
 																							<subprops>
 																								<Name classname='Str'>
-																									<value>pin_map_id</value>
+																									<value>sequence_context</value>
 																								</Name>
 																								<Type classname='Num'>
 																									<value>7</value>
 																								</Type>
 																								<ArgumentValue classname='ExprValue'>
-																									<value>FileGlobals.MeasurementLink.PinMapPath</value>
+																									<value>ThisContext</value>
 																								</ArgumentValue>
 																								<ArgumentDisplayValue classname='ExprValue'>
 																									<value/>
@@ -6074,391 +5740,9 @@
 												</subprops>
 											</Step>
 										</value>
-										<value>
-											<Step typename='Statement' xsi:type='Statement' name='Register active PinMapId'>
-												<subprops>
-													<TS classname='Obj'>
-														<subprops>
-															<Id classname='Str'>
-																<value>ID#:7xzPK+Rw7RGuNrjdh1OqZD</value>
-															</Id>
-															<Icon classname='Str'>
-																<value>StatementStep.ico</value>
-															</Icon>
-															<PreCond classname='ExprValue'>
-																<value/>
-															</PreCond>
-															<LoadOpt classname='Str'>
-																<value>PreloadWhenExecuted</value>
-															</LoadOpt>
-															<UnloadOpt classname='Str'>
-																<value>UnloadWithFile</value>
-															</UnloadOpt>
-															<Mode classname='Str'>
-																<value>Normal</value>
-															</Mode>
-															<WindowActivation classname='Str'>
-																<value>None</value>
-															</WindowActivation>
-															<ResultOption classname='Num'>
-																<value>1</value>
-															</ResultOption>
-															<StepFCSeqF classname='Bool'>
-																<value>true</value>
-															</StepFCSeqF>
-															<IgnoreRTE classname='Bool'>
-																<value>false</value>
-															</IgnoreRTE>
-															<UseMutex classname='Bool'>
-																<value>false</value>
-															</UseMutex>
-															<MutexNameOrRef classname='ExprValue'>
-																<value/>
-															</MutexNameOrRef>
-															<BatchSyncOpt classname='Num'>
-																<value>0</value>
-															</BatchSyncOpt>
-															<SwitchEnabled classname='Bool'>
-																<value>false</value>
-															</SwitchEnabled>
-															<VirtualDeviceName classname='ExprValue'>
-																<value/>
-															</VirtualDeviceName>
-															<SwitchOperation classname='Num'>
-																<value>1</value>
-															</SwitchOperation>
-															<RouteGroupConnect classname='ExprValue'>
-																<value/>
-															</RouteGroupConnect>
-															<RouteGroupDisconnect classname='ExprValue'>
-																<value/>
-															</RouteGroupDisconnect>
-															<MulticonnectMode classname='Num'>
-																<value>1</value>
-															</MulticonnectMode>
-															<OperationOrder classname='Num'>
-																<value>2</value>
-															</OperationOrder>
-															<ConnectionLifetime classname='Num'>
-																<value>0</value>
-															</ConnectionLifetime>
-															<WaitForDebounce classname='Bool'>
-																<value>true</value>
-															</WaitForDebounce>
-															<PassAct classname='Str'>
-																<value>Next</value>
-															</PassAct>
-															<FailAct classname='Str'>
-																<value>Next</value>
-															</FailAct>
-															<PassActTarget classname='ExprValue'>
-																<value/>
-															</PassActTarget>
-															<FailActTarget classname='ExprValue'>
-																<value/>
-															</FailActTarget>
-															<CustExpr classname='ExprValue'>
-																<value/>
-															</CustExpr>
-															<CustTrueAct classname='Str'>
-																<value>Next</value>
-															</CustTrueAct>
-															<CustFalseAct classname='Str'>
-																<value>Next</value>
-															</CustFalseAct>
-															<CustTrueActTarget classname='ExprValue'>
-																<value/>
-															</CustTrueActTarget>
-															<CustFalseActTarget classname='ExprValue'>
-																<value/>
-															</CustFalseActTarget>
-															<LoopType classname='Str'>
-																<value>NoLooping</value>
-															</LoopType>
-															<LoopWhile classname='ExprValue'>
-																<value/>
-															</LoopWhile>
-															<LoopStatus classname='ExprValue'>
-																<value/>
-															</LoopStatus>
-															<LoopIncrement classname='ExprValue'>
-																<value>RunState.LoopIndex += 1</value>
-															</LoopIncrement>
-															<LoopInitialize classname='ExprValue'>
-																<value>RunState.LoopIndex = 0</value>
-															</LoopInitialize>
-															<LoopOpt classname='Num'>
-																<value>0</value>
-															</LoopOpt>
-															<PreExpr classname='ExprValue'>
-																<value/>
-															</PreExpr>
-															<PostExpr classname='ExprValue'>
-																<value>RunState.Engine.TemporaryGlobals.SetValString("NI.MeasurementLink.PinMapId", 0x1, FileGlobals.MeasurementLink.PinMapPath)</value>
-															</PostExpr>
-															<StatusExpr classname='ExprValue'>
-																<value/>
-															</StatusExpr>
-															<CanSpecifyModule classname='Bool'>
-																<value>false</value>
-															</CanSpecifyModule>
-															<CanEditCode classname='Bool'>
-																<value>true</value>
-															</CanEditCode>
-															<CanEditModulePrototype classname='Bool'>
-																<value>true</value>
-															</CanEditModulePrototype>
-															<CanEditParameterAdditionalResults classname='Bool'>
-																<value>true</value>
-															</CanEditParameterAdditionalResults>
-															<PrecondIntExe classname='Num'>
-																<value>0</value>
-															</PrecondIntExe>
-															<CustomResults classname='Objs'>
-																<value lbound='[0]' ubound='[]'>
-																	<elemproto>
-																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-																			<subprops>
-																				<Name classname='ExprValue'>
-																					<value/>
-																				</Name>
-																				<ValueToLog classname='ExprValue'>
-																					<value/>
-																				</ValueToLog>
-																				<Condition classname='ExprValue'>
-																					<value/>
-																				</Condition>
-																				<Flags classname='Num'>
-																					<value>8192</value>
-																				</Flags>
-																				<CheckedState classname='Num'>
-																					<value>2</value>
-																				</CheckedState>
-																				<Type classname='PropertyObjectType'>
-																					<subprops>
-																						<ValueType classname='Num'>
-																							<value>3</value>
-																						</ValueType>
-																						<IsObject classname='Bool'>
-																							<value>true</value>
-																						</IsObject>
-																						<TypeName classname='Str'>
-																							<value/>
-																						</TypeName>
-																						<ElementType classname='Objs'>
-																							<value lbound='[0]' ubound='[]'/>
-																						</ElementType>
-																						<ArrayDimensions classname='ArrayDimensions'>
-																							<subprops>
-																								<LowerBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</LowerBounds>
-																								<UpperBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</UpperBounds>
-																							</subprops>
-																						</ArrayDimensions>
-																						<Representation classname='Num'>
-																							<value>1</value>
-																						</Representation>
-																						<ClassName classname='Str'>
-																							<value/>
-																						</ClassName>
-																					</subprops>
-																				</Type>
-																				<Elements classname='Objs'>
-																					<value lbound='[0]' ubound='[]'/>
-																				</Elements>
-																				<IsAnyType classname='Bool'>
-																					<value>true</value>
-																				</IsAnyType>
-																			</subprops>
-																		</_NAME_IN_ATTRIBUTE_>
-																	</elemproto>
-																</value>
-															</CustomResults>
-															<AdditionalResultsHints classname='Objs'>
-																<value lbound='[0]' ubound='[]'>
-																	<elemproto>
-																		<_NAME_IN_ATTRIBUTE_ name='' classname='CustomResult'>
-																			<subprops>
-																				<Name classname='ExprValue'>
-																					<value/>
-																				</Name>
-																				<ValueToLog classname='ExprValue'>
-																					<value/>
-																				</ValueToLog>
-																				<Condition classname='ExprValue'>
-																					<value/>
-																				</Condition>
-																				<Flags classname='Num'>
-																					<value>8192</value>
-																				</Flags>
-																				<CheckedState classname='Num'>
-																					<value>2</value>
-																				</CheckedState>
-																				<Type classname='PropertyObjectType'>
-																					<subprops>
-																						<ValueType classname='Num'>
-																							<value>3</value>
-																						</ValueType>
-																						<IsObject classname='Bool'>
-																							<value>true</value>
-																						</IsObject>
-																						<TypeName classname='Str'>
-																							<value/>
-																						</TypeName>
-																						<ElementType classname='Objs'>
-																							<value lbound='[0]' ubound='[]'/>
-																						</ElementType>
-																						<ArrayDimensions classname='ArrayDimensions'>
-																							<subprops>
-																								<LowerBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</LowerBounds>
-																								<UpperBounds classname='Nums'>
-																									<value lbound='[0]' ubound='[]'/>
-																								</UpperBounds>
-																							</subprops>
-																						</ArrayDimensions>
-																						<Representation classname='Num'>
-																							<value>1</value>
-																						</Representation>
-																						<ClassName classname='Str'>
-																							<value/>
-																						</ClassName>
-																					</subprops>
-																				</Type>
-																				<Elements classname='Objs'>
-																					<value lbound='[0]' ubound='[]'/>
-																				</Elements>
-																				<IsAnyType classname='Bool'>
-																					<value>true</value>
-																				</IsAnyType>
-																			</subprops>
-																		</_NAME_IN_ATTRIBUTE_>
-																	</elemproto>
-																</value>
-															</AdditionalResultsHints>
-														</subprops>
-													</TS>
-													<Result classname='Obj'>
-														<subprops>
-															<Error classname='Obj'>
-																<subprops>
-																	<Code classname='Num'>
-																		<value>0</value>
-																	</Code>
-																	<Msg classname='Str'>
-																		<value/>
-																	</Msg>
-																	<Occurred classname='Bool'>
-																		<value>false</value>
-																	</Occurred>
-																</subprops>
-															</Error>
-															<Status classname='Str'>
-																<value/>
-															</Status>
-															<ReportText classname='Str'>
-																<value/>
-															</ReportText>
-															<Common classname='Obj'/>
-														</subprops>
-													</Result>
-												</subprops>
-											</Step>
-										</value>
 									</value>
-								</Main>
-								<Setup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
 								</Setup>
 								<Cleanup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
-								</Cleanup>
-								<RecordResults classname='Bool' valueflags='4194312'>
-									<value>false</value>
-								</RecordResults>
-								<RTS classname='Obj' valueflags='4456456'>
-									<subprops>
-										<Type classname='Num' valueflags='4194304'>
-											<value>0</value>
-										</Type>
-										<OptimizeNonReentrantCalls classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</OptimizeNonReentrantCalls>
-										<EPNameExpr classname='Str' valueflags='4194304'>
-											<value>"Unnamed Entry Point"</value>
-										</EPNameExpr>
-										<EPEnabledExpr classname='Str' valueflags='4194304'>
-											<value>True</value>
-										</EPEnabledExpr>
-										<EPMenuHint classname='Str' valueflags='4194304'>
-											<value/>
-										</EPMenuHint>
-										<EPIgnoreClient classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</EPIgnoreClient>
-										<EPInitiallyHidden classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</EPInitiallyHidden>
-										<EPCheckToSaveTitledFile classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</EPCheckToSaveTitledFile>
-										<ShowEPAlways classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPAlways>
-										<ShowEPForFileWin classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</ShowEPForFileWin>
-										<ShowEPForExeWin classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPForExeWin>
-										<ShowEPForEditorOnly classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</ShowEPForEditorOnly>
-										<CopyStepsOnOverriding classname='Bool' valueflags='4194304'>
-											<value>true</value>
-										</CopyStepsOnOverriding>
-										<Priority classname='Num' valueflags='4194304'>
-											<value>2953567917</value>
-										</Priority>
-										<AllowIntExeOfEP classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</AllowIntExeOfEP>
-									</subprops>
-								</RTS>
-								<Requirements classname='Obj' valueflags='4456456'>
-									<subprops>
-										<Links classname='Strs' valueflags='71303168'>
-											<value lbound='[0]' ubound='[]'/>
-										</Links>
-									</subprops>
-								</Requirements>
-								<FailureAction classname='Num' valueflags='4194312'>
-									<value>2</value>
-								</FailureAction>
-							</subprops>
-						</Sequence>
-					</value>
-					<value>
-						<Sequence name='ProcessCleanup'>
-							<comment>Test UUTs and Single Pass call this callback in their cleanup step group. It is empty in the model file.  Override this in the client file to perform an action after all code in the model executes and just before the execution completes.</comment>
-							<subprops>
-								<Parameters classname='Obj' valueflags='4456448'/>
-								<Locals classname='Obj' valueflags='4194304'>
-									<subprops>
-										<ResultList classname='Objs'>
-											<value lbound='[0]' ubound='[]'>
-												<elemproto>
-													<_NAME_IN_ATTRIBUTE_ name='' classname='TEResult'/>
-												</elemproto>
-											</value>
-										</ResultList>
-									</subprops>
-								</Locals>
-								<Main classname='Objs' valueflags='4194304'>
 									<value lbound='[0]' ubound='[1]'>
 										<value>
 											<Step typename='Statement' xsi:type='Statement' name='Unregister active PinMapId'>
@@ -6466,7 +5750,7 @@
 													<TS classname='Obj'>
 														<subprops>
 															<Id classname='Str'>
-																<value>ID#:TTRVYa907RGuN5RXlymy0D</value>
+																<value>ID#:64R8h+bm7RGhzZiQlrVX7C</value>
 															</Id>
 															<Icon classname='Str'>
 																<value>StatementStep.ico</value>
@@ -6761,7 +6045,7 @@
 													<TS classname='Obj'>
 														<subprops>
 															<Id classname='Str'>
-																<value>ID#:syCDFOVw7RGuNrjdh1OqZD</value>
+																<value>ID#:7IR8h+bm7RGhzZiQlrVX7C</value>
 															</Id>
 															<Icon classname='Str'>
 																<value/>
@@ -6789,7 +6073,7 @@
 																				<value>true</value>
 																			</CreateIfInterpreterDoesNotExist>
 																			<ModulePath classname='PathValue'>
-																				<value>teststand_fixture.py</value>
+																				<value>teststand_nidmm.py</value>
 																			</ModulePath>
 																			<OperationType classname='Num'>
 																				<value>1</value>
@@ -7153,15 +6437,9 @@
 											</Step>
 										</value>
 									</value>
-								</Main>
-								<Setup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
-								</Setup>
-								<Cleanup classname='Objs' valueflags='4194304'>
-									<value lbound='[0]' ubound='[]'/>
 								</Cleanup>
 								<RecordResults classname='Bool' valueflags='4194312'>
-									<value>false</value>
+									<value>true</value>
 								</RecordResults>
 								<RTS classname='Obj' valueflags='4456456'>
 									<subprops>
@@ -7201,15 +6479,15 @@
 										<ShowEPForEditorOnly classname='Bool' valueflags='4194304'>
 											<value>false</value>
 										</ShowEPForEditorOnly>
+										<AllowIntExeOfEP classname='Bool' valueflags='4194304'>
+											<value>false</value>
+										</AllowIntExeOfEP>
 										<CopyStepsOnOverriding classname='Bool' valueflags='4194304'>
 											<value>true</value>
 										</CopyStepsOnOverriding>
 										<Priority classname='Num' valueflags='4194304'>
 											<value>2953567917</value>
 										</Priority>
-										<AllowIntExeOfEP classname='Bool' valueflags='4194304'>
-											<value>false</value>
-										</AllowIntExeOfEP>
 									</subprops>
 								</RTS>
 								<Requirements classname='Obj' valueflags='4456456'>
@@ -7234,11 +6512,8 @@
 							<EnableMonitoring classname='Bool'>
 								<value>false</value>
 							</EnableMonitoring>
-							<PinMapFileName classname='Str'>
-								<value>NIDmmMeasurement.pinmap</value>
-							</PinMapFileName>
 							<PinMapPath typename='Path' xsi:type='Path' classname='PathValue'>
-								<value/>
+								<value>NIDmmMeasurement.pinmap</value>
 							</PinMapPath>
 						</subprops>
 					</MeasurementLink>

--- a/examples/nidmm_measurement/teststand_pin_map.py
+++ b/examples/nidmm_measurement/teststand_pin_map.py
@@ -1,0 +1,27 @@
+"""TestStand code module for setting up pin maps with MeasurementLink."""
+from typing import Any
+
+from _helpers import GrpcChannelPoolHelper, PinMapClient, TestStandSupport
+
+
+def update_pin_map(pin_map_path: str, sequence_context: Any) -> str:
+    """Update registered pin map contents.
+
+    Create and register a pin map if a pin map resource for the specified pin map id is not found.
+
+    Args:
+        pin_map_path:
+            An absolute or relative path to the pin map file.
+        sequence_context:
+            The SequenceContext COM object from the TestStand sequence execution.
+            (Dynamically typed.)
+    """
+    teststand_support = TestStandSupport(sequence_context)
+    pin_map_abs_path = teststand_support.resolve_file_path(pin_map_path)
+
+    with GrpcChannelPoolHelper() as grpc_channel_pool:
+        pin_map_client = PinMapClient(grpc_channel=grpc_channel_pool.pin_map_channel)
+        pin_map_id = pin_map_client.update_pin_map(pin_map_abs_path)
+
+    teststand_support.set_active_pin_map_id(pin_map_id)
+    return pin_map_id


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Refactor TestStand code module to minimize impact of name conflicts between multiple examples:
- Move pin map support to `teststand_pin_map.py`
- Move modular instrument session support to `teststand_${driver}.py` (e.g. `teststand_nidcpower.py`)

Add a `multiple_measurements` example that demonstrates how to call multiple measurement services from TestStand. This example includes only the TestStand sequence and the relevant TestStand code modules.

### Why should this Pull Request be merged?

Make it easier to get started using multiple measurement services in TestStand.

### What testing has been done?

Manually tested.