### PR TITLE
Use resource_name instead of session_name when creating Task

### DIFF
--- a/examples/nidaqmx_analog_input/measurement.py
+++ b/examples/nidaqmx_analog_input/measurement.py
@@ -120,7 +120,7 @@ def _create_nidaqmx_task(
             initialization_behavior=nidaqmx.SessionInitializationBehavior.AUTO,
         )
 
-    return nidaqmx.Task(new_task_name=session_info.session_name, **session_kwargs)
+    return nidaqmx.Task(new_task_name=session_info.resource_name, **session_kwargs)
 
 
 def _log_measured_values(samples, max_samples_to_display=5):

--- a/examples/nidaqmx_analog_input/teststand_fixture.py
+++ b/examples/nidaqmx_analog_input/teststand_fixture.py
@@ -67,7 +67,7 @@ def create_nidaqmx_tasks(sequence_context: Any) -> None:
                 )
 
                 # Leave session open
-                task = nidaqmx.Task(new_task_name=session_info.session_name, **session_kwargs)
+                task = nidaqmx.Task(new_task_name=session_info.resource_name, **session_kwargs)
                 task.ai_channels.add_ai_voltage_chan(session_info.channel_list)
 
             session_management_client.register_sessions(reservation.session_info)
@@ -95,6 +95,6 @@ def destroy_nidaqmx_tasks() -> None:
                 )
 
                 task = nidaqmx.Task(
-                    new_task_name=session_info.session_name, grpc_options=grpc_options
+                    new_task_name=session_info.resource_name, grpc_options=grpc_options
                 )
                 task.close()


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

The nidaqmx_analog_input was using the session_information.session_name to create the nidaqmx session. It should be using the session_information.resource_name.

### Why should this Pull Request be merged?

Use the correct information to initialize a session.

### What testing has been done?

None. Prior to upcoming changes to session_information.session_name, the session_information.session_name would be identical to session_information.resource_name, so this should continue to work.