### PR TITLE
service: Add support for measurement v2 interface

### DIFF
--- a/ni_measurementlink_service/_internal/discovery_client.py
+++ b/ni_measurementlink_service/_internal/discovery_client.py
@@ -25,7 +25,10 @@ if sys.platform == "win32":
     import winerror
 
 
-_PROVIDED_MEASUREMENT_SERVICE = "ni.measurementlink.measurement.v1.MeasurementService"
+_PROVIDED_MEASUREMENT_SERVICES = [
+    "ni.measurementlink.measurement.v1.MeasurementService",
+    "ni.measurementlink.measurement.v2.MeasurementService",
+]
 
 _logger = logging.getLogger(__name__)
 
@@ -108,7 +111,7 @@ class DiscoveryClient:
             service_descriptor.display_name = measurement_info.display_name
             service_descriptor.service_class = service_info.service_class
             service_descriptor.description_url = service_info.description_url
-            service_descriptor.provided_interfaces.append(_PROVIDED_MEASUREMENT_SERVICE)
+            service_descriptor.provided_interfaces.extend(_PROVIDED_MEASUREMENT_SERVICES)
 
             # Registration Request Creation
             request = discovery_service_pb2.RegisterServiceRequest(

--- a/ni_measurementlink_service/_internal/grpc_servicer.py
+++ b/ni_measurementlink_service/_internal/grpc_servicer.py
@@ -14,8 +14,12 @@ from ni_measurementlink_service._internal.stubs.ni.measurementlink import (
     pin_map_context_pb2,
 )
 from ni_measurementlink_service._internal.stubs.ni.measurementlink.measurement.v1 import (
-    measurement_service_pb2,
-    measurement_service_pb2_grpc,
+    measurement_service_pb2 as v1_measurement_service_pb2,
+    measurement_service_pb2_grpc as v1_measurement_service_pb2_grpc,
+)
+from ni_measurementlink_service._internal.stubs.ni.measurementlink.measurement.v2 import (
+    measurement_service_pb2 as v2_measurement_service_pb2,
+    measurement_service_pb2_grpc as v2_measurement_service_pb2_grpc,
 )
 from ni_measurementlink_service.measurement.info import MeasurementInfo
 
@@ -74,7 +78,30 @@ measurement_service_context: ContextVar[MeasurementServiceContext] = ContextVar(
 )
 
 
-class MeasurementServiceServicer(measurement_service_pb2_grpc.MeasurementServiceServicer):
+def _get_mapping_by_parameter_name(
+    mapping_by_id: Dict[int, Any], measure_function: Callable[[], None]
+) -> Dict[str, Any]:
+    """Transform the mapping by id to mapping by parameter names of the measurement function.
+
+    Args
+    ----
+        mapping_by_id (Dict[int, Any]): Mapping by ID
+
+        measure_function (callable): Function from which the parameter names are extracted.
+
+    Returns
+    -------
+        Dict[str, Any]: Mapping by Parameters names based on the measurement function.
+
+    """
+    signature = inspect.signature(measure_function)
+    mapping_by_variable_name = {}
+    for i, parameter in enumerate(signature.parameters.values(), start=1):
+        mapping_by_variable_name[parameter.name] = mapping_by_id[i]
+    return mapping_by_variable_name
+
+
+class MeasurementServiceServicerV1(v1_measurement_service_pb2_grpc.MeasurementServiceServicer):
     """Implementation of the Measurement Service's gRPC base class.
 
     Attributes
@@ -128,19 +155,19 @@ class MeasurementServiceServicer(measurement_service_pb2_grpc.MeasurementService
     def GetMetadata(self, request, context):  # noqa: N802 - function name should be lowercase
         """RPC API to get complete metadata."""
         # measurement details
-        measurement_details = measurement_service_pb2.MeasurementDetails()
+        measurement_details = v1_measurement_service_pb2.MeasurementDetails()
         measurement_details.display_name = self.measurement_info.display_name
         measurement_details.version = self.measurement_info.version
 
         # Measurement Parameters
-        measurement_signature = measurement_service_pb2.MeasurementSignature(
+        measurement_signature = v1_measurement_service_pb2.MeasurementSignature(
             configuration_parameters_message_type="ni.measurementlink.measurement.v1.MeasurementConfigurations",
             outputs_message_type="ni.measurementlink.measurement.v1.MeasurementOutputs",
         )
 
         # Configurations
         for field_number, configuration_metadata in self.configuration_metadata.items():
-            configuration_parameter = measurement_service_pb2.ConfigurationParameter()
+            configuration_parameter = v1_measurement_service_pb2.ConfigurationParameter()
             configuration_parameter.field_number = field_number
             configuration_parameter.name = configuration_metadata.display_name
             configuration_parameter.repeated = configuration_metadata.repeated
@@ -155,7 +182,7 @@ class MeasurementServiceServicer(measurement_service_pb2_grpc.MeasurementService
 
         # Output Parameters Metadata
         for field_number, output_metadata in self.output_metadata.items():
-            output_parameter = measurement_service_pb2.Output()
+            output_parameter = v1_measurement_service_pb2.Output()
             output_parameter.field_number = field_number
             output_parameter.name = output_metadata.display_name
             output_parameter.type = output_metadata.type
@@ -163,7 +190,7 @@ class MeasurementServiceServicer(measurement_service_pb2_grpc.MeasurementService
             measurement_signature.outputs.append(output_parameter)
 
         # Sending back Response
-        metadata_response = measurement_service_pb2.GetMetadataResponse(
+        metadata_response = v1_measurement_service_pb2.GetMetadataResponse(
             measurement_details=measurement_details,
             measurement_signature=measurement_signature,
             user_interface_details=None,
@@ -171,7 +198,7 @@ class MeasurementServiceServicer(measurement_service_pb2_grpc.MeasurementService
 
         # User Interface details - Framed relative to the metadata python File
         for ui_file_path in self.measurement_info.ui_file_paths:
-            ui_details = measurement_service_pb2.UserInterfaceDetails()
+            ui_details = v1_measurement_service_pb2.UserInterfaceDetails()
             ui_details.file_url = pathlib.Path(ui_file_path).as_uri()
             metadata_response.user_interface_details.append(ui_details)
 
@@ -183,7 +210,7 @@ class MeasurementServiceServicer(measurement_service_pb2_grpc.MeasurementService
         mapping_by_id = serializer.deserialize_parameters(self.configuration_metadata, byte_string)
 
         # Calling the registered measurement
-        mapping_by_variable_name = self._get_mapping_by_parameter_name(
+        mapping_by_variable_name = _get_mapping_by_parameter_name(
             mapping_by_id, self.measure_function
         )
         token = measurement_service_context.set(
@@ -198,27 +225,133 @@ class MeasurementServiceServicer(measurement_service_pb2_grpc.MeasurementService
         # Frame the response and send back.
         output_any = any_pb2.Any()
         output_any.value = output_bytestring
-        return_value = measurement_service_pb2.MeasureResponse(outputs=output_any)
+        return_value = v1_measurement_service_pb2.MeasureResponse(outputs=output_any)
         return return_value
 
-    def _get_mapping_by_parameter_name(
-        self, mapping_by_id: Dict[int, Any], measure_function: Callable[[], None]
-    ) -> Dict[str, Any]:
-        """Transform the mapping by id to mapping by parameter names of the measurement function.
 
-        Args
-        ----
-            mapping_by_id (Dict[int, Any]): Mapping by ID
+class MeasurementServiceServicerV2(v2_measurement_service_pb2_grpc.MeasurementServiceServicer):
+    """Implementation of the Measurement Service's gRPC base class.
 
-            measure_function (callable): Function from which the parameter names are extracted.
+    Attributes
+    ----------
+        measurement_info (MeasurementInfo): Measurement info
 
-        Returns
-        -------
-            Dict[str, Any]: Mapping by Parameters names based on the measurement function.
+        configuration_parameter_list (List): List of configuration parameters.
+
+        output_parameter_list (List): List of output parameters.
+
+        measure_function (Callable): Registered measurement function.
+
+    """
+
+    def __init__(
+        self,
+        measurement_info: MeasurementInfo,
+        configuration_parameter_list: List[ParameterMetadata],
+        output_parameter_list: list,
+        measure_function: Callable,
+    ) -> None:
+        """Initialize the Measurement Service Servicer.
+
+        Args:
+            measurement_info (MeasurementInfo): Measurement info
+
+            configuration_parameter_list (List): List of configuration parameters.
+
+            output_parameter_list (List): List of output parameters.
+
+            measure_function (Callable): Registered measurement function.
 
         """
-        signature = inspect.signature(measure_function)
-        mapping_by_variable_name = {}
-        for i, parameter in enumerate(signature.parameters.values(), start=1):
-            mapping_by_variable_name[parameter.name] = mapping_by_id[i]
-        return mapping_by_variable_name
+        super().__init__()
+
+        def frame_metadata_dict(parameter_list: list):
+            metadata_dict = {}
+            for i, parameter in enumerate(parameter_list, start=1):
+                metadata_dict[i] = parameter
+            return metadata_dict
+
+        self.configuration_metadata: Dict[int, ParameterMetadata] = frame_metadata_dict(
+            configuration_parameter_list
+        )
+        self.output_metadata: Dict[int, ParameterMetadata] = frame_metadata_dict(
+            output_parameter_list
+        )
+        self.measurement_info: MeasurementInfo = measurement_info
+        self.measure_function = measure_function
+
+    def GetMetadata(self, request, context):  # noqa N802:inherited method names-autogen baseclass
+        """RPC API to get complete metadata."""
+        # measurement details
+        measurement_details = v2_measurement_service_pb2.MeasurementDetails()
+        measurement_details.display_name = self.measurement_info.display_name
+        measurement_details.version = self.measurement_info.version
+
+        # Measurement Parameters
+        measurement_signature = v2_measurement_service_pb2.MeasurementSignature(
+            configuration_parameters_message_type="ni.measurementlink.measurement.v1.MeasurementConfigurations",
+            outputs_message_type="ni.measurementlink.measurement.v1.MeasurementOutputs",
+        )
+
+        # Configurations
+        for field_number, configuration_metadata in self.configuration_metadata.items():
+            configuration_parameter = v2_measurement_service_pb2.ConfigurationParameter()
+            configuration_parameter.field_number = field_number
+            configuration_parameter.name = configuration_metadata.display_name
+            configuration_parameter.repeated = configuration_metadata.repeated
+            configuration_parameter.type = configuration_metadata.type
+            configuration_parameter.annotations.update(configuration_metadata.annotations)
+            measurement_signature.configuration_parameters.append(configuration_parameter)
+
+        # Configuration Defaults
+        measurement_signature.configuration_defaults.value = serializer.serialize_default_values(
+            self.configuration_metadata
+        )
+
+        # Output Parameters Metadata
+        for field_number, output_metadata in self.output_metadata.items():
+            output_parameter = v2_measurement_service_pb2.Output()
+            output_parameter.field_number = field_number
+            output_parameter.name = output_metadata.display_name
+            output_parameter.type = output_metadata.type
+            output_parameter.repeated = output_metadata.repeated
+            measurement_signature.outputs.append(output_parameter)
+
+        # Sending back Response
+        metadata_response = v2_measurement_service_pb2.GetMetadataResponse(
+            measurement_details=measurement_details,
+            measurement_signature=measurement_signature,
+            user_interface_details=None,
+        )
+
+        # User Interface details - Framed relative to the metadata python File
+        for ui_file_path in self.measurement_info.ui_file_paths:
+            ui_details = v2_measurement_service_pb2.UserInterfaceDetails()
+            ui_details.file_url = pathlib.Path(ui_file_path).as_uri()
+            metadata_response.user_interface_details.append(ui_details)
+
+        return metadata_response
+
+    def Measure(self, request, context):  # noqa N802:inherited method names-autogen baseclass
+        """RPC API that Executes the registered measurement method."""
+        byte_string = request.configuration_parameters.value
+        mapping_by_id = serializer.deserialize_parameters(self.configuration_metadata, byte_string)
+
+        # Calling the registered measurement
+        mapping_by_variable_name = _get_mapping_by_parameter_name(
+            mapping_by_id, self.measure_function
+        )
+        token = measurement_service_context.set(
+            MeasurementServiceContext(context, request.pin_map_context)
+        )
+        try:
+            output_value = self.measure_function(**mapping_by_variable_name)
+        finally:
+            measurement_service_context.get().mark_complete()
+            measurement_service_context.reset(token)
+        output_bytestring = serializer.serialize_parameters(self.output_metadata, output_value)
+        # Frame the response and send back.
+        output_any = any_pb2.Any()
+        output_any.value = output_bytestring
+        return_value = v2_measurement_service_pb2.MeasureResponse(outputs=output_any)
+        yield return_value

--- a/ni_measurementlink_service/_internal/service_manager.py
+++ b/ni_measurementlink_service/_internal/service_manager.py
@@ -6,11 +6,15 @@ from grpc.framework.foundation import logging_pool
 
 from ni_measurementlink_service._internal.discovery_client import DiscoveryClient
 from ni_measurementlink_service._internal.grpc_servicer import (
-    MeasurementServiceServicer,
+    MeasurementServiceServicerV1,
+    MeasurementServiceServicerV2,
 )
 from ni_measurementlink_service._internal.parameter.metadata import ParameterMetadata
 from ni_measurementlink_service._internal.stubs.ni.measurementlink.measurement.v1 import (
-    measurement_service_pb2_grpc,
+    measurement_service_pb2_grpc as v1_measurement_service_pb2_grpc,
+)
+from ni_measurementlink_service._internal.stubs.ni.measurementlink.measurement.v2 import (
+    measurement_service_pb2_grpc as v2_measurement_service_pb2_grpc,
 )
 from ni_measurementlink_service.measurement.info import MeasurementInfo, ServiceInfo
 
@@ -76,14 +80,23 @@ class GrpcService:
                 ("grpc.max_send_message_length", -1),
             ],
         )
-        self.servicer = MeasurementServiceServicer(
+        servicer_v1 = MeasurementServiceServicerV1(
             measurement_info,
             configuration_parameter_list,
             output_parameter_list,
             measure_function,
         )
-        measurement_service_pb2_grpc.add_MeasurementServiceServicer_to_server(
-            self.servicer, self.server
+        v1_measurement_service_pb2_grpc.add_MeasurementServiceServicer_to_server(
+            servicer_v1, self.server
+        )
+        servicer_v2 = MeasurementServiceServicerV2(
+            measurement_info,
+            configuration_parameter_list,
+            output_parameter_list,
+            measure_function,
+        )
+        v2_measurement_service_pb2_grpc.add_MeasurementServiceServicer_to_server(
+            servicer_v2, self.server
         )
         port = str(self.server.add_insecure_port("[::]:0"))
         self.server.start()

--- a/tests/acceptance/test_measurement_service.py
+++ b/tests/acceptance/test_measurement_service.py
@@ -3,6 +3,7 @@ import random
 import urllib.parse
 import urllib.request
 from os import path
+from typing import Generator, List, Union
 
 import grpc
 import pytest
@@ -10,96 +11,175 @@ from examples.sample_measurement import measurement
 from google.protobuf import any_pb2
 
 from ni_measurementlink_service._internal.stubs.ni.measurementlink.measurement.v1 import (
-    measurement_service_pb2,
-    measurement_service_pb2_grpc,
+    measurement_service_pb2 as v1_measurement_service_pb2,
+    measurement_service_pb2_grpc as v1_measurement_service_pb2_grpc,
 )
+from ni_measurementlink_service._internal.stubs.ni.measurementlink.measurement.v2 import (
+    measurement_service_pb2 as v2_measurement_service_pb2,
+    measurement_service_pb2_grpc as v2_measurement_service_pb2_grpc,
+)
+from ni_measurementlink_service.measurement.service import MeasurementService
 from tests.assets import sample_measurement_test_pb2
 
 EXPECTED_PARAMETER_COUNT = 5
 EXPECTED_UI_FILE_COUNT = 3
 
 
-def test___measurement_service___get_metadata_rpc_call___returns_metadata():
-    measurement_service_port = _host_service()
+def test___measurement_service_v1___get_metadata___returns_metadata(
+    stub_v1: v1_measurement_service_pb2_grpc.MeasurementServiceStub,
+):
+    response = stub_v1.GetMetadata(v1_measurement_service_pb2.GetMetadataRequest())
 
-    with _create_channel(measurement_service_port) as channel:
-        stub = measurement_service_pb2_grpc.MeasurementServiceStub(channel)
-        get_metadata_response = stub.GetMetadata(measurement_service_pb2.GetMetadataRequest())
+    _validate_get_metadata_response(response)
 
-    _validate_metadata_response(get_metadata_response)
+
+def test___measurement_service_v2___get_metadata___returns_metadata(
+    stub_v2: v2_measurement_service_pb2_grpc.MeasurementServiceStub,
+):
+    response = stub_v2.GetMetadata(v2_measurement_service_pb2.GetMetadataRequest())
+
+    _validate_get_metadata_response(response)
 
 
 @pytest.mark.parametrize(
     "float_in,double_array_in,bool_in,string_in, string_array_in",
     [(0.9, [1.0, 23.56], True, "InputString", ["", "TestString1", "#$%!@<*(&^~`"])],
 )
-def test___measurement_service___measure_rpc_call___returns_output(
-    float_in, double_array_in, bool_in, string_in, string_array_in
+def test___measurement_service_v1___measure___returns_output(
+    float_in: float,
+    double_array_in: List[float],
+    bool_in: bool,
+    string_in: str,
+    string_array_in: List[str],
+    stub_v1: v1_measurement_service_pb2_grpc.MeasurementServiceStub,
 ):
-    measurement_service_port = _host_service()
-
-    with _create_channel(measurement_service_port) as channel:
-        stub = measurement_service_pb2_grpc.MeasurementServiceStub(channel)
-        request = _get_sample_measurement_measure_request(
+    request = v1_measurement_service_pb2.MeasureRequest(
+        configuration_parameters=_get_configuration_parameters(
             float_in, double_array_in, bool_in, string_in, string_array_in
         )
-        measure_response = stub.Measure(request)
+    )
+    response = stub_v1.Measure(request)
 
     serialized_parameter = _get_serialized_measurement_signature(
         float_in, double_array_in, bool_in, string_in, string_array_in
     )
-    assert measure_response.outputs.value == serialized_parameter
+    assert response.outputs.value == serialized_parameter
+
+
+@pytest.mark.parametrize(
+    "float_in,double_array_in,bool_in,string_in, string_array_in",
+    [(0.9, [1.0, 23.56], True, "InputString", ["", "TestString1", "#$%!@<*(&^~`"])],
+)
+def test___measurement_service_v2___measure___returns_output(
+    float_in: float,
+    double_array_in: List[float],
+    bool_in: bool,
+    string_in: str,
+    string_array_in: List[str],
+    stub_v2: v2_measurement_service_pb2_grpc.MeasurementServiceStub,
+):
+    """End to End Test to validate Measure RPC call with Sample Measurement."""
+    request = v2_measurement_service_pb2.MeasureRequest(
+        configuration_parameters=_get_configuration_parameters(
+            float_in, double_array_in, bool_in, string_in, string_array_in
+        )
+    )
+    response_iterator = stub_v2.Measure(request)
+    responses = [response for response in response_iterator]
+
+    serialized_parameter = _get_serialized_measurement_signature(
+        float_in, double_array_in, bool_in, string_in, string_array_in
+    )
+    assert len(responses) == 1
+    assert responses[0].outputs.value == serialized_parameter
 
 
 @pytest.mark.parametrize("double_array_len", [10000, 100000, 1000000, 10000000])  # up to 80 MB
-def test___measurement_service___measure_with_large_array___returns_output(double_array_len):
-    measurement_service_port = _host_service()
+def test___measurement_service_v1___measure_with_large_array___returns_output(
+    double_array_len: int, stub_v1: v1_measurement_service_pb2_grpc.MeasurementServiceStub
+):
     float_in = 1.23
     double_array_in = [random.random() for i in range(double_array_len)]
     bool_in = False
     string_in = "InputString"
     string_array_in = ["", "TestString1", "#$%!@<*(&^~`"]
 
-    with _create_channel(measurement_service_port) as channel:
-        stub = measurement_service_pb2_grpc.MeasurementServiceStub(channel)
-        request = _get_sample_measurement_measure_request(
-            float_in, double_array_in, bool_in, string_in, string_array_in
-        )
-        measure_response = stub.Measure(request)
-
-    serialized_parameter = _get_serialized_measurement_signature(
-        float_in, double_array_in, bool_in, string_in, string_array_in
-    )
-    assert measure_response.outputs.value == serialized_parameter
-
-
-def _host_service() -> str:
-    measurement.sample_measurement_service.host_service()
-    return measurement.sample_measurement_service.grpc_service.port
-
-
-def _create_channel(port: str):
-    return grpc.insecure_channel(
-        "localhost:" + port,
-        options=[
-            ("grpc.max_receive_message_length", -1),
-            ("grpc.max_send_message_length", -1),
-        ],
-    )
-
-
-def _get_sample_measurement_measure_request(
-    float_in, double_array_in, bool_in, string_in, string_array_in
-):
-    request = measurement_service_pb2.MeasureRequest(
+    request = v1_measurement_service_pb2.MeasureRequest(
         configuration_parameters=_get_configuration_parameters(
             float_in, double_array_in, bool_in, string_in, string_array_in
         )
     )
-    return request
+    response = stub_v1.Measure(request)
+
+    serialized_parameter = _get_serialized_measurement_signature(
+        float_in, double_array_in, bool_in, string_in, string_array_in
+    )
+    assert response.outputs.value == serialized_parameter
 
 
-def _get_configuration_parameters(float_in, double_array_in, bool_in, string_in, string_array_in):
+@pytest.mark.parametrize("double_array_len", [10000, 100000, 1000000, 10000000])  # up to 80 MB
+def test___measurement_service_v2___measure_with_large_array___returns_output(
+    double_array_len: int, stub_v2: v2_measurement_service_pb2_grpc.MeasurementServiceStub
+):
+    float_in = 1.23
+    double_array_in = [random.random() for i in range(double_array_len)]
+    bool_in = False
+    string_in = "InputString"
+    string_array_in = ["", "TestString1", "#$%!@<*(&^~`"]
+
+    request = v2_measurement_service_pb2.MeasureRequest(
+        configuration_parameters=_get_configuration_parameters(
+            float_in, double_array_in, bool_in, string_in, string_array_in
+        )
+    )
+    response_iterator = stub_v2.Measure(request)
+    responses = [response for response in response_iterator]
+
+    serialized_parameter = _get_serialized_measurement_signature(
+        float_in, double_array_in, bool_in, string_in, string_array_in
+    )
+    assert len(responses) == 1
+    assert responses[0].outputs.value == serialized_parameter
+
+
+@pytest.fixture(scope="module")
+def measurement_service() -> Generator[MeasurementService, None, None]:
+    """Test fixture that creates and hosts a measurement service."""
+    with measurement.sample_measurement_service.host_service() as service:
+        yield service
+
+
+@pytest.fixture
+def grpc_channel(measurement_service: MeasurementService) -> Generator[grpc.Channel, None, None]:
+    """Test fixture that creates a gRPC channel."""
+    target = f"localhost:{measurement_service.grpc_service.port}"
+    options = [
+        ("grpc.max_receive_message_length", -1),
+        ("grpc.max_send_message_length", -1),
+    ]
+    with grpc.insecure_channel(target, options) as channel:
+        yield channel
+
+
+@pytest.fixture
+def stub_v1(grpc_channel: grpc.Channel) -> v1_measurement_service_pb2_grpc.MeasurementServiceStub:
+    """Test fixture that creates a MeasurementService v1 stub."""
+    return v1_measurement_service_pb2_grpc.MeasurementServiceStub(grpc_channel)
+
+
+@pytest.fixture
+def stub_v2(grpc_channel: grpc.Channel) -> v2_measurement_service_pb2_grpc.MeasurementServiceStub:
+    """Test fixture that creates a MeasurementService v2 stub."""
+    return v2_measurement_service_pb2_grpc.MeasurementServiceStub(grpc_channel)
+
+
+def _get_configuration_parameters(
+    float_in: float,
+    double_array_in: List[float],
+    bool_in: bool,
+    string_in: str,
+    string_array_in: List[str],
+) -> any_pb2.Any:
     serialized_parameter = _get_serialized_measurement_signature(
         float_in, double_array_in, bool_in, string_in, string_array_in
     )
@@ -109,8 +189,12 @@ def _get_configuration_parameters(float_in, double_array_in, bool_in, string_in,
 
 
 def _get_serialized_measurement_signature(
-    float_in, double_array_in, bool_in, string_in, string_array_in
-):
+    float_in: float,
+    double_array_in: List[float],
+    bool_in: bool,
+    string_in: str,
+    string_array_in: List[str],
+) -> bytes:
     config_params = sample_measurement_test_pb2.SampleMeasurementParameter()
     config_params.float_in = float_in
     config_params.double_array_in.extend(double_array_in)
@@ -124,7 +208,12 @@ def _get_serialized_measurement_signature(
     return grpc_serialized_data
 
 
-def _validate_metadata_response(get_metadata_response):
+def _validate_get_metadata_response(
+    get_metadata_response: Union[
+        v1_measurement_service_pb2.GetMetadataResponse,
+        v2_measurement_service_pb2.GetMetadataResponse,
+    ]
+):
     assert get_metadata_response.measurement_details.display_name == "Sample Measurement (Py)"
     assert get_metadata_response.measurement_details.version == "0.1.0.0"
 

--- a/tests/assets/example.serviceconfig
+++ b/tests/assets/example.serviceconfig
@@ -4,7 +4,10 @@
       "displayName": "SampleMeasurement",
       "serviceClass": "SampleMeasurement_Python",
       "descriptionUrl": "https://www.example.com/SampleMeasurement.html",
-      "providedInterfaces": [ "ni.measurementlink.measurement.v1.MeasurementService" ],
+      "providedInterfaces": [
+        "ni.measurementlink.measurement.v1.MeasurementService",
+        "ni.measurementlink.measurement.v2.MeasurementService"
+      ],
       "path": "start.bat"
     }
   ]

--- a/tests/unit/test_discovery_client.py
+++ b/tests/unit/test_discovery_client.py
@@ -5,17 +5,14 @@ from typing import cast
 import pytest
 
 from ni_measurementlink_service._internal.discovery_client import (
-    DiscoveryClient,
     _PROVIDED_MEASUREMENT_SERVICES,
+    DiscoveryClient,
 )
 from ni_measurementlink_service._internal.stubs.ni.measurementlink.discovery.v1.discovery_service_pb2_grpc import (
     DiscoveryServiceStub,
 )
-from ni_measurementlink_service.measurement.info import ServiceInfo, MeasurementInfo
-from tests.utilities.fake_discovery_service import (
-    FakeDiscoveryServiceStub,
-)
-
+from ni_measurementlink_service.measurement.info import MeasurementInfo, ServiceInfo
+from tests.utilities.fake_discovery_service import FakeDiscoveryServiceStub
 
 _TEST_SERVICE_PORT = "9999"
 _TEST_SERVICE_INFO = ServiceInfo("TestServiceClass", "TestUrl")
@@ -87,4 +84,6 @@ def _validate_grpc_request(request):
     assert request.service_description.service_class == _TEST_SERVICE_INFO.service_class
     assert request.service_description.description_url == _TEST_SERVICE_INFO.description_url
     assert request.service_description.display_name == _TEST_MEASUREMENT_INFO.display_name
-    assert all(service_interface in request.service_description.provided_interfaces for service_interface in _PROVIDED_MEASUREMENT_SERVICES)
+    assert set(request.service_description.provided_interfaces) >= set(
+        _PROVIDED_MEASUREMENT_SERVICES
+    )

--- a/tests/unit/test_discovery_client.py
+++ b/tests/unit/test_discovery_client.py
@@ -6,7 +6,7 @@ import pytest
 
 from ni_measurementlink_service._internal.discovery_client import (
     DiscoveryClient,
-    _PROVIDED_MEASUREMENT_SERVICE,
+    _PROVIDED_MEASUREMENT_SERVICES,
 )
 from ni_measurementlink_service._internal.stubs.ni.measurementlink.discovery.v1.discovery_service_pb2_grpc import (
     DiscoveryServiceStub,
@@ -87,4 +87,4 @@ def _validate_grpc_request(request):
     assert request.service_description.service_class == _TEST_SERVICE_INFO.service_class
     assert request.service_description.description_url == _TEST_SERVICE_INFO.description_url
     assert request.service_description.display_name == _TEST_MEASUREMENT_INFO.display_name
-    assert _PROVIDED_MEASUREMENT_SERVICE in request.service_description.provided_interfaces
+    assert all(service_interface in request.service_description.provided_interfaces for service_interface in _PROVIDED_MEASUREMENT_SERVICES)

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -3,10 +3,7 @@ import pathlib
 
 import pytest
 
-from ni_measurementlink_service.measurement.info import (
-    DataType,
-    TypeSpecialization,
-)
+from ni_measurementlink_service.measurement.info import DataType, TypeSpecialization
 from ni_measurementlink_service.measurement.service import MeasurementService
 
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add support for the `ni.measurementlink.measurement.v2.MeasurementService` interface.

Also:
- Validate that the data returned from the measurement function is a sequence (i.e. list or tuple)
- Refactor `grpcservicer` submodule
- Update some type annotations and docstrings

This PR does not add `ni.measurementlink.measurement.v2.MeasurementService` to the example services' `.serviceconfig` files. We should update the examples to depend on ni-measurementlink-service >=1.1 when we do that, to ensure that the examples do not advertise the v2 interface when using a version of ni-measurementlink-service that only supports v1.

### Why should this Pull Request be merged?

This is a prerequisite for supporting features that are only supported in the measurement v2 interface.

### What testing has been done?

- Ran `ni-python-styleguide`, `mypy`, and `pytest`.
- Manually tested `sample_measurement` with dev nims uncommented and latest dev build of InstrumentStudio.
- Manually tested `sample_measurement` and `nidcpower_source_dc_voltage` with dev nims uncommented and InstrumentStudio 23.3.