### PR TITLE
service: Add support for updating outputs during the measurement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ exclude = '''
 
 [tool.poetry]
 name = "ni_measurementlink_service"
-version = "1.0.1"
+version = "1.1.0a0"
 description = "MeasurementLink Support for Python"
 authors = ["NI <opensource@ni.com>"]
 readme = "README.md" # apply the repo readme to the package as well


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Currently, measurement services send outputs to the client when the measurement is complete, by returning a list/tuple of output values. This PR allows measurement services to send outputs to the client during the measurement, by yielding a list/tuple of output values.

When accessed via the `ni.measurementlink.measurement.v1.MeasurementService` interface, only the last update is sent to the client.

The final update may use either a `yield` or `return` statement, so that adding a `yield` statement to a previously working measurement service doesn't cause the return value to be ignored. This is why this code catches `StopIteration`: to inspect the return value stored in the exception's `value` field.

Also:
- Update the `ni-measurementlink-service` version to 1.1.0a0
 
### Why should this Pull Request be merged?

AB#2371309

### What testing has been done?

- Ran `ni-python-styleguide`, `mypy`, and `pytest`.
- Manually tested `ui_progress_updates` example (with latest dev build of InstrumentStudio.
   - Used logging to test that the **STOP** button makes the measurement stop.
   - This example will be added in a separate PR.