### PR TITLE
Publish workflow: Upload archive of examples as release assets

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - 'releases/**'
 
 env:
   POETRY_VERSION: 1.2.2

--- a/.github/workflows/Publish_NIMS.yml
+++ b/.github/workflows/Publish_NIMS.yml
@@ -98,8 +98,9 @@ jobs:
         env:
           EXAMPLE_ARCHIVE: measurementlink-python-examples-${{ steps.vars.outputs.tag }} 
         run: |
+          # Use --prefix for the tarball but not the zip file. Windows zip tools often create a directory automatically.
           git archive -o dist/${EXAMPLE_ARCHIVE}.zip ${GITHUB_REF}:examples/
-          git archive -o dist/${EXAMPLE_ARCHIVE}.tar.gz ${GITHUB_REF}:examples/
+          git archive -o dist/${EXAMPLE_ARCHIVE}.tar.gz --prefix ${EXAMPLE_ARCHIVE}/ ${GITHUB_REF}:examples/
 
       - name: Upload release assets
         if: ${{ startsWith(github.event.release.target_commitish, 'main') || startsWith(github.event.release.target_commitish, 'releases/') }}

--- a/.github/workflows/Publish_NIMS.yml
+++ b/.github/workflows/Publish_NIMS.yml
@@ -94,6 +94,25 @@ jobs:
           poetry publish --build --username __token__ --password ${{ secrets.PYPI_TOKEN }}
         working-directory: ./ni_measurementlink_generator
 
+      - name: Create archives of the examples
+        env:
+          EXAMPLE_ARCHIVE: measurementlink-python-examples-${{ steps.vars.outputs.tag }} 
+        run: |
+          git archive -o dist/${EXAMPLE_ARCHIVE}.zip ${GITHUB_REF}:examples/
+          git archive -o dist/${EXAMPLE_ARCHIVE}.tar.gz ${GITHUB_REF}:examples/
+
+      - name: Upload release assets
+        if: ${{ startsWith(github.event.release.target_commitish, 'main') || startsWith(github.event.release.target_commitish, 'releases/') }}
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "dist/measurementlink-python-examples-*"
+          allowUpdates: true
+          omitBodyDuringUpdate: true
+          omitDraftDuringUpdate: true
+          omitNameDuringUpdate: true
+          omitPrereleaseDuringUpdate: true
+          updateOnlyUnreleased: true
+
       - uses: actions/upload-artifact@v3
         with:
           name: NIMS Artifacts

--- a/.github/workflows/Publish_NIMS.yml
+++ b/.github/workflows/Publish_NIMS.yml
@@ -67,7 +67,7 @@ jobs:
           poetry run sphinx-build _docs_source docs -b html
 
       - name: Commit file changes.
-        if: ${{ startsWith(github.event.release.target_commitish, 'main') }}
+        if: ${{ startsWith(github.event.release.target_commitish, 'main') || startsWith(github.event.release.target_commitish, 'releases/') }}
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
@@ -75,7 +75,7 @@ jobs:
           git commit -m "Promote NIMS package version and update Sphinx generated files in _docs" -a
       
       - name: Push changes to the Main branch
-        if: ${{ startsWith(github.event.release.target_commitish, 'main') }}
+        if: ${{ startsWith(github.event.release.target_commitish, 'main') || startsWith(github.event.release.target_commitish, 'releases/') }}
         uses: CasperWA/push-protected@v2
         with:
           token: ${{ secrets.ADMIN_PAT }}
@@ -84,12 +84,12 @@ jobs:
 
       # To Test the Publish use : poetry publish --build --username __token__ --password ${{ secrets.TEST_PYPI_TOKEN }} -r test-pypi
       - name: Build NIMS Python package and publish to PyPI
-        if: ${{ startsWith(github.event.release.target_commitish, 'main') }}
+        if: ${{ startsWith(github.event.release.target_commitish, 'main') || startsWith(github.event.release.target_commitish, 'releases/') }}
         run: |
           poetry publish --build --username __token__ --password ${{ secrets.PYPI_TOKEN }}
         
       - name: Build NIMG Python package and publish to PyPI
-        if: ${{ startsWith(github.event.release.target_commitish, 'main') }}
+        if: ${{ startsWith(github.event.release.target_commitish, 'main') || startsWith(github.event.release.target_commitish, 'releases/') }}
         run: |
           poetry publish --build --username __token__ --password ${{ secrets.PYPI_TOKEN }}
         working-directory: ./ni_measurementlink_generator

--- a/.github/workflows/Publish_NIMS.yml
+++ b/.github/workflows/Publish_NIMS.yml
@@ -74,7 +74,7 @@ jobs:
           git add .
           git commit -m "Promote NIMS package version and update Sphinx generated files in _docs" -a
       
-      - name: Push changes to the Main branch
+      - name: Push changes to the appropriate branch
         if: ${{ startsWith(github.event.release.target_commitish, 'main') || startsWith(github.event.release.target_commitish, 'releases/') }}
         uses: CasperWA/push-protected@v2
         with:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Create `measurementlink-python-examples-1.1.0a0.zip` and `measurementlink-python-examples-1.1.0a0.tar.gz` and upload them as release assets.

The archive includes the contents of the examples directory and does not have a top-level directory:
```
PS D:\dev\measurementlink-python> git archive -o dist\measurementlink-python-examples-1.1.0a0.tar.gz main:examples/
PS D:\dev\measurementlink-python> tar tzvf .\dist\measurementlink-python-examples-1.1.0a0.tar.gz
-rw-rw-r--  0 root   root     4485 May 08 15:06 README.md
drwxrwxr-x  0 root   root        0 May 08 15:06 nidaqmx_analog_input/
-rw-rw-r--  0 root   root     1536 May 08 15:06 nidaqmx_analog_input/NIDAQmxAnalogInput.instudioproj
...
drwxrwxr-x  0 root   root        0 May 08 15:06 nidcpower_source_dc_voltage/
-rw-rw-r--  0 root   root     2371 May 08 15:06 nidcpower_source_dc_voltage/NIDCPowerSourceDCVoltage.instudioproj
...
```

Update PR/publish workflows to allow releasing out of the `releases/*` branches.

### Why should this Pull Request be merged?

Simplify distribution of examples.

### What testing has been done?

Manually tested `git archive` command.
I will create a prerelease after committing this change.