### PR TITLE
Publish workflow: Use `published` to run when publishing a draft prerelease

### DIFF
--- a/.github/workflows/Publish_NIMS.yml
+++ b/.github/workflows/Publish_NIMS.yml
@@ -2,7 +2,7 @@ name:  Update docs and Publish NIMS
 
 on:
   release:
-    types: [released]
+    types: [published]
 
 concurrency: publish_to_pypi
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update trigger for `Publish_NIMS` workflow to use `published` as described in https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release

### Why should this Pull Request be merged?

Allow publishing prerelease builds from a draft.

### What testing has been done?

None