### PR TITLE
scripts: Fix imports in .pyi type stubs

### DIFF
--- a/ni_measurementlink_service/_internal/stubs/ni/measurementlink/measurement/v1/measurement_service_pb2.pyi
+++ b/ni_measurementlink_service/_internal/stubs/ni/measurementlink/measurement/v1/measurement_service_pb2.pyi
@@ -11,7 +11,7 @@ import google.protobuf.descriptor
 import google.protobuf.internal.containers
 import google.protobuf.message
 import google.protobuf.type_pb2
-import ni.measurementlink.pin_map_context_pb2
+import ni_measurementlink_service._internal.stubs.ni.measurementlink.pin_map_context_pb2 as ni_measurementlink_pin_map_context_pb2
 import sys
 
 if sys.version_info >= (3, 8):
@@ -72,7 +72,7 @@ class MeasureRequest(google.protobuf.message.Message):
         to valid input ranges.
         """
     @property
-    def pin_map_context(self) -> ni.measurementlink.pin_map_context_pb2.PinMapContext:
+    def pin_map_context(self) -> ni_measurementlink_pin_map_context_pb2.PinMapContext:
         """Optional. Specifies the pin map context for the measurement, if any. This field is optional in that callers
         may not always have a pin map context available to include in the request message. Each measurement will
         define if a valid pin map context is required in order to run or not and generate errors appropriately.
@@ -81,7 +81,7 @@ class MeasureRequest(google.protobuf.message.Message):
         self,
         *,
         configuration_parameters: google.protobuf.any_pb2.Any | None = ...,
-        pin_map_context: ni.measurementlink.pin_map_context_pb2.PinMapContext | None = ...,
+        pin_map_context: ni_measurementlink_pin_map_context_pb2.PinMapContext | None = ...,
     ) -> None: ...
     def HasField(self, field_name: typing_extensions.Literal["configuration_parameters", b"configuration_parameters", "pin_map_context", b"pin_map_context"]) -> builtins.bool: ...
     def ClearField(self, field_name: typing_extensions.Literal["configuration_parameters", b"configuration_parameters", "pin_map_context", b"pin_map_context"]) -> None: ...

--- a/ni_measurementlink_service/_internal/stubs/ni/measurementlink/measurement/v2/measurement_service_pb2.pyi
+++ b/ni_measurementlink_service/_internal/stubs/ni/measurementlink/measurement/v2/measurement_service_pb2.pyi
@@ -11,7 +11,7 @@ import google.protobuf.descriptor
 import google.protobuf.internal.containers
 import google.protobuf.message
 import google.protobuf.type_pb2
-import ni.measurementlink.pin_map_context_pb2
+import ni_measurementlink_service._internal.stubs.ni.measurementlink.pin_map_context_pb2 as ni_measurementlink_pin_map_context_pb2
 import sys
 
 if sys.version_info >= (3, 8):
@@ -72,7 +72,7 @@ class MeasureRequest(google.protobuf.message.Message):
         to valid input ranges.
         """
     @property
-    def pin_map_context(self) -> ni.measurementlink.pin_map_context_pb2.PinMapContext:
+    def pin_map_context(self) -> ni_measurementlink_pin_map_context_pb2.PinMapContext:
         """Optional. Specifies the pin map context for the measurement, if any. This field is optional in that callers
         may not always have a pin map context available to include in the request message. Each measurement will
         define if a valid pin map context is required in order to run or not and generate errors appropriately.
@@ -81,7 +81,7 @@ class MeasureRequest(google.protobuf.message.Message):
         self,
         *,
         configuration_parameters: google.protobuf.any_pb2.Any | None = ...,
-        pin_map_context: ni.measurementlink.pin_map_context_pb2.PinMapContext | None = ...,
+        pin_map_context: ni_measurementlink_pin_map_context_pb2.PinMapContext | None = ...,
     ) -> None: ...
     def HasField(self, field_name: typing_extensions.Literal["configuration_parameters", b"configuration_parameters", "pin_map_context", b"pin_map_context"]) -> builtins.bool: ...
     def ClearField(self, field_name: typing_extensions.Literal["configuration_parameters", b"configuration_parameters", "pin_map_context", b"pin_map_context"]) -> None: ...

--- a/ni_measurementlink_service/_internal/stubs/ni/measurementlink/sessionmanagement/v1/session_management_service_pb2.pyi
+++ b/ni_measurementlink_service/_internal/stubs/ni/measurementlink/sessionmanagement/v1/session_management_service_pb2.pyi
@@ -7,8 +7,8 @@ import collections.abc
 import google.protobuf.descriptor
 import google.protobuf.internal.containers
 import google.protobuf.message
-import ni.measurementlink.pin_map_context_pb2
-import session_pb2
+import ni_measurementlink_service._internal.stubs.ni.measurementlink.pin_map_context_pb2 as ni_measurementlink_pin_map_context_pb2
+from ni_measurementlink_service._internal.stubs import session_pb2
 import sys
 
 if sys.version_info >= (3, 8):
@@ -116,7 +116,7 @@ class ReserveSessionsRequest(google.protobuf.message.Message):
     INSTRUMENT_TYPE_ID_FIELD_NUMBER: builtins.int
     TIMEOUT_IN_MILLISECONDS_FIELD_NUMBER: builtins.int
     @property
-    def pin_map_context(self) -> ni.measurementlink.pin_map_context_pb2.PinMapContext:
+    def pin_map_context(self) -> ni_measurementlink_pin_map_context_pb2.PinMapContext:
         """Required. Includes the pin map ID for the pin map in the Pin Map Service, as well as the list of sites for the measurement."""
     @property
     def pin_or_relay_names(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
@@ -140,7 +140,7 @@ class ReserveSessionsRequest(google.protobuf.message.Message):
     def __init__(
         self,
         *,
-        pin_map_context: ni.measurementlink.pin_map_context_pb2.PinMapContext | None = ...,
+        pin_map_context: ni_measurementlink_pin_map_context_pb2.PinMapContext | None = ...,
         pin_or_relay_names: collections.abc.Iterable[builtins.str] | None = ...,
         instrument_type_id: builtins.str = ...,
         timeout_in_milliseconds: builtins.int = ...,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,10 @@ filterwarnings = ["always::ImportWarning", "always::ResourceWarning"]
 testpaths = ["tests"]
 
 [tool.mypy]
-exclude = ["stubs"]
+exclude = [
+  # https://github.com/grpc/grpc/issues/27682 - module 'grpc' has no attribute 'experimental'
+  "stubs/.*_grpc\\.py$"
+]
 warn_unused_configs = true
 namespace_packages = true
 check_untyped_defs = true


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

mypy-protobuf generates `.pyi` type stubs for our protobuf codegen (`*_pb2.py`, not `*_pb2_grpc.py`). However, we aren't fixing up the imports for these files, so we currently exclude them from mypy type checking.

Update `generate_grpc_stubs.py` to fix up the imports in `*_pb2.pyi`.

Update `pyproject.toml` to stop excluding `*_pb2.py` and only exclude `*_pb2_grpc.py`, with a comment explaining why.

### Why should this Pull Request be merged?

Make mypy type checking more accurate and exclude fewer files from type checking.

### What testing has been done?

Ran `poetry run mypy ni_measurementlink_service`