### PR TITLE
Update Example Services' TestStand Sequences for Enum Support

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -12,6 +12,8 @@ For best results, use the example measurements corresponding to the version of M
 that you are using. Newer examples may demonstrate features that are not available in older
 versions of MeasurementLink.
 
+The TestStand sequence files associated with each example are saved in TestStand 2021 SP1.
+
 ### Available Example Measurements
 
 - `sample_measurement`: Performs a loopback measurement with various data types. Provides a Measurement UI and a LabVIEW UI.

--- a/examples/nidmm_measurement/NIDmmMeasurement.seq
+++ b/examples/nidmm_measurement/NIDmmMeasurement.seq
@@ -4608,6 +4608,9 @@
 																				<TypeSpecialization classname='Str'>
 																					<value>Pin</value>
 																				</TypeSpecialization>
+																				<EnumDefinition classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</EnumDefinition>
 																			</subprops>
 																		</Obj>
 																	</value>
@@ -4618,26 +4621,110 @@
 																					<value>measurement_type</value>
 																				</Name>
 																				<ArgumentValue classname='ExprValue'>
-																					<value>"DC Volts"</value>
+																					<value>1i64</value>
 																				</ArgumentValue>
 																				<Direction classname='Str'>
 																					<value>In</value>
 																				</Direction>
 																				<Log classname='Bool'>
-																					<value>false</value>
+																					<value>true</value>
 																				</Log>
 																				<Dimension classname='Num'>
 																					<value representation='UInt64'>0</value>
 																				</Dimension>
 																				<Type classname='Str'>
-																					<value>TypeString</value>
+																					<value>TypeEnum</value>
 																				</Type>
 																				<ID classname='Num'>
 																					<value representation='Int64'>2</value>
 																				</ID>
 																				<TypeSpecialization classname='Str'>
-																					<value>None</value>
+																					<value>Enum</value>
 																				</TypeSpecialization>
+																				<EnumDefinition classname='Objs'>
+																					<value lbound='[0]' ubound='[15]'>
+																						<value>
+																							<Num name='NONE'>
+																								<value representation='Int64'>0</value>
+																							</Num>
+																						</value>
+																						<value>
+																							<Num name='DC_VOLTS'>
+																								<value representation='Int64'>1</value>
+																							</Num>
+																						</value>
+																						<value>
+																							<Num name='AC_VOLTS'>
+																								<value representation='Int64'>2</value>
+																							</Num>
+																						</value>
+																						<value>
+																							<Num name='DC_CURRENT'>
+																								<value representation='Int64'>3</value>
+																							</Num>
+																						</value>
+																						<value>
+																							<Num name='AC_CURRENT'>
+																								<value representation='Int64'>4</value>
+																							</Num>
+																						</value>
+																						<value>
+																							<Num name='TWO_WIRE_RES'>
+																								<value representation='Int64'>5</value>
+																							</Num>
+																						</value>
+																						<value>
+																							<Num name='FOUR_WIRE_RES'>
+																								<value representation='Int64'>101</value>
+																							</Num>
+																						</value>
+																						<value>
+																							<Num name='FREQ'>
+																								<value representation='Int64'>104</value>
+																							</Num>
+																						</value>
+																						<value>
+																							<Num name='PERIOD'>
+																								<value representation='Int64'>105</value>
+																							</Num>
+																						</value>
+																						<value>
+																							<Num name='TEMPERATURE'>
+																								<value representation='Int64'>108</value>
+																							</Num>
+																						</value>
+																						<value>
+																							<Num name='AC_VOLTS_DC_COUPLED'>
+																								<value representation='Int64'>1001</value>
+																							</Num>
+																						</value>
+																						<value>
+																							<Num name='DIODE'>
+																								<value representation='Int64'>1002</value>
+																							</Num>
+																						</value>
+																						<value>
+																							<Num name='WAVEFORM_VOLTAGE'>
+																								<value representation='Int64'>1003</value>
+																							</Num>
+																						</value>
+																						<value>
+																							<Num name='WAVEFORM_CURRENT'>
+																								<value representation='Int64'>1004</value>
+																							</Num>
+																						</value>
+																						<value>
+																							<Num name='CAPACITANCE'>
+																								<value representation='Int64'>1005</value>
+																							</Num>
+																						</value>
+																						<value>
+																							<Num name='INDUCTANCE'>
+																								<value representation='Int64'>1006</value>
+																							</Num>
+																						</value>
+																					</value>
+																				</EnumDefinition>
 																			</subprops>
 																		</Obj>
 																	</value>
@@ -4668,6 +4755,9 @@
 																				<TypeSpecialization classname='Str'>
 																					<value>None</value>
 																				</TypeSpecialization>
+																				<EnumDefinition classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</EnumDefinition>
 																			</subprops>
 																		</Obj>
 																	</value>
@@ -4698,6 +4788,9 @@
 																				<TypeSpecialization classname='Str'>
 																					<value>None</value>
 																				</TypeSpecialization>
+																				<EnumDefinition classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</EnumDefinition>
 																			</subprops>
 																		</Obj>
 																	</value>
@@ -4728,6 +4821,9 @@
 																				<TypeSpecialization classname='Str'>
 																					<value>None</value>
 																				</TypeSpecialization>
+																				<EnumDefinition classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</EnumDefinition>
 																			</subprops>
 																		</Obj>
 																	</value>
@@ -4758,6 +4854,9 @@
 																				<TypeSpecialization classname='Str'>
 																					<value>None</value>
 																				</TypeSpecialization>
+																				<EnumDefinition classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</EnumDefinition>
 																			</subprops>
 																		</Obj>
 																	</value>
@@ -4788,6 +4887,9 @@
 																				<TypeSpecialization classname='Str'>
 																					<value>None</value>
 																				</TypeSpecialization>
+																				<EnumDefinition classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</EnumDefinition>
 																			</subprops>
 																		</Obj>
 																	</value>

--- a/examples/nidmm_measurement/measurement.py
+++ b/examples/nidmm_measurement/measurement.py
@@ -3,12 +3,12 @@
 import logging
 import math
 import pathlib
+from enum import Enum
 from typing import Tuple
 
 import click
 import grpc
 import nidmm
-from enum import Enum
 from _helpers import (
     ServiceOptions,
     configure_logging,

--- a/examples/nidmm_measurement/measurement.py
+++ b/examples/nidmm_measurement/measurement.py
@@ -8,6 +8,7 @@ from typing import Tuple
 import click
 import grpc
 import nidmm
+from enum import Enum
 from _helpers import (
     ServiceOptions,
     configure_logging,
@@ -31,6 +32,27 @@ measurement_service = nims.MeasurementService(
 service_options = ServiceOptions()
 
 
+class Function(Enum):
+    """Wrapper enum that contains a zero value."""
+
+    NONE = 0
+    DC_VOLTS = nidmm.Function.DC_VOLTS.value
+    AC_VOLTS = nidmm.Function.AC_VOLTS.value
+    DC_CURRENT = nidmm.Function.DC_CURRENT.value
+    AC_CURRENT = nidmm.Function.AC_CURRENT.value
+    TWO_WIRE_RES = nidmm.Function.TWO_WIRE_RES.value
+    FOUR_WIRE_RES = nidmm.Function.FOUR_WIRE_RES.value
+    FREQ = nidmm.Function.FREQ.value
+    PERIOD = nidmm.Function.PERIOD.value
+    TEMPERATURE = nidmm.Function.TEMPERATURE.value
+    AC_VOLTS_DC_COUPLED = nidmm.Function.AC_VOLTS_DC_COUPLED.value
+    DIODE = nidmm.Function.DIODE.value
+    WAVEFORM_VOLTAGE = nidmm.Function.WAVEFORM_VOLTAGE.value
+    WAVEFORM_CURRENT = nidmm.Function.WAVEFORM_CURRENT.value
+    CAPACITANCE = nidmm.Function.CAPACITANCE.value
+    INDUCTANCE = nidmm.Function.INDUCTANCE.value
+
+
 @measurement_service.register_measurement
 @measurement_service.configuration(
     "pin_name",
@@ -39,7 +61,7 @@ service_options = ServiceOptions()
     instrument_type=nims.session_management.INSTRUMENT_TYPE_NI_DMM,
 )
 @measurement_service.configuration(
-    "measurement_type", nims.DataType.Enum, nidmm.Function.DC_VOLTS, enum_type=nidmm.Function
+    "measurement_type", nims.DataType.Enum, Function.DC_VOLTS, enum_type=Function
 )
 @measurement_service.configuration("range", nims.DataType.Double, 10.0)
 @measurement_service.configuration("resolution_digits", nims.DataType.Double, 5.5)
@@ -48,7 +70,7 @@ service_options = ServiceOptions()
 @measurement_service.output("absolute_resolution", nims.DataType.Double)
 def measure(
     pin_name: str,
-    measurement_type: nidmm.Function,
+    measurement_type: Function,
     range: float,
     resolution_digits: float,
 ) -> Tuple:
@@ -82,7 +104,7 @@ def measure(
         grpc_device_channel = get_grpc_device_channel(measurement_service, nidmm, service_options)
         with create_session(session_info, grpc_device_channel) as session:
             session.configure_measurement_digits(
-                measurement_type,
+                measurement_type if measurement_type != Function.NONE else Function.DC_VOLTS,
                 range,
                 resolution_digits,
             )

--- a/examples/nifgen_standard_function/NIFgenStandardFunction.seq
+++ b/examples/nifgen_standard_function/NIFgenStandardFunction.seq
@@ -4608,6 +4608,9 @@
 																				<TypeSpecialization classname='Str'>
 																					<value>Pin</value>
 																				</TypeSpecialization>
+																				<EnumDefinition classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</EnumDefinition>
 																			</subprops>
 																		</Obj>
 																	</value>
@@ -4618,7 +4621,7 @@
 																					<value>waveform_type</value>
 																				</Name>
 																				<ArgumentValue classname='ExprValue'>
-																					<value>"Sine"</value>
+																					<value>1i64</value>
 																				</ArgumentValue>
 																				<Direction classname='Str'>
 																					<value>In</value>
@@ -4630,14 +4633,63 @@
 																					<value representation='UInt64'>0</value>
 																				</Dimension>
 																				<Type classname='Str'>
-																					<value>TypeString</value>
+																					<value>TypeEnum</value>
 																				</Type>
 																				<ID classname='Num'>
 																					<value representation='Int64'>2</value>
 																				</ID>
 																				<TypeSpecialization classname='Str'>
-																					<value>None</value>
+																					<value>Enum</value>
 																				</TypeSpecialization>
+																				<EnumDefinition classname='Objs'>
+																					<value lbound='[0]' ubound='[8]'>
+																						<value>
+																							<Num name='NONE'>
+																								<value representation='Int64'>0</value>
+																							</Num>
+																						</value>
+																						<value>
+																							<Num name='SINE'>
+																								<value representation='Int64'>1</value>
+																							</Num>
+																						</value>
+																						<value>
+																							<Num name='SQUARE'>
+																								<value representation='Int64'>2</value>
+																							</Num>
+																						</value>
+																						<value>
+																							<Num name='TRIANGLE'>
+																								<value representation='Int64'>3</value>
+																							</Num>
+																						</value>
+																						<value>
+																							<Num name='RAMP_UP'>
+																								<value representation='Int64'>4</value>
+																							</Num>
+																						</value>
+																						<value>
+																							<Num name='RAMP_DOWN'>
+																								<value representation='Int64'>5</value>
+																							</Num>
+																						</value>
+																						<value>
+																							<Num name='DC'>
+																								<value representation='Int64'>6</value>
+																							</Num>
+																						</value>
+																						<value>
+																							<Num name='NOISE'>
+																								<value representation='Int64'>101</value>
+																							</Num>
+																						</value>
+																						<value>
+																							<Num name='USER'>
+																								<value representation='Int64'>102</value>
+																							</Num>
+																						</value>
+																					</value>
+																				</EnumDefinition>
 																			</subprops>
 																		</Obj>
 																	</value>
@@ -4668,6 +4720,9 @@
 																				<TypeSpecialization classname='Str'>
 																					<value>None</value>
 																				</TypeSpecialization>
+																				<EnumDefinition classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</EnumDefinition>
 																			</subprops>
 																		</Obj>
 																	</value>
@@ -4698,6 +4753,9 @@
 																				<TypeSpecialization classname='Str'>
 																					<value>None</value>
 																				</TypeSpecialization>
+																				<EnumDefinition classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</EnumDefinition>
 																			</subprops>
 																		</Obj>
 																	</value>
@@ -4728,6 +4786,9 @@
 																				<TypeSpecialization classname='Str'>
 																					<value>None</value>
 																				</TypeSpecialization>
+																				<EnumDefinition classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</EnumDefinition>
 																			</subprops>
 																		</Obj>
 																	</value>

--- a/examples/nifgen_standard_function/measurement.py
+++ b/examples/nifgen_standard_function/measurement.py
@@ -10,6 +10,7 @@ import click
 import grpc
 import hightime
 import nifgen
+from enum import Enum
 from _helpers import (
     ServiceOptions,
     configure_logging,
@@ -36,6 +37,20 @@ measurement_service = nims.MeasurementService(
 service_options = ServiceOptions()
 
 
+class Waveform(Enum):
+    """Wrapper enum that contains a zero value."""
+
+    NONE = 0
+    SINE = nifgen.Waveform.SINE.value
+    SQUARE = nifgen.Waveform.SQUARE.value
+    TRIANGLE = nifgen.Waveform.TRIANGLE.value
+    RAMP_UP = nifgen.Waveform.RAMP_UP.value
+    RAMP_DOWN = nifgen.Waveform.RAMP_DOWN.value
+    DC = nifgen.Waveform.DC.value
+    NOISE = nifgen.Waveform.NOISE.value
+    USER = nifgen.Waveform.USER.value
+
+
 @measurement_service.register_measurement
 # TODO: Rename pin_name to pin_names and make it PinArray1D
 @measurement_service.configuration(
@@ -45,14 +60,14 @@ service_options = ServiceOptions()
     instrument_type=nims.session_management.INSTRUMENT_TYPE_NI_FGEN,
 )
 @measurement_service.configuration(
-    "waveform_type", nims.DataType.Enum, nifgen.Waveform.SINE, enum_type=nifgen.Waveform
+    "waveform_type", nims.DataType.Enum, Waveform.SINE, enum_type=Waveform
 )
 @measurement_service.configuration("frequency", nims.DataType.Double, 1.0e6)
 @measurement_service.configuration("amplitude", nims.DataType.Double, 2.0)
 @measurement_service.configuration("duration", nims.DataType.Double, 10.0)
 def measure(
     pin_name: str,
-    waveform_type: nifgen.Waveform,
+    waveform_type: Waveform,
     frequency: float,
     amplitude: float,
     duration: float,
@@ -61,7 +76,7 @@ def measure(
     logging.info(
         "Starting generation: pin_name=%s waveform_type=%s frequency=%g amplitude=%g",
         pin_name,
-        waveform_type,
+        waveform_type if waveform_type != Waveform.NONE else Waveform.SINE,
         frequency,
         amplitude,
     )

--- a/examples/nifgen_standard_function/measurement.py
+++ b/examples/nifgen_standard_function/measurement.py
@@ -4,13 +4,13 @@ import contextlib
 import logging
 import pathlib
 import time
+from enum import Enum
 from typing import Tuple
 
 import click
 import grpc
 import hightime
 import nifgen
-from enum import Enum
 from _helpers import (
     ServiceOptions,
     configure_logging,

--- a/examples/niscope_acquire_waveform/NIScopeAcquireWaveform.seq
+++ b/examples/niscope_acquire_waveform/NIScopeAcquireWaveform.seq
@@ -4608,6 +4608,9 @@
 																				<TypeSpecialization classname='Str'>
 																					<value>Pin</value>
 																				</TypeSpecialization>
+																				<EnumDefinition classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</EnumDefinition>
 																			</subprops>
 																		</Obj>
 																	</value>
@@ -4638,6 +4641,9 @@
 																				<TypeSpecialization classname='Str'>
 																					<value>None</value>
 																				</TypeSpecialization>
+																				<EnumDefinition classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</EnumDefinition>
 																			</subprops>
 																		</Obj>
 																	</value>
@@ -4648,26 +4654,45 @@
 																					<value>vertical_coupling</value>
 																				</Name>
 																				<ArgumentValue classname='ExprValue'>
-																					<value>"DC"</value>
+																					<value>1i64</value>
 																				</ArgumentValue>
 																				<Direction classname='Str'>
 																					<value>In</value>
 																				</Direction>
 																				<Log classname='Bool'>
-																					<value>false</value>
+																					<value>true</value>
 																				</Log>
 																				<Dimension classname='Num'>
 																					<value representation='UInt64'>0</value>
 																				</Dimension>
 																				<Type classname='Str'>
-																					<value>TypeString</value>
+																					<value>TypeEnum</value>
 																				</Type>
 																				<ID classname='Num'>
 																					<value representation='Int64'>3</value>
 																				</ID>
 																				<TypeSpecialization classname='Str'>
-																					<value>None</value>
+																					<value>Enum</value>
 																				</TypeSpecialization>
+																				<EnumDefinition classname='Objs'>
+																					<value lbound='[0]' ubound='[2]'>
+																						<value>
+																							<Num name='AC'>
+																								<value representation='Int64'>0</value>
+																							</Num>
+																						</value>
+																						<value>
+																							<Num name='DC'>
+																								<value representation='Int64'>1</value>
+																							</Num>
+																						</value>
+																						<value>
+																							<Num name='GND'>
+																								<value representation='Int64'>2</value>
+																							</Num>
+																						</value>
+																					</value>
+																				</EnumDefinition>
 																			</subprops>
 																		</Obj>
 																	</value>
@@ -4698,6 +4723,9 @@
 																				<TypeSpecialization classname='Str'>
 																					<value>None</value>
 																				</TypeSpecialization>
+																				<EnumDefinition classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</EnumDefinition>
 																			</subprops>
 																		</Obj>
 																	</value>
@@ -4728,6 +4756,9 @@
 																				<TypeSpecialization classname='Str'>
 																					<value>None</value>
 																				</TypeSpecialization>
+																				<EnumDefinition classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</EnumDefinition>
 																			</subprops>
 																		</Obj>
 																	</value>
@@ -4758,6 +4789,9 @@
 																				<TypeSpecialization classname='Str'>
 																					<value>None</value>
 																				</TypeSpecialization>
+																				<EnumDefinition classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</EnumDefinition>
 																			</subprops>
 																		</Obj>
 																	</value>
@@ -4788,6 +4822,9 @@
 																				<TypeSpecialization classname='Str'>
 																					<value>Pin</value>
 																				</TypeSpecialization>
+																				<EnumDefinition classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</EnumDefinition>
 																			</subprops>
 																		</Obj>
 																	</value>
@@ -4818,6 +4855,9 @@
 																				<TypeSpecialization classname='Str'>
 																					<value>None</value>
 																				</TypeSpecialization>
+																				<EnumDefinition classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</EnumDefinition>
 																			</subprops>
 																		</Obj>
 																	</value>
@@ -4828,26 +4868,45 @@
 																					<value>trigger_slope</value>
 																				</Name>
 																				<ArgumentValue classname='ExprValue'>
-																					<value>"Positive"</value>
+																					<value>1i64</value>
 																				</ArgumentValue>
 																				<Direction classname='Str'>
 																					<value>In</value>
 																				</Direction>
 																				<Log classname='Bool'>
-																					<value>false</value>
+																					<value>true</value>
 																				</Log>
 																				<Dimension classname='Num'>
 																					<value representation='UInt64'>0</value>
 																				</Dimension>
 																				<Type classname='Str'>
-																					<value>TypeString</value>
+																					<value>TypeEnum</value>
 																				</Type>
 																				<ID classname='Num'>
 																					<value representation='Int64'>9</value>
 																				</ID>
 																				<TypeSpecialization classname='Str'>
-																					<value>None</value>
+																					<value>Enum</value>
 																				</TypeSpecialization>
+																				<EnumDefinition classname='Objs'>
+																					<value lbound='[0]' ubound='[2]'>
+																						<value>
+																							<Num name='NEGATIVE'>
+																								<value representation='Int64'>0</value>
+																							</Num>
+																						</value>
+																						<value>
+																							<Num name='POSITIVE'>
+																								<value representation='Int64'>1</value>
+																							</Num>
+																						</value>
+																						<value>
+																							<Num name='SLOPE_EITHER'>
+																								<value representation='Int64'>3</value>
+																							</Num>
+																						</value>
+																					</value>
+																				</EnumDefinition>
 																			</subprops>
 																		</Obj>
 																	</value>
@@ -4878,6 +4937,9 @@
 																				<TypeSpecialization classname='Str'>
 																					<value>None</value>
 																				</TypeSpecialization>
+																				<EnumDefinition classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</EnumDefinition>
 																			</subprops>
 																		</Obj>
 																	</value>
@@ -4888,26 +4950,55 @@
 																					<value>trigger_coupling</value>
 																				</Name>
 																				<ArgumentValue classname='ExprValue'>
-																					<value>"DC"</value>
+																					<value>1i64</value>
 																				</ArgumentValue>
 																				<Direction classname='Str'>
 																					<value>In</value>
 																				</Direction>
 																				<Log classname='Bool'>
-																					<value>false</value>
+																					<value>true</value>
 																				</Log>
 																				<Dimension classname='Num'>
 																					<value representation='UInt64'>0</value>
 																				</Dimension>
 																				<Type classname='Str'>
-																					<value>TypeString</value>
+																					<value>TypeEnum</value>
 																				</Type>
 																				<ID classname='Num'>
 																					<value representation='Int64'>11</value>
 																				</ID>
 																				<TypeSpecialization classname='Str'>
-																					<value>None</value>
+																					<value>Enum</value>
 																				</TypeSpecialization>
+																				<EnumDefinition classname='Objs'>
+																					<value lbound='[0]' ubound='[4]'>
+																						<value>
+																							<Num name='AC'>
+																								<value representation='Int64'>0</value>
+																							</Num>
+																						</value>
+																						<value>
+																							<Num name='DC'>
+																								<value representation='Int64'>1</value>
+																							</Num>
+																						</value>
+																						<value>
+																							<Num name='HF_REJECT'>
+																								<value representation='Int64'>3</value>
+																							</Num>
+																						</value>
+																						<value>
+																							<Num name='LF_REJECT'>
+																								<value representation='Int64'>4</value>
+																							</Num>
+																						</value>
+																						<value>
+																							<Num name='AC_PLUS_HF_REJECT'>
+																								<value representation='Int64'>1001</value>
+																							</Num>
+																						</value>
+																					</value>
+																				</EnumDefinition>
 																			</subprops>
 																		</Obj>
 																	</value>
@@ -4938,6 +5029,9 @@
 																				<TypeSpecialization classname='Str'>
 																					<value>None</value>
 																				</TypeSpecialization>
+																				<EnumDefinition classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</EnumDefinition>
 																			</subprops>
 																		</Obj>
 																	</value>
@@ -4968,6 +5062,9 @@
 																				<TypeSpecialization classname='Str'>
 																					<value>None</value>
 																				</TypeSpecialization>
+																				<EnumDefinition classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</EnumDefinition>
 																			</subprops>
 																		</Obj>
 																	</value>
@@ -4998,6 +5095,9 @@
 																				<TypeSpecialization classname='Str'>
 																					<value>None</value>
 																				</TypeSpecialization>
+																				<EnumDefinition classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</EnumDefinition>
 																			</subprops>
 																		</Obj>
 																	</value>
@@ -5028,6 +5128,9 @@
 																				<TypeSpecialization classname='Str'>
 																					<value>None</value>
 																				</TypeSpecialization>
+																				<EnumDefinition classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</EnumDefinition>
 																			</subprops>
 																		</Obj>
 																	</value>
@@ -5058,6 +5161,9 @@
 																				<TypeSpecialization classname='Str'>
 																					<value>None</value>
 																				</TypeSpecialization>
+																				<EnumDefinition classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</EnumDefinition>
 																			</subprops>
 																		</Obj>
 																	</value>

--- a/examples/nivisa_dmm_measurement/NIVisaDmmMeasurement.seq
+++ b/examples/nivisa_dmm_measurement/NIVisaDmmMeasurement.seq
@@ -4608,6 +4608,9 @@
 																				<TypeSpecialization classname='Str'>
 																					<value>Pin</value>
 																				</TypeSpecialization>
+																				<EnumDefinition classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</EnumDefinition>
 																			</subprops>
 																		</Obj>
 																	</value>
@@ -4618,7 +4621,7 @@
 																					<value>measurement_type</value>
 																				</Name>
 																				<ArgumentValue classname='ExprValue'>
-																					<value>"DC Volts"</value>
+																					<value>0i64</value>
 																				</ArgumentValue>
 																				<Direction classname='Str'>
 																					<value>In</value>
@@ -4630,14 +4633,28 @@
 																					<value representation='UInt64'>0</value>
 																				</Dimension>
 																				<Type classname='Str'>
-																					<value>TypeString</value>
+																					<value>TypeEnum</value>
 																				</Type>
 																				<ID classname='Num'>
 																					<value representation='Int64'>2</value>
 																				</ID>
 																				<TypeSpecialization classname='Str'>
-																					<value>None</value>
+																					<value>Enum</value>
 																				</TypeSpecialization>
+																				<EnumDefinition classname='Objs'>
+																					<value lbound='[0]' ubound='[1]'>
+																						<value>
+																							<Num name='DC_VOLTS'>
+																								<value representation='Int64'>0</value>
+																							</Num>
+																						</value>
+																						<value>
+																							<Num name='AC_VOLTS'>
+																								<value representation='Int64'>1</value>
+																							</Num>
+																						</value>
+																					</value>
+																				</EnumDefinition>
 																			</subprops>
 																		</Obj>
 																	</value>
@@ -4668,6 +4685,9 @@
 																				<TypeSpecialization classname='Str'>
 																					<value>None</value>
 																				</TypeSpecialization>
+																				<EnumDefinition classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</EnumDefinition>
 																			</subprops>
 																		</Obj>
 																	</value>
@@ -4698,6 +4718,9 @@
 																				<TypeSpecialization classname='Str'>
 																					<value>None</value>
 																				</TypeSpecialization>
+																				<EnumDefinition classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</EnumDefinition>
 																			</subprops>
 																		</Obj>
 																	</value>
@@ -4728,6 +4751,9 @@
 																				<TypeSpecialization classname='Str'>
 																					<value>None</value>
 																				</TypeSpecialization>
+																				<EnumDefinition classname='Objs'>
+																					<value lbound='[0]' ubound='[]'/>
+																				</EnumDefinition>
 																			</subprops>
 																		</Obj>
 																	</value>

--- a/examples/nivisa_dmm_measurement/measurement.py
+++ b/examples/nivisa_dmm_measurement/measurement.py
@@ -2,7 +2,7 @@
 
 import logging
 import pathlib
-from enum import Enum, auto
+from enum import Enum
 from typing import Tuple
 
 import click

--- a/examples/nivisa_dmm_measurement/measurement.py
+++ b/examples/nivisa_dmm_measurement/measurement.py
@@ -47,8 +47,8 @@ RESOLUTION_DIGITS_TO_VALUE = {"3.5": 0.001, "4.5": 0.0001, "5.5": 1e-5, "6.5": 1
 class Function(Enum):
     """Function that represents the measurement type."""
 
-    DC_VOLTS = auto()
-    AC_VOLTS = auto()
+    DC_VOLTS = 0
+    AC_VOLTS = 1
 
 
 FUNCTION_TO_VALUE = {


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Updates the TestStand sequence files for the examples that use enums via opening them up and clicking "Reload Measurement Parameters".
- Fixed an issue where some of these examples used enums that did not have a zero-value.

### Why should this Pull Request be merged?

[AB#2426140](https://ni.visualstudio.com/DevCentral/_backlogs/backlog/InstrumentStudio%20Platform/Features/?workitem=2426140)

### What testing has been done?

- Manually validated that the examples services starts successfully.
- Manually validated that we can connect to the services in TestStand and reload measurement parameters.
- Manually inspected that the reloaded measurement parameters specify enum for enum parameters.