### PR TITLE
Fixed an issue with enums where zero-value parameters are not passed …

### DIFF
--- a/ni_measurementlink_service/_internal/parameter/serializer.py
+++ b/ni_measurementlink_service/_internal/parameter/serializer.py
@@ -193,9 +193,14 @@ def _get_missing_parameters(
     missing_parameters = {}
     for key, value in parameter_metadata_dict.items():
         if key not in parameter_by_id:
-            missing_parameters[key] = serialization_strategy.Context.get_type_default(
-                value.type, value.repeated
-            )
+            enum_annotations = get_enum_values_annotation(value)
+            if enum_annotations and not value.repeated:
+                enum_type = _get_enum_type(value)
+                missing_parameters[key] = enum_type(0)
+            else:
+                missing_parameters[key] = serialization_strategy.Context.get_type_default(
+                    value.type, value.repeated
+                )
     return missing_parameters
 
 

--- a/tests/unit/test_serializer.py
+++ b/tests/unit/test_serializer.py
@@ -164,6 +164,44 @@ def test___serializer___deserialize_parameter___successful_deserialization(value
     assert list(parameter_value_by_id.values()) == values
 
 
+def test___empty_buffer___deserialize_parameters___returns_zero_or_empty():
+    # Note that we set nonzero defaults to validate that we are getting zero-values
+    # as opposed to simply getting the defaults.
+    nonzero_defaults = [
+        2.0,
+        19.2,
+        3,
+        1,
+        2,
+        2,
+        True,
+        "TestString",
+        [5.5, 3.3, 1.0],
+        [5.5, 3, 1],
+        [1, 2, 3, 4],
+        [0, 1, 399],
+        [1, 2, 3, 4],
+        [0, 1, 399],
+        [True, False, True],
+        ["String1", "String2"],
+        DifferentColor.ORANGE,
+        [DifferentColor.TEAL, DifferentColor.BROWN],
+    ]
+    parameter = _get_test_parameter_by_id(nonzero_defaults)
+    parameter_value_by_id = serializer.deserialize_parameters(parameter, bytes())
+
+    for key, value in parameter_value_by_id.items():
+        parameter_metadata = parameter[key]
+        if parameter_metadata.repeated:
+            assert value == list()
+        elif parameter_metadata.type == type_pb2.Field.TYPE_ENUM:
+            assert value.value == 0
+        elif parameter_metadata.type == type_pb2.Field.TYPE_STRING:
+            assert value == ""
+        else:
+            assert value == 0
+
+
 def _validate_serialized_bytes(custom_serialized_bytes, values):
     # Serialization using gRPC Any
     grpc_serialized_data = _get_grpc_serialized_data(values)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Instead of using `serialization_strategy.Context.get_type_default` for enums, we coerce the value to the zero-value for that enum. This is because the measurement client does not send the zero-values over gRPC, Note that we do not use the default value as a non-zero default value would have been included in `parameter_metadata_dict`.

### Why should this Pull Request be merged?

[AB#2430949](https://dev.azure.com/ni/DevCentral/_workitems/edit/2430949)

### What testing has been done?
- Ran `dmm` and `nivisa_dmm` example measurements in InstrumentStudio.
- Tests pass.

![image](https://github.com/ni/measurementlink-python/assets/103216564/83b6224b-8827-4d49-8e40-677fb6af09fb)
