### PR TITLE
Use timing and levels sheets name when applying rather than path

### DIFF
--- a/examples/nidigital_spi/measurement.py
+++ b/examples/nidigital_spi/measurement.py
@@ -150,17 +150,15 @@ def _create_nidigital_session(
 def _resolve_relative_path(
     directory_path: pathlib.Path, file_path: Union[str, pathlib.Path]
 ) -> pathlib.Path:
-    if not isinstance(file_path, pathlib.Path):
-        file_path = pathlib.Path(file_path)
+    file_path = pathlib.Path(file_path)
     if file_path.is_absolute():
         return file_path
     else:
         return (directory_path / file_path).resolve()
 
 
-def _get_file_name_from_path(file_path: Union[str, pathlib.Path]) -> str:
-    if not isinstance(file_path, pathlib.Path):
-        file_path = pathlib.Path(file_path)
+def _get_file_name_from_path(file_path: Union[str, pathlib.PurePath]) -> str:
+    file_path = pathlib.PurePath(file_path)
     return file_path.stem
 
 

--- a/examples/nidigital_spi/measurement.py
+++ b/examples/nidigital_spi/measurement.py
@@ -104,10 +104,9 @@ def measure(
                 str(_resolve_relative_path(service_directory, pattern_file_path)),
             )
 
-        selected_sites.apply_levels_and_timing(
-            str(_resolve_relative_path(service_directory, levels_file_path)),
-            str(_resolve_relative_path(service_directory, timing_file_path)),
-        )
+        levels_file_name = _get_file_name_from_path(levels_file_path)
+        timing_file_name = _get_file_name_from_path(timing_file_path)
+        selected_sites.apply_levels_and_timing(levels_file_name, timing_file_name)
         selected_sites.burst_pattern(start_label="SPI_Pattern")
         site_pass_fail = selected_sites.get_site_pass_fail()
         passing_sites = [site for site, pass_fail in site_pass_fail.items() if pass_fail]
@@ -157,6 +156,12 @@ def _resolve_relative_path(
         return file_path
     else:
         return (directory_path / file_path).resolve()
+
+
+def _get_file_name_from_path(file_path: Union[str, pathlib.Path]) -> str:
+    if not isinstance(file_path, pathlib.Path):
+        file_path = pathlib.Path(file_path)
+    return file_path.stem
 
 
 @click.command

--- a/examples/nidigital_spi/measurement.py
+++ b/examples/nidigital_spi/measurement.py
@@ -104,8 +104,8 @@ def measure(
                 str(_resolve_relative_path(service_directory, pattern_file_path)),
             )
 
-        levels_file_name = _get_file_name_from_path(levels_file_path)
-        timing_file_name = _get_file_name_from_path(timing_file_path)
+        levels_file_name = pathlib.Path(levels_file_path).stem
+        timing_file_name = pathlib.Path(timing_file_path).stem
         selected_sites.apply_levels_and_timing(levels_file_name, timing_file_name)
         selected_sites.burst_pattern(start_label="SPI_Pattern")
         site_pass_fail = selected_sites.get_site_pass_fail()
@@ -155,11 +155,6 @@ def _resolve_relative_path(
         return file_path
     else:
         return (directory_path / file_path).resolve()
-
-
-def _get_file_name_from_path(file_path: Union[str, pathlib.PurePath]) -> str:
-    file_path = pathlib.PurePath(file_path)
-    return file_path.stem
 
 
 @click.command


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fixes Issue #259 

The [apply_levels_and_timing API ](https://nimi-python.readthedocs.io/en/master/nidigital/class.html#apply-levels-and-timing) allows the use of the file name (without extension) or the use of an absolute path. Since the file names are passed in as relative paths, while it is necessary to resolve to an absolute path if calling `load_specifications_levels_and_timing`, the name can be used when calling `apply_levels_and_timing`. This allows for when the files have been loaded from a different location at session initialization time, as is the case with the TestStand sequence.

### Why should this Pull Request be merged?

Make the nidigital_spi example work in cases where the TestStand sequence initializes the session with files that are found in a different location than next to the measurement service.

### What testing has been done?

Followed the steps to reproduce before the fix to see the error. Followed the steps to reproduce after the fix to see the sequence pass.