### PR TITLE
service: Add missing type info to MeasurementContext & use correct types

### DIFF
--- a/ni_measurementlink_service/_internal/grpc_servicer.py
+++ b/ni_measurementlink_service/_internal/grpc_servicer.py
@@ -51,7 +51,7 @@ class MeasurementServiceContext:
         """Get the pin map context for the RPC."""
         return self._pin_map_context
 
-    def add_cancel_callback(self, cancel_callback: Callable) -> None:
+    def add_cancel_callback(self, cancel_callback: Callable[[], None]) -> None:
         """Add a callback that is invoked when the RPC is canceled."""
 
         def grpc_callback():

--- a/ni_measurementlink_service/_internal/grpc_servicer.py
+++ b/ni_measurementlink_service/_internal/grpc_servicer.py
@@ -31,27 +31,27 @@ class MeasurementServiceContext:
 
     def __init__(
         self, grpc_context: grpc.ServicerContext, pin_map_context: pin_map_context_pb2.PinMapContext
-    ):
+    ) -> None:
         """Initialize the Measurement Service Context."""
         self._grpc_context: grpc.ServicerContext = grpc_context
         self._pin_map_context: pin_map_context_pb2.PinMapContext = pin_map_context
         self._is_complete: bool = False
 
-    def mark_complete(self):
+    def mark_complete(self) -> None:
         """Mark the current RPC as complete."""
         self._is_complete = True
 
     @property
-    def grpc_context(self):
+    def grpc_context(self) -> grpc.ServicerContext:
         """Get the context for the RPC."""
         return self._grpc_context
 
     @property
-    def pin_map_context(self):
+    def pin_map_context(self) -> pin_map_context_pb2.PinMapContext:
         """Get the pin map context for the RPC."""
         return self._pin_map_context
 
-    def add_cancel_callback(self, cancel_callback: Callable):
+    def add_cancel_callback(self, cancel_callback: Callable) -> None:
         """Add a callback that is invoked when the RPC is canceled."""
 
         def grpc_callback():
@@ -60,17 +60,17 @@ class MeasurementServiceContext:
 
         self._grpc_context.add_callback(grpc_callback)
 
-    def cancel(self):
+    def cancel(self) -> None:
         """Cancel the RPC."""
         if not self._is_complete:
             self._grpc_context.cancel()
 
     @property
-    def time_remaining(self):
+    def time_remaining(self) -> float:
         """Get the time remaining for the RPC."""
         return self._grpc_context.time_remaining()
 
-    def abort(self, code, details):
+    def abort(self, code: grpc.StatusCode, details: str) -> None:
         """Aborts the RPC."""
         self._grpc_context.abort(code, details)
 

--- a/ni_measurementlink_service/measurement/service.py
+++ b/ni_measurementlink_service/measurement/service.py
@@ -16,15 +16,13 @@ from ni_measurementlink_service._internal.parameter import (
     metadata as parameter_metadata,
 )
 from ni_measurementlink_service._internal.service_manager import GrpcService
-from ni_measurementlink_service._internal.stubs.ni.measurementlink import (
-    pin_map_context_pb2,
-)
 from ni_measurementlink_service.measurement.info import (
     DataType,
     MeasurementInfo,
     ServiceInfo,
     TypeSpecialization,
 )
+from ni_measurementlink_service.session_management import PinMapContext
 
 
 class MeasurementContext:
@@ -36,7 +34,7 @@ class MeasurementContext:
         return grpc_servicer.measurement_service_context.get().grpc_context
 
     @property
-    def pin_map_context(self) -> pin_map_context_pb2.PinMapContext:
+    def pin_map_context(self) -> PinMapContext:
         """Get the pin map context for the RPC."""
         return grpc_servicer.measurement_service_context.get().pin_map_context
 

--- a/ni_measurementlink_service/measurement/service.py
+++ b/ni_measurementlink_service/measurement/service.py
@@ -16,6 +16,9 @@ from ni_measurementlink_service._internal.parameter import (
     metadata as parameter_metadata,
 )
 from ni_measurementlink_service._internal.service_manager import GrpcService
+from ni_measurementlink_service._internal.stubs.ni.measurementlink import (
+    pin_map_context_pb2,
+)
 from ni_measurementlink_service.measurement.info import (
     DataType,
     MeasurementInfo,
@@ -28,29 +31,29 @@ class MeasurementContext:
     """Proxy for the Measurement Service's context-local state."""
 
     @property
-    def grpc_context(self):
+    def grpc_context(self) -> grpc.ServicerContext:
         """Get the context for the RPC."""
         return grpc_servicer.measurement_service_context.get().grpc_context
 
     @property
-    def pin_map_context(self):
+    def pin_map_context(self) -> pin_map_context_pb2.PinMapContext:
         """Get the pin map context for the RPC."""
         return grpc_servicer.measurement_service_context.get().pin_map_context
 
-    def add_cancel_callback(self, cancel_callback: Callable):
+    def add_cancel_callback(self, cancel_callback: Callable) -> None:
         """Add a callback which is invoked when the RPC is canceled."""
         grpc_servicer.measurement_service_context.get().add_cancel_callback(cancel_callback)
 
-    def cancel(self):
+    def cancel(self) -> None:
         """Cancel the RPC."""
         grpc_servicer.measurement_service_context.get().cancel()
 
     @property
-    def time_remaining(self):
+    def time_remaining(self) -> float:
         """Get the time remaining for the RPC."""
         return grpc_servicer.measurement_service_context.get().time_remaining
 
-    def abort(self, code, details):
+    def abort(self, code: grpc.StatusCode, details: str) -> None:
         """Aborts the RPC."""
         grpc_servicer.measurement_service_context.get().abort(code, details)
 

--- a/ni_measurementlink_service/measurement/service.py
+++ b/ni_measurementlink_service/measurement/service.py
@@ -40,7 +40,7 @@ class MeasurementContext:
         """Get the pin map context for the RPC."""
         return grpc_servicer.measurement_service_context.get().pin_map_context
 
-    def add_cancel_callback(self, cancel_callback: Callable) -> None:
+    def add_cancel_callback(self, cancel_callback: Callable[[], None]) -> None:
         """Add a callback which is invoked when the RPC is canceled."""
         grpc_servicer.measurement_service_context.get().add_cancel_callback(cancel_callback)
 

--- a/ni_measurementlink_service/session_management.py
+++ b/ni_measurementlink_service/session_management.py
@@ -40,10 +40,10 @@ class PinMapContext(NamedTuple):
 
     Attributes
     ----------
-        pin_map_id (str): The resource id of the pin map in the Pin Map service that should be used
-            for the call.
+        pin_map_id: The resource id of the pin map in the Pin Map service that should be used for
+            the call.
 
-        sites (list): List of site numbers being used for the call. If None, use all sites in the
+        sites: List of site numbers being used for the call. If None or empty, use all sites in the
             pin map.
 
     """


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add type annotations to the public `MeasurementContext` class as well as the internal implementation class.

Change `MeasurementContext.add_cancel_callback()` to expect a callable with 0 arguments that returns None, not just any callable.

Change `MeasurementContext.pin_map_context` to return a `ni_measurementlink_service.session_management.PinMapContext` rather than the corresponding protobuf message.

### Why should this Pull Request be merged?

It makes Intellisense and type checking more accurate.

It fixes a type mismatch between the session management API and the measurement context API.

### What testing has been done?

`poetry run pytest -v`
`poetry run mypy -p ni_measurement_service`
Tested the NI-DCPower and NI-Digital examples in InstrumentStudio, TestStand, and with mypy.