### PR TITLE
service: Simplify single-session measurements

### DIFF
--- a/examples/nidaqmx_analog_input/pyproject.toml
+++ b/examples/nidaqmx_analog_input/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidaqmx = { version = ">=0.8.0-dev0", extras = ["grpc"], allow-prereleases = true }
-ni-measurementlink-service = "^1.0.0"
+ni-measurementlink-service = "^1.1.0-dev1"
 click = ">=7.1.2"
 
 [tool.poetry.group.dev.dependencies]
@@ -24,7 +24,6 @@ build-backend = "poetry.core.masonry.api"
 
 [[tool.mypy.overrides]]
 module = [
-    "ni_measurementlink_service.*", # TODO: remove after 1.0.2 is released with py.typed marker
     "nidaqmx.*",
 ]
 ignore_missing_imports = true

--- a/examples/nidaqmx_analog_input/pyproject.toml
+++ b/examples/nidaqmx_analog_input/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidaqmx = { version = ">=0.8.0-dev0", extras = ["grpc"], allow-prereleases = true }
-ni-measurementlink-service = "^1.1.0-dev1"
+ni-measurementlink-service = "^1.1.0-dev2"
 click = ">=7.1.2"
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/nidaqmx_analog_input/pyproject.toml
+++ b/examples/nidaqmx_analog_input/pyproject.toml
@@ -16,7 +16,8 @@ grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies (requires poetry>=1.2).
 # TODO: Comment out once a prerelease is built.
 nidaqmx = { git = "https://github.com/ni/nidaqmx-python.git", branch = "master", extras = ["grpc"]}
-# ni-measurementlink-service = {path = "../..", develop = true}
+# Uncomment once 1.1.0-dev2 is released
+ni-measurementlink-service = {path = "../..", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.2.0"]

--- a/examples/nidaqmx_analog_input/teststand_fixture.py
+++ b/examples/nidaqmx_analog_input/teststand_fixture.py
@@ -59,7 +59,7 @@ def create_nidaqmx_tasks(sequence_context: Any) -> None:
             # This code module sets up the sessions, so error immediately if they are in use.
             timeout=0,
         ) as reservation:
-            for session_info in reservation.session_info:
+            for session_info in reservation.session_infos:
                 session_kwargs["grpc_options"] = GrpcSessionOptions(
                     grpc_channel_pool.get_grpc_device_channel(GRPC_SERVICE_INTERFACE_NAME),
                     session_name=session_info.session_name,
@@ -70,7 +70,7 @@ def create_nidaqmx_tasks(sequence_context: Any) -> None:
                 task = nidaqmx.Task(new_task_name=session_info.session_name, **session_kwargs)
                 task.ai_channels.add_ai_voltage_chan(session_info.channel_list)
 
-            session_management_client.register_sessions(reservation.session_info)
+            session_management_client.register_sessions(reservation.session_infos)
 
 
 def destroy_nidaqmx_tasks() -> None:
@@ -85,9 +85,9 @@ def destroy_nidaqmx_tasks() -> None:
             # This code module sets up the sessions, so error immediately if they are in use.
             timeout=0,
         ) as reservation:
-            session_management_client.unregister_sessions(reservation.session_info)
+            session_management_client.unregister_sessions(reservation.session_infos)
 
-            for session_info in reservation.session_info:
+            for session_info in reservation.session_infos:
                 grpc_options = GrpcSessionOptions(
                     grpc_channel_pool.get_grpc_device_channel(GRPC_SERVICE_INTERFACE_NAME),
                     session_name=session_info.session_name,

--- a/examples/nidcpower_source_dc_voltage/_nidcpower_helpers.py
+++ b/examples/nidcpower_source_dc_voltage/_nidcpower_helpers.py
@@ -43,7 +43,7 @@ def reserve_session(
     pin_map_context: nims.session_management.PinMapContext,
     pin_names: Optional[Iterable[str]] = None,
     timeout: Optional[float] = None,
-) -> nims.session_management.Reservation:
+) -> nims.session_management.MultiSessionReservation:
     """Reserve session(s).
 
     Reserve session(s) for the given pins and returns the

--- a/examples/nidcpower_source_dc_voltage/measurement.py
+++ b/examples/nidcpower_source_dc_voltage/measurement.py
@@ -78,20 +78,12 @@ def measure(
         # Long measurements may require a longer timeout.
         timeout=60,
     ) as reservation:
-        if len(reservation.session_info) != 1:
-            measurement_service.context.abort(
-                grpc.StatusCode.INVALID_ARGUMENT,
-                f"Unsupported number of sessions: {len(reservation.session_info)}",
-            )
-
-        session_info = reservation.session_info[0]
-
         with create_session(
-            session_info,
+            reservation.session_info,
             get_grpc_device_channel(measurement_service, nidcpower),
         ) as session:
-            channels = session.channels[session_info.channel_list]
-            channel_mappings = session_info.channel_mappings
+            channels = session.channels[reservation.session_info.channel_list]
+            channel_mappings = reservation.session_info.channel_mappings
 
             pending_cancellation = False
 

--- a/examples/nidcpower_source_dc_voltage/pyproject.toml
+++ b/examples/nidcpower_source_dc_voltage/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidcpower = ">=1.4.3"
-ni-measurementlink-service = "^1.1.0-dev1"
+ni-measurementlink-service = "^1.1.0-dev2"
 click = ">=7.1.2"
 grpcio = "*"
 

--- a/examples/nidcpower_source_dc_voltage/pyproject.toml
+++ b/examples/nidcpower_source_dc_voltage/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidcpower = ">=1.4.3"
-ni-measurementlink-service = "^1.0.0"
+ni-measurementlink-service = "^1.1.0-dev1"
 click = ">=7.1.2"
 grpcio = "*"
 
@@ -25,7 +25,6 @@ build-backend = "poetry.core.masonry.api"
 [[tool.mypy.overrides]]
 module = [
     "hightime.*",
-    "ni_measurementlink_service.*", # TODO: remove after 1.0.2 is released with py.typed marker
     "nidcpower.*",
 ]
 ignore_missing_imports = true

--- a/examples/nidcpower_source_dc_voltage/pyproject.toml
+++ b/examples/nidcpower_source_dc_voltage/pyproject.toml
@@ -16,7 +16,8 @@ mypy = ">=1.0"
 grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies (requires poetry>=1.2).
 # nidcpower = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/nidcpower"}
-# ni-measurementlink-service = {path = "../..", develop = true}
+# Uncomment once 1.1.0-dev2 is released
+ni-measurementlink-service = {path = "../..", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.2.0"]

--- a/examples/nidcpower_source_dc_voltage/teststand_fixture.py
+++ b/examples/nidcpower_source_dc_voltage/teststand_fixture.py
@@ -54,7 +54,7 @@ def create_nidcpower_sessions(sequence_context: Any) -> None:
             # This code module sets up the sessions, so error immediately if they are in use.
             timeout=0,
         ) as reservation:
-            for session_info in reservation.session_info:
+            for session_info in reservation.session_infos:
                 grpc_device_channel = grpc_channel_pool.get_grpc_device_channel(
                     nidcpower.GRPC_SERVICE_INTERFACE_NAME
                 )
@@ -64,7 +64,7 @@ def create_nidcpower_sessions(sequence_context: Any) -> None:
                     initialization_behavior=nidcpower.SessionInitializationBehavior.INITIALIZE_SERVER_SESSION,
                 )
 
-            session_management_client.register_sessions(reservation.session_info)
+            session_management_client.register_sessions(reservation.session_infos)
 
 
 def destroy_nidcpower_sessions() -> None:
@@ -79,9 +79,9 @@ def destroy_nidcpower_sessions() -> None:
             # This code module sets up the sessions, so error immediately if they are in use.
             timeout=0,
         ) as reservation:
-            session_management_client.unregister_sessions(reservation.session_info)
+            session_management_client.unregister_sessions(reservation.session_infos)
 
-            for session_info in reservation.session_info:
+            for session_info in reservation.session_infos:
                 grpc_device_channel = grpc_channel_pool.get_grpc_device_channel(
                     nidcpower.GRPC_SERVICE_INTERFACE_NAME
                 )

--- a/examples/nidigital_spi/measurement.py
+++ b/examples/nidigital_spi/measurement.py
@@ -88,7 +88,7 @@ def measure(
         session = stack.enter_context(_create_nidigital_session(session_info))
 
         pin_map_context = measurement_service.context.pin_map_context
-        selected_sites_string = ",".join(f"site{i}" for i in pin_map_context.sites)
+        selected_sites_string = ",".join(f"site{i}" for i in pin_map_context.sites or [])
         selected_sites = session.sites[selected_sites_string]
 
         if not session_info.session_exists:

--- a/examples/nidigital_spi/pyproject.toml
+++ b/examples/nidigital_spi/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidigital = ">=1.4.4"
-ni-measurementlink-service = "^1.0.0"
+ni-measurementlink-service = "^1.1.0-dev1"
 click = ">=7.1.2"
 grpcio = "*"
 
@@ -24,7 +24,6 @@ build-backend = "poetry.core.masonry.api"
 
 [[tool.mypy.overrides]]
 module = [
-    "ni_measurementlink_service.*", # TODO: remove after 1.0.2 is released with py.typed marker
     "nidigital.*",
 ]
 ignore_missing_imports = true

--- a/examples/nidigital_spi/pyproject.toml
+++ b/examples/nidigital_spi/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidigital = ">=1.4.4"
-ni-measurementlink-service = "^1.1.0-dev1"
+ni-measurementlink-service = "^1.1.0-dev2"
 click = ">=7.1.2"
 grpcio = "*"
 

--- a/examples/nidigital_spi/pyproject.toml
+++ b/examples/nidigital_spi/pyproject.toml
@@ -16,7 +16,8 @@ mypy = ">=1.0"
 grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies (requires poetry>=1.2).
 # nidigital = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/nidigital"}
-# ni-measurementlink-service = {path = "../..", develop = true}
+# Uncomment once 1.1.0-dev2 is released
+ni-measurementlink-service = {path = "../..", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.2.0"]

--- a/examples/nidigital_spi/teststand_fixture.py
+++ b/examples/nidigital_spi/teststand_fixture.py
@@ -54,11 +54,11 @@ def create_nidigital_sessions(sequence_context: Any) -> None:
         with _reserve_sessions(
             session_management_client, pin_map_id, INSTRUMENT_TYPE_NI_DIGITAL_PATTERN
         ) as reservation:
-            for session_info in reservation.session_info:
+            for session_info in reservation.session_infos:
                 # Leave session open.
                 _ = _create_new_nidigital_session(grpc_channel_pool, session_info)
 
-            session_management_client.register_sessions(reservation.session_info)
+            session_management_client.register_sessions(reservation.session_infos)
 
 
 def load_nidigital_pin_map(pin_map_path: str, sequence_context: Any) -> None:
@@ -82,7 +82,7 @@ def load_nidigital_pin_map(pin_map_path: str, sequence_context: Any) -> None:
         with _reserve_sessions(
             session_management_client, pin_map_id, INSTRUMENT_TYPE_NI_DIGITAL_PATTERN
         ) as reservation:
-            for session_info in reservation.session_info:
+            for session_info in reservation.session_infos:
                 with _attach_nidigital_session(grpc_channel_pool, session_info) as session:
                     session.load_pin_map(pin_map_abs_path)
 
@@ -121,7 +121,7 @@ def load_nidigital_specifications_levels_and_timing(
         with _reserve_sessions(
             session_management_client, pin_map_id, INSTRUMENT_TYPE_NI_DIGITAL_PATTERN
         ) as reservation:
-            for session_info in reservation.session_info:
+            for session_info in reservation.session_infos:
                 with _attach_nidigital_session(grpc_channel_pool, session_info) as session:
                     session.load_specifications_levels_and_timing(
                         specifications_file_abs_paths, levels_file_abs_paths, timing_file_abs_paths
@@ -152,7 +152,7 @@ def load_nidigital_patterns(
         with _reserve_sessions(
             session_management_client, pin_map_id, INSTRUMENT_TYPE_NI_DIGITAL_PATTERN
         ) as reservation:
-            for session_info in reservation.session_info:
+            for session_info in reservation.session_infos:
                 with _attach_nidigital_session(grpc_channel_pool, session_info) as session:
                     for pattern_file_abs_path in pattern_file_abs_paths:
                         session.load_pattern(pattern_file_abs_path)
@@ -169,9 +169,9 @@ def destroy_nidigital_sessions() -> None:
             # This code module sets up the sessions, so error immediately if they are in use.
             timeout=0,
         ) as reservation:
-            session_management_client.unregister_sessions(reservation.session_info)
+            session_management_client.unregister_sessions(reservation.session_infos)
 
-            for session_info in reservation.session_info:
+            for session_info in reservation.session_infos:
                 session = _attach_nidigital_session(grpc_channel_pool, session_info)
                 session.close()
 
@@ -180,7 +180,7 @@ def _reserve_sessions(
     session_management_client: nims.session_management.Client,
     pin_map_id: str,
     instrument_type_id: str,
-) -> nims.session_management.Reservation:
+) -> nims.session_management.MultiSessionReservation:
     pin_map_context = nims.session_management.PinMapContext(pin_map_id=pin_map_id, sites=None)
 
     return session_management_client.reserve_sessions(

--- a/examples/nidmm_measurement/measurement.py
+++ b/examples/nidmm_measurement/measurement.py
@@ -88,7 +88,7 @@ def measure(
 
     with contextlib.ExitStack() as stack:
         reservation = stack.enter_context(
-            session_management_client.reserve_sessions(
+            session_management_client.reserve_session(
                 context=measurement_service.context.pin_map_context,
                 pin_or_relay_names=[pin_name],
                 instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_DMM,
@@ -99,14 +99,7 @@ def measure(
             )
         )
 
-        if len(reservation.session_info) != 1:
-            measurement_service.context.abort(
-                grpc.StatusCode.INVALID_ARGUMENT,
-                f"Unsupported number of sessions: {len(reservation.session_info)}",
-            )
-
-        session_info = reservation.session_info[0]
-        session = stack.enter_context(_create_nidmm_session(session_info))
+        session = stack.enter_context(_create_nidmm_session(reservation.session_info))
         session.configure_measurement_digits(
             str_to_enum(FUNCTION_TO_ENUM, measurement_type),
             range,

--- a/examples/nidmm_measurement/pyproject.toml
+++ b/examples/nidmm_measurement/pyproject.toml
@@ -16,7 +16,8 @@ mypy = ">=1.0"
 grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies (requires poetry>=1.2).
 # nidmm = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/nidmm"}
-# ni-measurementlink-service = {path = "../..", develop = true}
+# Uncomment once 1.1.0-dev2 is released
+ni-measurementlink-service = {path = "../..", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.2.0"]

--- a/examples/nidmm_measurement/pyproject.toml
+++ b/examples/nidmm_measurement/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidmm = ">=1.4.3"
-ni-measurementlink-service = "^1.1.0-dev1"
+ni-measurementlink-service = "^1.1.0-dev2"
 click = ">=7.1.2"
 grpcio = "*"
 

--- a/examples/nidmm_measurement/pyproject.toml
+++ b/examples/nidmm_measurement/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidmm = ">=1.4.3"
-ni-measurementlink-service = "^1.0.0"
+ni-measurementlink-service = "^1.1.0-dev1"
 click = ">=7.1.2"
 grpcio = "*"
 
@@ -24,7 +24,6 @@ build-backend = "poetry.core.masonry.api"
 
 [[tool.mypy.overrides]]
 module = [
-    "ni_measurementlink_service.*", # TODO: remove after 1.0.2 is released with py.typed marker
     "nidmm.*",
 ]
 ignore_missing_imports = true

--- a/examples/nidmm_measurement/teststand_fixture.py
+++ b/examples/nidmm_measurement/teststand_fixture.py
@@ -54,7 +54,7 @@ def create_nidmm_sessions(sequence_context: Any) -> None:
             # This code module sets up the sessions, so error immediately if they are in use.
             timeout=0,
         ) as reservation:
-            for session_info in reservation.session_info:
+            for session_info in reservation.session_infos:
                 options: Dict[str, Any] = {}
                 if USE_SIMULATION:
                     options["simulate"] = True
@@ -73,7 +73,7 @@ def create_nidmm_sessions(sequence_context: Any) -> None:
                     grpc_options=grpc_options,
                 )
 
-            session_management_client.register_sessions(reservation.session_info)
+            session_management_client.register_sessions(reservation.session_infos)
 
 
 def destroy_nidmm_sessions() -> None:
@@ -88,9 +88,9 @@ def destroy_nidmm_sessions() -> None:
             # This code module sets up the sessions, so error immediately if they are in use.
             timeout=0,
         ) as reservation:
-            session_management_client.unregister_sessions(reservation.session_info)
+            session_management_client.unregister_sessions(reservation.session_infos)
 
-            for session_info in reservation.session_info:
+            for session_info in reservation.session_infos:
                 grpc_options = nidmm.GrpcSessionOptions(
                     grpc_channel_pool.get_grpc_device_channel(nidmm.GRPC_SERVICE_INTERFACE_NAME),
                     session_name=session_info.session_name,

--- a/examples/nifgen_standard_function/measurement.py
+++ b/examples/nifgen_standard_function/measurement.py
@@ -107,10 +107,10 @@ def measure(
 
         sessions = [
             stack.enter_context(_create_nifgen_session(session_info))
-            for session_info in reservation.session_info
+            for session_info in reservation.session_infos
         ]
 
-        for session, session_info in zip(sessions, reservation.session_info):
+        for session, session_info in zip(sessions, reservation.session_infos):
             # Output mode must be the same for all channels in the session.
             session.output_mode = nifgen.OutputMode.FUNC
 

--- a/examples/nifgen_standard_function/pyproject.toml
+++ b/examples/nifgen_standard_function/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nifgen = ">=1.4.3"
-ni-measurementlink-service = "^1.1.0-dev1"
+ni-measurementlink-service = "^1.1.0-dev2"
 click = ">=7.1.2"
 grpcio = "*"
 

--- a/examples/nifgen_standard_function/pyproject.toml
+++ b/examples/nifgen_standard_function/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nifgen = ">=1.4.3"
-ni-measurementlink-service = "^1.0.0"
+ni-measurementlink-service = "^1.1.0-dev1"
 click = ">=7.1.2"
 grpcio = "*"
 
@@ -25,7 +25,6 @@ build-backend = "poetry.core.masonry.api"
 [[tool.mypy.overrides]]
 module = [
     "hightime.*",
-    "ni_measurementlink_service.*", # TODO: remove after 1.0.2 is released with py.typed marker
     "nifgen.*",
 ]
 ignore_missing_imports = true

--- a/examples/nifgen_standard_function/pyproject.toml
+++ b/examples/nifgen_standard_function/pyproject.toml
@@ -16,7 +16,8 @@ mypy = ">=1.0"
 grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies (requires poetry>=1.2).
 # nifgen = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/nifgen"}
-# ni-measurementlink-service = {path = "../..", develop = true}
+# Uncomment once 1.1.0-dev2 is released
+ni-measurementlink-service = {path = "../..", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.2.0"]

--- a/examples/nifgen_standard_function/teststand_fixture.py
+++ b/examples/nifgen_standard_function/teststand_fixture.py
@@ -54,7 +54,7 @@ def create_nifgen_sessions(sequence_context: Any) -> None:
             # This code module sets up the sessions, so error immediately if they are in use.
             timeout=0,
         ) as reservation:
-            for session_info in reservation.session_info:
+            for session_info in reservation.session_infos:
                 options: Dict[str, Any] = {}
                 if USE_SIMULATION:
                     options["simulate"] = True
@@ -74,7 +74,7 @@ def create_nifgen_sessions(sequence_context: Any) -> None:
                     grpc_options=grpc_options,
                 )
 
-            session_management_client.register_sessions(reservation.session_info)
+            session_management_client.register_sessions(reservation.session_infos)
 
 
 def destroy_nifgen_sessions() -> None:
@@ -89,9 +89,9 @@ def destroy_nifgen_sessions() -> None:
             # This code module sets up the sessions, so error immediately if they are in use.
             timeout=0,
         ) as reservation:
-            session_management_client.unregister_sessions(reservation.session_info)
+            session_management_client.unregister_sessions(reservation.session_infos)
 
-            for session_info in reservation.session_info:
+            for session_info in reservation.session_infos:
                 grpc_options = nifgen.GrpcSessionOptions(
                     grpc_channel_pool.get_grpc_device_channel(nifgen.GRPC_SERVICE_INTERFACE_NAME),
                     session_name=session_info.session_name,

--- a/examples/niscope_acquire_waveform/measurement.py
+++ b/examples/niscope_acquire_waveform/measurement.py
@@ -132,21 +132,14 @@ def measure(
             )
         )
 
-        if len(reservation.session_info) != 1:
-            measurement_service.context.abort(
-                grpc.StatusCode.INVALID_ARGUMENT,
-                f"Unsupported number of sessions: {len(reservation.session_info)}",
-            )
-
-        session_info = reservation.session_info[0]
-        channel_names = session_info.channel_list
+        channel_names = reservation.session_info.channel_list
         pin_to_channel = {
-            mapping.pin_or_relay_name: mapping.channel for mapping in session_info.channel_mappings
+            mapping.pin_or_relay_name: mapping.channel for mapping in reservation.session_info.channel_mappings
         }
         if trigger_source in pin_to_channel:
             trigger_source = pin_to_channel[trigger_source]
 
-        session = stack.enter_context(_create_niscope_session(session_info))
+        session = stack.enter_context(_create_niscope_session(reservation.session_info))
         session.channels[""].channel_enabled = False
         session.channels[channel_names].configure_vertical(
             vertical_range,

--- a/examples/niscope_acquire_waveform/pyproject.toml
+++ b/examples/niscope_acquire_waveform/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 niscope = ">=1.4.3"
-ni-measurementlink-service = "^1.0.0"
+ni-measurementlink-service = "^1.1.0-dev1"
 click = ">=7.1.2"
 grpcio = "*"
 
@@ -24,7 +24,6 @@ build-backend = "poetry.core.masonry.api"
 
 [[tool.mypy.overrides]]
 module = [
-    "ni_measurementlink_service.*", # TODO: remove after 1.0.2 is released with py.typed marker
     "niscope.*",
 ]
 ignore_missing_imports = true

--- a/examples/niscope_acquire_waveform/pyproject.toml
+++ b/examples/niscope_acquire_waveform/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 niscope = ">=1.4.3"
-ni-measurementlink-service = "^1.1.0-dev1"
+ni-measurementlink-service = "^1.1.0-dev2"
 click = ">=7.1.2"
 grpcio = "*"
 

--- a/examples/niscope_acquire_waveform/pyproject.toml
+++ b/examples/niscope_acquire_waveform/pyproject.toml
@@ -16,7 +16,8 @@ mypy = ">=1.0"
 grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies (requires poetry>=1.2).
 # niscope = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/niscope"}
-# ni-measurementlink-service = {path = "../..", develop = true}
+# Uncomment once 1.1.0-dev2 is released
+ni-measurementlink-service = {path = "../..", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.2.0"]

--- a/examples/niscope_acquire_waveform/teststand_fixture.py
+++ b/examples/niscope_acquire_waveform/teststand_fixture.py
@@ -55,7 +55,7 @@ def create_niscope_sessions(sequence_context: Any) -> None:
             # This code module sets up the sessions, so error immediately if they are in use.
             timeout=0,
         ) as reservation:
-            for session_info in reservation.session_info:
+            for session_info in reservation.session_infos:
                 options: Dict[str, Any] = {}
                 if USE_SIMULATION:
                     options["simulate"] = True
@@ -74,7 +74,7 @@ def create_niscope_sessions(sequence_context: Any) -> None:
                     grpc_options=grpc_options,
                 )
 
-            session_management_client.register_sessions(reservation.session_info)
+            session_management_client.register_sessions(reservation.session_infos)
 
 
 def destroy_niscope_sessions() -> None:
@@ -89,9 +89,9 @@ def destroy_niscope_sessions() -> None:
             # This code module sets up the sessions, so error immediately if they are in use.
             timeout=0,
         ) as reservation:
-            session_management_client.unregister_sessions(reservation.session_info)
+            session_management_client.unregister_sessions(reservation.session_infos)
 
-            for session_info in reservation.session_info:
+            for session_info in reservation.session_infos:
                 grpc_options = niscope.GrpcSessionOptions(
                     grpc_channel_pool.get_grpc_device_channel(niscope.GRPC_SERVICE_INTERFACE_NAME),
                     session_name=session_info.session_name,

--- a/examples/niswitch_control_relays/measurement.py
+++ b/examples/niswitch_control_relays/measurement.py
@@ -68,10 +68,10 @@ def measure(
 
         sessions = [
             stack.enter_context(_create_niswitch_session(session_info))
-            for session_info in reservation.session_info
+            for session_info in reservation.session_infos
         ]
 
-        for session, session_info in zip(sessions, reservation.session_info):
+        for session, session_info in zip(sessions, reservation.session_infos):
             session.relay_control(
                 session_info.channel_list,
                 niswitch.RelayAction.CLOSE if close_relays else niswitch.RelayAction.OPEN,

--- a/examples/niswitch_control_relays/pyproject.toml
+++ b/examples/niswitch_control_relays/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 niswitch = ">=1.4.3"
-ni-measurementlink-service = "^1.0.0"
+ni-measurementlink-service = "^1.1.0-dev1"
 click = ">=7.1.2"
 grpcio = "*"
 
@@ -24,7 +24,6 @@ build-backend = "poetry.core.masonry.api"
 
 [[tool.mypy.overrides]]
 module = [
-    "ni_measurementlink_service.*", # TODO: remove after 1.0.2 is released with py.typed marker
     "niswitch.*",
 ]
 ignore_missing_imports = true

--- a/examples/niswitch_control_relays/pyproject.toml
+++ b/examples/niswitch_control_relays/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 niswitch = ">=1.4.3"
-ni-measurementlink-service = "^1.1.0-dev1"
+ni-measurementlink-service = "^1.1.0-dev2"
 click = ">=7.1.2"
 grpcio = "*"
 

--- a/examples/niswitch_control_relays/pyproject.toml
+++ b/examples/niswitch_control_relays/pyproject.toml
@@ -16,7 +16,8 @@ mypy = ">=1.0"
 grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies (requires poetry>=1.2).
 # niswitch = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/niswitch"}
-# ni-measurementlink-service = {path = "../..", develop = true}
+# Uncomment once 1.1.0-dev2 is released
+ni-measurementlink-service = {path = "../..", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.2.0"]

--- a/examples/niswitch_control_relays/teststand_fixture.py
+++ b/examples/niswitch_control_relays/teststand_fixture.py
@@ -55,7 +55,7 @@ def create_niswitch_sessions(sequence_context: Any) -> None:
             # This code module sets up the sessions, so error immediately if they are in use.
             timeout=0,
         ) as reservation:
-            for session_info in reservation.session_info:
+            for session_info in reservation.session_infos:
                 resource_name = session_info.resource_name
                 session_kwargs: Dict[str, Any] = {}
                 if USE_SIMULATION:
@@ -72,7 +72,7 @@ def create_niswitch_sessions(sequence_context: Any) -> None:
                 # Leave session open
                 niswitch.Session(resource_name, **session_kwargs)
 
-            session_management_client.register_sessions(reservation.session_info)
+            session_management_client.register_sessions(reservation.session_infos)
 
 
 def destroy_niswitch_sessions() -> None:
@@ -87,9 +87,9 @@ def destroy_niswitch_sessions() -> None:
             # This code module sets up the sessions, so error immediately if they are in use.
             timeout=0,
         ) as reservation:
-            session_management_client.unregister_sessions(reservation.session_info)
+            session_management_client.unregister_sessions(reservation.session_infos)
 
-            for session_info in reservation.session_info:
+            for session_info in reservation.session_infos:
                 grpc_options = niswitch.GrpcSessionOptions(
                     grpc_channel_pool.get_grpc_device_channel(niswitch.GRPC_SERVICE_INTERFACE_NAME),
                     session_name=session_info.session_name,

--- a/examples/nivisa_dmm_measurement/pyproject.toml
+++ b/examples/nivisa_dmm_measurement/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-ni-measurementlink-service = "^1.1.0-dev1"
+ni-measurementlink-service = "^1.1.0-dev2"
 PyVISA = "^1.13.0"
 PyVISA-sim = "^0.5.1"
 click = ">=7.1.2"

--- a/examples/nivisa_dmm_measurement/pyproject.toml
+++ b/examples/nivisa_dmm_measurement/pyproject.toml
@@ -16,7 +16,8 @@ grpcio = "*"
 mypy = ">=1.0"
 grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies (requires poetry>=1.2).
-# ni-measurementlink-service = {path = "../..", develop = true}
+# Uncomment once 1.1.0-dev2 is released
+ni-measurementlink-service = {path = "../..", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.2.0"]

--- a/examples/nivisa_dmm_measurement/pyproject.toml
+++ b/examples/nivisa_dmm_measurement/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-ni-measurementlink-service = "^1.0.0"
+ni-measurementlink-service = "^1.1.0-dev1"
 PyVISA = "^1.13.0"
 PyVISA-sim = "^0.5.1"
 click = ">=7.1.2"
@@ -21,9 +21,3 @@ grpc-stubs = "^1.53"
 [build-system]
 requires = ["poetry-core>=1.2.0"]
 build-backend = "poetry.core.masonry.api"
-
-[[tool.mypy.overrides]]
-module = [
-    "ni_measurementlink_service.*", # TODO: remove after 1.0.2 is released with py.typed marker
-]
-ignore_missing_imports = true

--- a/examples/nivisa_dmm_measurement/teststand_fixture.py
+++ b/examples/nivisa_dmm_measurement/teststand_fixture.py
@@ -64,7 +64,7 @@ def create_nivisa_dmm_sessions(sequence_context: Any) -> None:
         ) as reservation:
             resource_manager = create_visa_resource_manager(USE_SIMULATION)
 
-            for session_info in reservation.session_info:
+            for session_info in reservation.session_infos:
                 with create_visa_session(resource_manager, session_info.resource_name) as session:
                     # Work around https://github.com/pyvisa/pyvisa/issues/739 - Type annotation
                     # for Resource context manager implicitly upcasts derived class to base class
@@ -72,7 +72,7 @@ def create_nivisa_dmm_sessions(sequence_context: Any) -> None:
                     log_instrument_id(session)
                     reset_instrument(session)
 
-            session_management_client.register_sessions(reservation.session_info)
+            session_management_client.register_sessions(reservation.session_infos)
 
 
 def destroy_nivisa_dmm_sessions() -> None:
@@ -87,4 +87,4 @@ def destroy_nivisa_dmm_sessions() -> None:
             # This code module sets up the sessions, so error immediately if they are in use.
             timeout=0,
         ) as reservation:
-            session_management_client.unregister_sessions(reservation.session_info)
+            session_management_client.unregister_sessions(reservation.session_infos)

--- a/examples/sample_measurement/pyproject.toml
+++ b/examples/sample_measurement/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-ni-measurementlink-service = "^1.0.0"
+ni-measurementlink-service = "^1.1.0-dev1"
 click = ">=7.1.2"
 
 [tool.poetry.group.dev.dependencies]
@@ -18,9 +18,3 @@ grpc-stubs = "^1.53"
 [build-system]
 requires = ["poetry-core>=1.2.0"]
 build-backend = "poetry.core.masonry.api"
-
-[[tool.mypy.overrides]]
-module = [
-    "ni_measurementlink_service.*", # TODO: remove after 1.0.2 is released with py.typed marker
-]
-ignore_missing_imports = true

--- a/poetry.lock
+++ b/poetry.lock
@@ -106,6 +106,17 @@ tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.1
 toml = ["tomli"]
 
 [[package]]
+name = "deprecation"
+version = "2.1.0"
+description = "A library to handle automated deprecations"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+packaging = "*"
+
+[[package]]
 name = "docutils"
 version = "0.18.1"
 description = "Docutils -- Python Documentation Utilities"
@@ -386,7 +397,7 @@ toml = ">=0.10.1"
 name = "packaging"
 version = "23.1"
 description = "Core utilities for Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -857,7 +868,7 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "db19fe68418536fcf9711f76779e9236e753259d859d538b11245d508e5566ca"
+content-hash = "adac96e286138dea834043a8ca62d88f9222bb658e27cce1d0d024c8bdf3f6ca"
 
 [metadata.files]
 alabaster = [
@@ -1049,6 +1060,10 @@ coverage = [
     {file = "coverage-7.2.7-cp39-cp39-win_amd64.whl", hash = "sha256:eb393e5ebc85245347950143969b241d08b52b88a3dc39479822e073a1a8eb27"},
     {file = "coverage-7.2.7-pp37.pp38.pp39-none-any.whl", hash = "sha256:b7b4c971f05e6ae490fef852c218b0e79d4e52f79ef0c8475566584a8fb3e01d"},
     {file = "coverage-7.2.7.tar.gz", hash = "sha256:924d94291ca674905fe9481f12294eb11f2d3d3fd1adb20314ba89e94f44ed59"},
+]
+deprecation = [
+    {file = "deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a"},
+    {file = "deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff"},
 ]
 docutils = [
     {file = "docutils-0.18.1-py2.py3-none-any.whl", hash = "sha256:23010f129180089fbcd3bc08cfefccb3b890b0050e1ca00c867036e9d161b98c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ python = "^3.8"
 grpcio = "^1.49.1"
 protobuf = "^4.21"
 pywin32 = {version = ">=303", platform = "win32"}
+deprecation = ">=2.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7.2.0"
@@ -89,5 +90,9 @@ warn_redundant_casts = true
 warn_unused_ignores = true
 
 [[tool.mypy.overrides]]
-module = ["grpc.framework.foundation.*"]
+module = [
+  # https://github.com/briancurtin/deprecation/issues/56 - Add type information (PEP 561)
+  "deprecation.*",
+  "grpc.framework.foundation.*"
+]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ exclude = '''
 
 [tool.poetry]
 name = "ni_measurementlink_service"
-version = "1.1.0-dev1"
+version = "1.1.0-dev2"
 description = "MeasurementLink Support for Python"
 authors = ["NI <opensource@ni.com>"]
 readme = "README.md" # apply the repo readme to the package as well

--- a/tests/unit/test_session_management.py
+++ b/tests/unit/test_session_management.py
@@ -14,10 +14,80 @@ from ni_measurementlink_service._internal.stubs.ni.measurementlink.sessionmanage
 )
 from ni_measurementlink_service.session_management import (
     Client,
+    MultiSessionReservation,
     PinMapContext,
-    Reservation,
     SessionInformation,
+    SingleSessionReservation,
 )
+
+
+def test___reserve_session___sends_request(client: Client, stub: Mock) -> None:
+    stub.ReserveSessions.return_value = session_management_service_pb2.ReserveSessionsResponse(
+        sessions=_create_grpc_session_infos(1)
+    )
+
+    _ = client.reserve_session(
+        PinMapContext("MyPinMap", [0, 1]),
+        pin_or_relay_names=["Pin1", "Pin2"],
+        instrument_type_id="MyInstrumentType",
+        timeout=123.456,
+    )
+
+    stub.ReserveSessions.assert_called_once()
+    (request,) = stub.ReserveSessions.call_args.args
+    assert request.pin_map_context.pin_map_id == "MyPinMap"
+    assert request.pin_map_context.sites == [0, 1]
+    assert request.pin_or_relay_names == ["Pin1", "Pin2"]
+    assert request.instrument_type_id == "MyInstrumentType"
+    assert request.timeout_in_milliseconds == 123456
+
+
+def test___single_session___reserve_session___returns_single_session_info(
+    client: Client, stub: Mock
+) -> None:
+    stub.ReserveSessions.return_value = session_management_service_pb2.ReserveSessionsResponse(
+        sessions=_create_grpc_session_infos(1)
+    )
+
+    reservation = client.reserve_session(
+        PinMapContext("MyPinMap", [0, 1]),
+        pin_or_relay_names=["Pin1", "Pin2"],
+        instrument_type_id="MyInstrumentType",
+        timeout=123.456,
+    )
+
+    assert isinstance(reservation, SingleSessionReservation)
+    assert reservation.session_info.session_name == "MySession0"
+
+
+def test___no_sessions___reserve_session___raises_no_sessions_value_error(
+    client: Client, stub: Mock
+) -> None:
+    stub.ReserveSessions.return_value = session_management_service_pb2.ReserveSessionsResponse()
+
+    with pytest.raises(ValueError, match="No sessions reserved."):
+        _ = client.reserve_session(
+            PinMapContext("MyPinMap", [0, 1]),
+            pin_or_relay_names=["Pin1", "Pin2"],
+            instrument_type_id="MyInstrumentType",
+            timeout=123.456,
+        )
+
+
+def test___too_many_sessions___reserve_session___raises_too_many_sessions_value_error(
+    client: Client, stub: Mock
+) -> None:
+    stub.ReserveSessions.return_value = session_management_service_pb2.ReserveSessionsResponse(
+        sessions=_create_grpc_session_infos(2)
+    )
+
+    with pytest.raises(ValueError, match="Too many sessions reserved."):
+        _ = client.reserve_session(
+            PinMapContext("MyPinMap", [0, 1]),
+            pin_or_relay_names=["Pin1", "Pin2"],
+            instrument_type_id="MyInstrumentType",
+            timeout=123.456,
+        )
 
 
 def test___reserve_sessions___sends_request(client: Client, stub: Mock) -> None:
@@ -40,7 +110,7 @@ def test___reserve_sessions___sends_request(client: Client, stub: Mock) -> None:
 
 
 @pytest.mark.parametrize("session_count", [0, 1, 2])
-def test___varying_session_count___reserve_sessions___returns_session_infos(
+def test___varying_session_count___reserve_sessions___returns_multiple_session_infos(
     client: Client, stub: Mock, session_count: int
 ) -> None:
     stub.ReserveSessions.return_value = session_management_service_pb2.ReserveSessionsResponse(
@@ -54,8 +124,9 @@ def test___varying_session_count___reserve_sessions___returns_session_infos(
         timeout=123.456,
     )
 
-    assert len(reservation.session_info) == session_count
-    assert [s.session_name for s in reservation.session_info] == [
+    assert isinstance(reservation, MultiSessionReservation)
+    assert len(reservation.session_infos) == session_count
+    assert [s.session_name for s in reservation.session_infos] == [
         f"MySession{i}" for i in range(session_count)
     ]
 
@@ -64,7 +135,7 @@ def test___varying_session_count___reserve_sessions___returns_session_infos(
 def test___varying_session_count___unreserve___sends_request(
     client: Client, stub: Mock, session_count: int
 ) -> None:
-    reservation = Reservation(client, _create_grpc_session_infos(session_count))
+    reservation = MultiSessionReservation(client, _create_grpc_session_infos(session_count))
     stub.UnreserveSessions.return_value = session_management_service_pb2.UnreserveSessionsResponse()
 
     reservation.unreserve()
@@ -81,7 +152,7 @@ def test___varying_session_count___unreserve___sends_request(
 def test___varying_session_count___exit_reservation___sends_request(
     client: Client, stub: Mock, session_count: int
 ) -> None:
-    reservation = Reservation(client, _create_grpc_session_infos(session_count))
+    reservation = MultiSessionReservation(client, _create_grpc_session_infos(session_count))
     stub.UnreserveSessions.return_value = session_management_service_pb2.UnreserveSessionsResponse()
 
     with reservation:
@@ -158,10 +229,32 @@ def test___varying_session_count___reserve_all_registered_sessions___returns_ses
         instrument_type_id="MyInstrumentType", timeout=123.456
     )
 
-    assert len(reservation.session_info) == session_count
-    assert [s.session_name for s in reservation.session_info] == [
+    assert len(reservation.session_infos) == session_count
+    assert [s.session_name for s in reservation.session_infos] == [
         f"MySession{i}" for i in range(session_count)
     ]
+
+
+def test___multi_session_reservation___session_info___reports_deprecated_warning_and_calls_session_infos(
+    client: Client,
+) -> None:
+    reservation = MultiSessionReservation(client, _create_grpc_session_infos(3))
+
+    with pytest.deprecated_call():
+        session_info = reservation.session_info
+
+    assert session_info is reservation.session_infos
+
+
+def test___use_reservation_type___reports_deprecated_warning_and_aliases_to_multi_session_reservation(
+    client: Client,
+) -> None:
+    with pytest.deprecated_call():
+        from ni_measurementlink_service.session_management import Reservation
+
+        reservation = Reservation(client, _create_grpc_session_infos(3))
+
+    assert isinstance(reservation, MultiSessionReservation)
 
 
 def _create_session_infos(session_count: int) -> List[SessionInformation]:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

`session_management.py`:
- Add `Client.reserve_session` (singular), which returns a `SingleSessionReservation`, which has a `session_info` property that returns a single `SessionInformation` object.
- Change `Client.reserve_sessions` (plural) to return a `MultiSessionReservation`, which has a `session_infos` property that returns a list of `SessionInformation` objects.
- Compatibility:
   - `Reservation` is an alias for `MultiSessionReservation` which reports a `DeprecationWarning`
   - `MultiSessionReservation.session_info` is an alias for `MultiSessionReservation.session_infos` which reports a `DeprecationWarning`

Update tests and examples to use updated APIs.

Add single-session and deprecation test cases.

### Why should this Pull Request be merged?

Simplify single-session measurements by removing the need to check the number of session infos and index the session info list.

### What testing has been done?

Ran updated unit tests.
Manually tested a couple examples in InstrumentStudio and TestStand with an earlier version of this branch.
TODO: re-test all examples
Ran mypy on all examples.