### PR TITLE
examples: Simplify reserve call by extracting reservation timeout constant

### DIFF
--- a/examples/nidaqmx_analog_input/measurement.py
+++ b/examples/nidaqmx_analog_input/measurement.py
@@ -28,6 +28,11 @@ measurement_service = nims.MeasurementService(
 )
 service_options = ServiceOptions()
 
+# If another measurement is using the session, the reserve function will wait
+# for it to complete. Specify a reservation timeout to aid in debugging missed
+# unreserve calls. Long measurements may require a longer timeout.
+RESERVATION_TIMEOUT_IN_SECONDS = 60.0
+
 
 @measurement_service.register_measurement
 @measurement_service.configuration(
@@ -52,10 +57,7 @@ def measure(pin_name, sample_rate, number_of_samples):
         context=measurement_service.context.pin_map_context,
         pin_or_relay_names=[pin_name],
         instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_DAQMX,
-        # If another measurement is using the session, wait for it to complete.
-        # Specify a timeout to aid in debugging missed unreserve calls.
-        # Long measurements may require a longer timeout.
-        timeout=60,
+        timeout=RESERVATION_TIMEOUT_IN_SECONDS,
     ) as reservation:
         task: Optional[nidaqmx.Task] = None
 

--- a/examples/nidaqmx_analog_input/measurement.py
+++ b/examples/nidaqmx_analog_input/measurement.py
@@ -28,10 +28,13 @@ measurement_service = nims.MeasurementService(
 )
 service_options = ServiceOptions()
 
-# If another measurement is using the session, the reserve function will wait
-# for it to complete. Specify a reservation timeout to aid in debugging missed
-# unreserve calls. Long measurements may require a longer timeout.
+
 RESERVATION_TIMEOUT_IN_SECONDS = 60.0
+"""
+If another measurement is using the session, the reserve function will wait
+for it to complete. Specify a reservation timeout to aid in debugging missed
+unreserve calls. Long measurements may require a longer timeout.
+"""
 
 
 @measurement_service.register_measurement

--- a/examples/nidcpower_source_dc_voltage/_nidcpower_helpers.py
+++ b/examples/nidcpower_source_dc_voltage/_nidcpower_helpers.py
@@ -7,9 +7,11 @@ import nidcpower
 
 import ni_measurementlink_service as nims
 
-# To use a physical NI SMU instrument, set this to False or specify
-# --no-use-simulation on the command line.
 USE_SIMULATION = True
+"""
+To use a physical NI SMU instrument, set this to False or specify
+--no-use-simulation on the command line.
+"""
 
 
 def create_session(

--- a/examples/nidcpower_source_dc_voltage/measurement.py
+++ b/examples/nidcpower_source_dc_voltage/measurement.py
@@ -37,10 +37,12 @@ measurement_service = nims.MeasurementService(
 )
 service_options = ServiceOptions()
 
-# If another measurement is using the session, the reserve function will wait
-# for it to complete. Specify a reservation timeout to aid in debugging missed
-# unreserve calls. Long measurements may require a longer timeout.
 RESERVATION_TIMEOUT_IN_SECONDS = 60.0
+"""
+If another measurement is using the session, the reserve function will wait
+for it to complete. Specify a reservation timeout to aid in debugging missed
+unreserve calls. Long measurements may require a longer timeout.
+"""
 
 
 @measurement_service.register_measurement

--- a/examples/nidcpower_source_dc_voltage/measurement.py
+++ b/examples/nidcpower_source_dc_voltage/measurement.py
@@ -37,6 +37,11 @@ measurement_service = nims.MeasurementService(
 )
 service_options = ServiceOptions()
 
+# If another measurement is using the session, the reserve function will wait
+# for it to complete. Specify a reservation timeout to aid in debugging missed
+# unreserve calls. Long measurements may require a longer timeout.
+RESERVATION_TIMEOUT_IN_SECONDS = 60.0
+
 
 @measurement_service.register_measurement
 @measurement_service.configuration(
@@ -72,10 +77,7 @@ def measure(
         context=measurement_service.context.pin_map_context,
         pin_or_relay_names=pin_names,
         instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_DCPOWER,
-        # If another measurement is using the session, wait for it to complete.
-        # Specify a timeout to aid in debugging missed unreserve calls.
-        # Long measurements may require a longer timeout.
-        timeout=60,
+        timeout=RESERVATION_TIMEOUT_IN_SECONDS,
     ) as reservation:
         grpc_device_channel = get_grpc_device_channel(
             measurement_service, nidcpower, service_options

--- a/examples/nidigital_spi/_nidigital_helpers.py
+++ b/examples/nidigital_spi/_nidigital_helpers.py
@@ -7,9 +7,11 @@ import nidigital
 
 import ni_measurementlink_service as nims
 
-# To use a physical NI digital pattern instrument, set this to False or specify
-# --no-use-simulation on the command line.
 USE_SIMULATION = True
+"""
+To use a physical NI digital pattern instrument, set this to False or specify
+--no-use-simulation on the command line.
+"""
 
 
 def create_session(

--- a/examples/nidigital_spi/measurement.py
+++ b/examples/nidigital_spi/measurement.py
@@ -28,10 +28,12 @@ measurement_service = nims.MeasurementService(
 )
 service_options = ServiceOptions()
 
-# If another measurement is using the session, the reserve function will wait
-# for it to complete. Specify a reservation timeout to aid in debugging missed
-# unreserve calls. Long measurements may require a longer timeout.
 RESERVATION_TIMEOUT_IN_SECONDS = 60.0
+"""
+If another measurement is using the session, the reserve function will wait
+for it to complete. Specify a reservation timeout to aid in debugging missed
+unreserve calls. Long measurements may require a longer timeout.
+"""
 
 
 @measurement_service.register_measurement

--- a/examples/nidigital_spi/measurement.py
+++ b/examples/nidigital_spi/measurement.py
@@ -28,6 +28,11 @@ measurement_service = nims.MeasurementService(
 )
 service_options = ServiceOptions()
 
+# If another measurement is using the session, the reserve function will wait
+# for it to complete. Specify a reservation timeout to aid in debugging missed
+# unreserve calls. Long measurements may require a longer timeout.
+RESERVATION_TIMEOUT_IN_SECONDS = 60.0
+
 
 @measurement_service.register_measurement
 @measurement_service.configuration(
@@ -61,10 +66,7 @@ def measure(
         context=measurement_service.context.pin_map_context,
         pin_or_relay_names=pin_names,
         instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_DIGITAL_PATTERN,
-        # If another measurement is using the session, wait for it to complete.
-        # Specify a timeout to aid in debugging missed unreserve calls.
-        # Long measurements may require a longer timeout.
-        timeout=60,
+        timeout=RESERVATION_TIMEOUT_IN_SECONDS,
     ) as reservation:
         grpc_device_channel = get_grpc_device_channel(
             measurement_service, nidigital, service_options

--- a/examples/nidmm_measurement/_nidmm_helpers.py
+++ b/examples/nidmm_measurement/_nidmm_helpers.py
@@ -7,9 +7,11 @@ import nidmm
 
 import ni_measurementlink_service as nims
 
-# To use a physical NI DMM instrument, set this to False or specify
-# --no-use-simulation on the command line.
 USE_SIMULATION = True
+"""
+To use a physical NI DMM instrument, set this to False or specify
+--no-use-simulation on the command line.
+"""
 
 
 def create_session(

--- a/examples/nidmm_measurement/measurement.py
+++ b/examples/nidmm_measurement/measurement.py
@@ -30,10 +30,12 @@ measurement_service = nims.MeasurementService(
 )
 service_options = ServiceOptions()
 
-# If another measurement is using the session, the reserve function will wait
-# for it to complete. Specify a reservation timeout to aid in debugging missed
-# unreserve calls. Long measurements may require a longer timeout.
 RESERVATION_TIMEOUT_IN_SECONDS = 60.0
+"""
+If another measurement is using the session, the reserve function will wait
+for it to complete. Specify a reservation timeout to aid in debugging missed
+unreserve calls. Long measurements may require a longer timeout.
+"""
 
 
 class Function(Enum):

--- a/examples/nidmm_measurement/measurement.py
+++ b/examples/nidmm_measurement/measurement.py
@@ -30,6 +30,11 @@ measurement_service = nims.MeasurementService(
 )
 service_options = ServiceOptions()
 
+# If another measurement is using the session, the reserve function will wait
+# for it to complete. Specify a reservation timeout to aid in debugging missed
+# unreserve calls. Long measurements may require a longer timeout.
+RESERVATION_TIMEOUT_IN_SECONDS = 60.0
+
 
 class Function(Enum):
     """Wrapper enum that contains a zero value."""
@@ -88,10 +93,7 @@ def measure(
         context=measurement_service.context.pin_map_context,
         pin_or_relay_names=[pin_name],
         instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_DMM,
-        # If another measurement is using the session, wait for it to complete.
-        # Specify a timeout to aid in debugging missed unreserve calls.
-        # Long measurements may require a longer timeout.
-        timeout=60,
+        timeout=RESERVATION_TIMEOUT_IN_SECONDS,
     ) as reservation:
         grpc_device_channel = get_grpc_device_channel(measurement_service, nidmm, service_options)
         with create_session(reservation.session_info, grpc_device_channel) as session:

--- a/examples/nifgen_standard_function/_nifgen_helpers.py
+++ b/examples/nifgen_standard_function/_nifgen_helpers.py
@@ -7,9 +7,11 @@ import nifgen
 
 import ni_measurementlink_service as nims
 
-# To use a physical NI waveform generator instrument, set this to False or specify
-# --no-use-simulation on the command line.
 USE_SIMULATION = True
+"""
+To use a physical NI waveform generator instrument, set this to False or specify
+--no-use-simulation on the command line.
+"""
 
 
 def create_session(

--- a/examples/nifgen_standard_function/measurement.py
+++ b/examples/nifgen_standard_function/measurement.py
@@ -36,6 +36,11 @@ measurement_service = nims.MeasurementService(
 )
 service_options = ServiceOptions()
 
+# If another measurement is using the session, the reserve function will wait
+# for it to complete. Specify a reservation timeout to aid in debugging missed
+# unreserve calls. Long measurements may require a longer timeout.
+RESERVATION_TIMEOUT_IN_SECONDS = 60.0
+
 
 class Waveform(Enum):
     """Wrapper enum that contains a zero value."""
@@ -98,10 +103,7 @@ def measure(
                 context=measurement_service.context.pin_map_context,
                 pin_or_relay_names=[pin_name],
                 instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_FGEN,
-                # If another measurement is using the session, wait for it to complete.
-                # Specify a timeout to aid in debugging missed unreserve calls.
-                # Long measurements may require a longer timeout.
-                timeout=60,
+                timeout=RESERVATION_TIMEOUT_IN_SECONDS,
             )
         )
 

--- a/examples/nifgen_standard_function/measurement.py
+++ b/examples/nifgen_standard_function/measurement.py
@@ -36,10 +36,12 @@ measurement_service = nims.MeasurementService(
 )
 service_options = ServiceOptions()
 
-# If another measurement is using the session, the reserve function will wait
-# for it to complete. Specify a reservation timeout to aid in debugging missed
-# unreserve calls. Long measurements may require a longer timeout.
 RESERVATION_TIMEOUT_IN_SECONDS = 60.0
+"""
+If another measurement is using the session, the reserve function will wait
+for it to complete. Specify a reservation timeout to aid in debugging missed
+unreserve calls. Long measurements may require a longer timeout.
+"""
 
 
 class Waveform(Enum):

--- a/examples/niscope_acquire_waveform/_niscope_helpers.py
+++ b/examples/niscope_acquire_waveform/_niscope_helpers.py
@@ -7,9 +7,11 @@ import niscope
 
 import ni_measurementlink_service as nims
 
-# To use a physical NI oscilloscope instrument, set this to False or specify
-# --no-use-simulation on the command line.
 USE_SIMULATION = True
+"""
+To use a physical NI oscilloscope instrument, set this to False or specify
+--no-use-simulation on the command line.
+"""
 
 
 def create_session(

--- a/examples/niscope_acquire_waveform/measurement.py
+++ b/examples/niscope_acquire_waveform/measurement.py
@@ -30,10 +30,12 @@ measurement_service = nims.MeasurementService(
 )
 service_options = ServiceOptions()
 
-# If another measurement is using the session, the reserve function will wait
-# for it to complete. Specify a reservation timeout to aid in debugging missed
-# unreserve calls. Long measurements may require a longer timeout.
 RESERVATION_TIMEOUT_IN_SECONDS = 60.0
+"""
+If another measurement is using the session, the reserve function will wait
+for it to complete. Specify a reservation timeout to aid in debugging missed
+unreserve calls. Long measurements may require a longer timeout.
+"""
 
 
 @measurement_service.register_measurement

--- a/examples/niscope_acquire_waveform/measurement.py
+++ b/examples/niscope_acquire_waveform/measurement.py
@@ -30,6 +30,11 @@ measurement_service = nims.MeasurementService(
 )
 service_options = ServiceOptions()
 
+# If another measurement is using the session, the reserve function will wait
+# for it to complete. Specify a reservation timeout to aid in debugging missed
+# unreserve calls. Long measurements may require a longer timeout.
+RESERVATION_TIMEOUT_IN_SECONDS = 60.0
+
 
 @measurement_service.register_measurement
 @measurement_service.configuration(
@@ -111,10 +116,7 @@ def measure(
         context=measurement_service.context.pin_map_context,
         pin_or_relay_names=pin_names,
         instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_SCOPE,
-        # If another measurement is using the session, wait for it to complete.
-        # Specify a timeout to aid in debugging missed unreserve calls.
-        # Long measurements may require a longer timeout.
-        timeout=60,
+        timeout=RESERVATION_TIMEOUT_IN_SECONDS,
     ) as reservation:
         channel_names = reservation.session_info.channel_list
         pin_to_channel = {

--- a/examples/niswitch_control_relays/_niswitch_helpers.py
+++ b/examples/niswitch_control_relays/_niswitch_helpers.py
@@ -7,9 +7,11 @@ import niswitch
 
 import ni_measurementlink_service as nims
 
-# To use a physical NI relay driver instrument, set this to False or specify
-# --no-use-simulation on the command line.
 USE_SIMULATION = True
+"""
+To use a physical NI relay driver instrument, set this to False or specify
+--no-use-simulation on the command line.
+"""
 
 
 def create_session(

--- a/examples/niswitch_control_relays/measurement.py
+++ b/examples/niswitch_control_relays/measurement.py
@@ -29,10 +29,12 @@ measurement_service = nims.MeasurementService(
 )
 service_options = ServiceOptions()
 
-# If another measurement is using the session, the reserve function will wait
-# for it to complete. Specify a reservation timeout to aid in debugging missed
-# unreserve calls. Long measurements may require a longer timeout.
 RESERVATION_TIMEOUT_IN_SECONDS = 60.0
+"""
+If another measurement is using the session, the reserve function will wait
+for it to complete. Specify a reservation timeout to aid in debugging missed
+unreserve calls. Long measurements may require a longer timeout.
+"""
 
 
 @measurement_service.register_measurement

--- a/examples/niswitch_control_relays/measurement.py
+++ b/examples/niswitch_control_relays/measurement.py
@@ -29,6 +29,11 @@ measurement_service = nims.MeasurementService(
 )
 service_options = ServiceOptions()
 
+# If another measurement is using the session, the reserve function will wait
+# for it to complete. Specify a reservation timeout to aid in debugging missed
+# unreserve calls. Long measurements may require a longer timeout.
+RESERVATION_TIMEOUT_IN_SECONDS = 60.0
+
 
 @measurement_service.register_measurement
 @measurement_service.configuration("relay_names", nims.DataType.String, "SiteRelay1")
@@ -53,10 +58,7 @@ def measure(
                 context=measurement_service.context.pin_map_context,
                 pin_or_relay_names=relay_list,
                 instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_RELAY_DRIVER,
-                # If another measurement is using the session, wait for it to complete.
-                # Specify a timeout to aid in debugging missed unreserve calls.
-                # Long measurements may require a longer timeout.
-                timeout=60,
+                timeout=RESERVATION_TIMEOUT_IN_SECONDS,
             )
         )
 

--- a/examples/nivisa_dmm_measurement/README.md
+++ b/examples/nivisa_dmm_measurement/README.md
@@ -35,9 +35,8 @@ simulate the instrument in software.
 behavior of the simulated instrument. 
 
 To use NI Instrument Simulator hardware:
-- Disable software simulation by setting `USE_SIMULATION = False` in both
-  [`measurement.py`](./measurement.py) and
-  [`teststand_fixture.py`](./teststand_fixture.py). 
+- Disable software simulation by setting `USE_SIMULATION = False` in
+  [`_visa_helpers.py`](./_visa_helpers.py). 
 - Connect the NI Instrument Simulator over GPIB or serial.
 - By default, the pin map included with this example uses the resource name
   `GPIB0::3::INSTR`, which matches the NI Instrument Simulator's factory default

--- a/examples/nivisa_dmm_measurement/_visa_helpers.py
+++ b/examples/nivisa_dmm_measurement/_visa_helpers.py
@@ -12,9 +12,17 @@ INSTRUMENT_TYPE_FGEN_SIMULATOR = "WaveformGeneratorSimulator"
 INSTRUMENT_TYPE_SCOPE_SIMULATOR = "OscilloscopeSimulator"
 INSTRUMENT_TYPE_DMM_SIMULATOR = "DigitalMultimeterSimulator"
 
-# Path to a simulation YAML file that can be used to simulate an NI Instrument Simulator v2.0
-# with pyvisa-sim
 SIMULATION_YAML_PATH = pathlib.Path(__file__).resolve().parent / "NIInstrumentSimulatorV2_0.yaml"
+"""
+Path to a simulation YAML file that can be used to simulate an NI Instrument Simulator v2.0
+with pyvisa-sim
+"""
+
+USE_SIMULATION = True
+"""
+To use NI Instrument Simulator v2.0 hardware, set this to False or specify
+--no-use-simulation on the command line.
+"""
 
 
 def create_visa_resource_manager(

--- a/examples/nivisa_dmm_measurement/measurement.py
+++ b/examples/nivisa_dmm_measurement/measurement.py
@@ -17,6 +17,7 @@ from _helpers import (
 )
 from _visa_helpers import (
     INSTRUMENT_TYPE_DMM_SIMULATOR,
+    USE_SIMULATION,
     check_instrument_error,
     create_visa_resource_manager,
     create_visa_session,
@@ -25,10 +26,6 @@ from _visa_helpers import (
 )
 
 import ni_measurementlink_service as nims
-
-# To use NI Instrument Simulator v2.0 hardware, set this to False or specify
-# --no-use-simulation on the command line.
-USE_SIMULATION = True
 
 
 service_directory = pathlib.Path(__file__).resolve().parent

--- a/examples/nivisa_dmm_measurement/measurement.py
+++ b/examples/nivisa_dmm_measurement/measurement.py
@@ -39,10 +39,12 @@ measurement_service = nims.MeasurementService(
 )
 service_options = ServiceOptions()
 
-# If another measurement is using the session, the reserve function will wait
-# for it to complete. Specify a reservation timeout to aid in debugging missed
-# unreserve calls. Long measurements may require a longer timeout.
 RESERVATION_TIMEOUT_IN_SECONDS = 60.0
+"""
+If another measurement is using the session, the reserve function will wait
+for it to complete. Specify a reservation timeout to aid in debugging missed
+unreserve calls. Long measurements may require a longer timeout.
+"""
 
 RESOLUTION_DIGITS_TO_VALUE = {"3.5": 0.001, "4.5": 0.0001, "5.5": 1e-5, "6.5": 1e-6}
 

--- a/examples/nivisa_dmm_measurement/measurement.py
+++ b/examples/nivisa_dmm_measurement/measurement.py
@@ -39,6 +39,10 @@ measurement_service = nims.MeasurementService(
 )
 service_options = ServiceOptions()
 
+# If another measurement is using the session, the reserve function will wait
+# for it to complete. Specify a reservation timeout to aid in debugging missed
+# unreserve calls. Long measurements may require a longer timeout.
+RESERVATION_TIMEOUT_IN_SECONDS = 60.0
 
 RESOLUTION_DIGITS_TO_VALUE = {"3.5": 0.001, "4.5": 0.0001, "5.5": 1e-5, "6.5": 1e-6}
 
@@ -87,10 +91,7 @@ def measure(
         context=measurement_service.context.pin_map_context,
         pin_or_relay_names=[pin_name],
         instrument_type_id=INSTRUMENT_TYPE_DMM_SIMULATOR,
-        # If another measurement is using the session, wait for it to complete.
-        # Specify a timeout to aid in debugging missed unreserve calls.
-        # Long measurements may require a longer timeout.
-        timeout=60,
+        timeout=RESERVATION_TIMEOUT_IN_SECONDS,
     ) as reservation:
         resource_manager = create_visa_resource_manager(service_options.use_simulation)
         with create_visa_session(

--- a/examples/nivisa_dmm_measurement/teststand_fixture.py
+++ b/examples/nivisa_dmm_measurement/teststand_fixture.py
@@ -5,6 +5,7 @@ import pyvisa.resources
 from _helpers import GrpcChannelPoolHelper, PinMapClient, TestStandSupport
 from _visa_helpers import (
     INSTRUMENT_TYPE_DMM_SIMULATOR,
+    USE_SIMULATION,
     create_visa_resource_manager,
     create_visa_session,
     log_instrument_id,
@@ -12,9 +13,6 @@ from _visa_helpers import (
 )
 
 import ni_measurementlink_service as nims
-
-# To use NI Instrument Simulator v2.0 hardware, set this to False.
-USE_SIMULATION = True
 
 
 def update_pin_map(pin_map_path: str, sequence_context: Any) -> None:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

The reserve call has a large comment about the reservation timeout. Extracting a constant allows us to move the comment outside of the call.

Also:
- Turn `USE_SIMULATION` and `SIMULATION_YAML_PATH` comments into docstrings.
- Single-source VISA `USE_SIMULATION` constant.

### Why should this Pull Request be merged?

Make examples more readable.

### What testing has been done?

Manually tested NI-DCPower example.