### PR TITLE
tests: Update pytest options for doctests, markers, testpaths, and warnings

### DIFF
--- a/ni_measurementlink_generator/pyproject.toml
+++ b/ni_measurementlink_generator/pyproject.toml
@@ -49,3 +49,8 @@ warn_unused_ignores = true
 [[tool.mypy.overrides]]
 module = "mako.*"
 ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+addopts = "--doctest-modules --ignore tests/test_assets --strict-markers"
+filterwarnings = ["always::ImportWarning", "always::ResourceWarning"]
+testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,9 +71,9 @@ build-backend = "poetry.core.masonry.api"
 extend_exclude = "*_pb2_grpc.py,*_pb2.py,venv,ni_measurementlink_generator/*"
 
 [tool.pytest.ini_options]
-testpaths = [
-    "tests"
-]
+addopts = "--doctest-modules --strict-markers"
+filterwarnings = ["always::ImportWarning", "always::ResourceWarning"]
+testpaths = ["tests"]
 
 [tool.mypy]
 exclude = ["stubs"]


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Specify --doctest-modules. If we add doctests to the main package, we should run them.
- Specify --strict-markers. Require markers to be declared to avoid typos and ensure they are documented.
- Enable ImportWarning and ResourceWarning. By default, Python filters out DeprecationWarning, DeprecationPendingWarning, ImportWarning, and ResourceWarning. Pytest enables DeprecationWarning and DeprecationPendingWarning but not the others. Enabling ResourceWarning in nidaqmx-python has caught some resource leaks.
- generator: Specify testpaths to test pytest where to search for tests.
- generator: Specify --ignore to prevent pytest from looking for doctests in test_assets.

> **Note**
> I chose not to enable --cov or --verbose in pyproject.toml. These are still specified in the PR workflow.

### Why should this Pull Request be merged?

Ensure proper handling of doctests, markers, and warnings.

Specifying testpaths should reduce the number of directories that pytest searches for tests.

### What testing has been done?

Ran `poetry run pytest -v`