### PR TITLE
scripts: Make install_examples.py work with path="../.."

### DIFF
--- a/scripts/install_examples.py
+++ b/scripts/install_examples.py
@@ -3,10 +3,13 @@
 
 import os
 import pathlib
+import re
 import shutil
 import subprocess
+import sys
 
-EXAMPLES_PATH = pathlib.Path(__file__).parent.parent / "examples"
+ROOT_DIR = pathlib.Path(__file__).parent.parent
+EXAMPLES_PATH = ROOT_DIR / "examples"
 SERVICES_PATH = (
     pathlib.Path(os.environ["ProgramData"])
     / "National Instruments"
@@ -41,6 +44,18 @@ def main():
         if venv_dir.is_dir():
             print(f"Deleting virtualenv {venv_dir}")
             shutil.rmtree(venv_dir)
+
+        pyproject_path = install_path / "pyproject.toml"
+        pyproject_data = pyproject_path.read_text()
+        new_pyproject_data = re.sub(
+            r'^ni-measurementlink-service\s*=\s*\{\s*path\s*=\s*"\.\./\.\."',
+            lambda m: m.group(0).replace('../..', ROOT_DIR.absolute().as_posix()),
+            pyproject_data,
+            flags=re.MULTILINE,
+        )
+        if new_pyproject_data != pyproject_data:
+            print(f"Patching pyproject.toml to use absolute path")
+            pyproject_path.write_text(new_pyproject_data)
 
         print(f"Installing dependencies")
         subprocess.run(["poetry", "-v", "install"], check=True, cwd=install_path, env=clean_env)

--- a/scripts/install_examples.py
+++ b/scripts/install_examples.py
@@ -6,7 +6,6 @@ import pathlib
 import re
 import shutil
 import subprocess
-import sys
 
 ROOT_DIR = pathlib.Path(__file__).parent.parent
 EXAMPLES_PATH = ROOT_DIR / "examples"
@@ -49,7 +48,7 @@ def main():
         pyproject_data = pyproject_path.read_text()
         new_pyproject_data = re.sub(
             r'^ni-measurementlink-service\s*=\s*\{\s*path\s*=\s*"\.\./\.\."',
-            lambda m: m.group(0).replace('../..', ROOT_DIR.absolute().as_posix()),
+            lambda m: m.group(0).replace("../..", ROOT_DIR.absolute().as_posix()),
             pyproject_data,
             flags=re.MULTILINE,
         )


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Make `install_examples.py` update `ni-measurementlink-service = { path = "../.."` to use an absolute path.

> **Note**
>
> If your Git repo has a different drive letter than `%ProgramData%`, this still doesn't work. This is a Poetry limitation: it wants to write relative paths into `poetry.lock`, and relative paths can't span drive letters.

### Why should this Pull Request be merged?

Make it easier to install examples with local builds.

### What testing has been done?

Manually tested.