### PR TITLE
examples: Update dependencies and providedInterfaces

### DIFF
--- a/examples/nidaqmx_analog_input/NIDAQmxAnalogInput.serviceconfig
+++ b/examples/nidaqmx_analog_input/NIDAQmxAnalogInput.serviceconfig
@@ -4,7 +4,10 @@
       "displayName": "NI-DAQmx Analog Input (Py)",
       "serviceClass": "ni.examples.NIDAQmxAnalogInput_Python",
       "descriptionUrl": "",
-      "providedInterfaces": [ "ni.measurementlink.measurement.v1.MeasurementService" ],
+      "providedInterfaces": [
+        "ni.measurementlink.measurement.v1.MeasurementService",
+        "ni.measurementlink.measurement.v2.MeasurementService"
+      ],
       "path": "start.bat"
     }
   ]

--- a/examples/nidaqmx_analog_input/pyproject.toml
+++ b/examples/nidaqmx_analog_input/pyproject.toml
@@ -16,8 +16,7 @@ grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies (requires poetry>=1.2).
 # TODO: Comment out once a prerelease is built.
 nidaqmx = { git = "https://github.com/ni/nidaqmx-python.git", branch = "master", extras = ["grpc"]}
-# Uncomment once 1.1.0-dev2 is released
-ni-measurementlink-service = {path = "../..", develop = true}
+# ni-measurementlink-service = {path = "../..", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.2.0"]

--- a/examples/nidaqmx_analog_input/pyproject.toml
+++ b/examples/nidaqmx_analog_input/pyproject.toml
@@ -13,7 +13,7 @@ click = ">=7.1.2"
 [tool.poetry.group.dev.dependencies]
 mypy = ">=1.0"
 grpc-stubs = "^1.53"
-# Uncomment to use prerelease dependencies (requires poetry>=1.2).
+# Uncomment to use prerelease dependencies.
 # TODO: Comment out once a prerelease is built.
 nidaqmx = { git = "https://github.com/ni/nidaqmx-python.git", branch = "master", extras = ["grpc"]}
 # ni-measurementlink-service = {path = "../..", develop = true}

--- a/examples/nidcpower_source_dc_voltage/NIDCPowerSourceDCVoltage.serviceconfig
+++ b/examples/nidcpower_source_dc_voltage/NIDCPowerSourceDCVoltage.serviceconfig
@@ -4,7 +4,10 @@
       "displayName": "NI-DCPower Source DC Voltage (Py)",
       "serviceClass": "ni.examples.NIDCPowerSourceDCVoltage_Python",
       "descriptionUrl": "",
-      "providedInterfaces": [ "ni.measurementlink.measurement.v1.MeasurementService" ],
+      "providedInterfaces": [
+        "ni.measurementlink.measurement.v1.MeasurementService",
+        "ni.measurementlink.measurement.v2.MeasurementService"
+      ],
       "path": "start.bat"
     }
   ]

--- a/examples/nidcpower_source_dc_voltage/pyproject.toml
+++ b/examples/nidcpower_source_dc_voltage/pyproject.toml
@@ -14,7 +14,7 @@ grpcio = "*"
 [tool.poetry.group.dev.dependencies]
 mypy = ">=1.0"
 grpc-stubs = "^1.53"
-# Uncomment to use prerelease dependencies (requires poetry>=1.2).
+# Uncomment to use prerelease dependencies.
 # nidcpower = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/nidcpower"}
 # ni-measurementlink-service = {path = "../..", develop = true}
 

--- a/examples/nidcpower_source_dc_voltage/pyproject.toml
+++ b/examples/nidcpower_source_dc_voltage/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-nidcpower = ">=1.4.3"
+nidcpower = { version = ">=1.4.4", extras = ["grpc"] }
 ni-measurementlink-service = {version = "^1.1.0-dev2", allow-prereleases = true}
 click = ">=7.1.2"
 grpcio = "*"

--- a/examples/nidcpower_source_dc_voltage/pyproject.toml
+++ b/examples/nidcpower_source_dc_voltage/pyproject.toml
@@ -16,8 +16,7 @@ mypy = ">=1.0"
 grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies (requires poetry>=1.2).
 # nidcpower = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/nidcpower"}
-# Uncomment once 1.1.0-dev2 is released
-ni-measurementlink-service = {path = "../..", develop = true}
+# ni-measurementlink-service = {path = "../..", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.2.0"]

--- a/examples/nidigital_spi/NIDigitalSPI.serviceconfig
+++ b/examples/nidigital_spi/NIDigitalSPI.serviceconfig
@@ -4,7 +4,10 @@
       "displayName": "NI-Digital SPI (Py)",
       "serviceClass": "ni.examples.NIDigitalSPI_Python",
       "descriptionUrl": "",
-      "providedInterfaces": [ "ni.measurementlink.measurement.v1.MeasurementService" ],
+      "providedInterfaces": [
+        "ni.measurementlink.measurement.v1.MeasurementService",
+        "ni.measurementlink.measurement.v2.MeasurementService"
+      ],
       "path": "start.bat"
     }
   ]

--- a/examples/nidigital_spi/pyproject.toml
+++ b/examples/nidigital_spi/pyproject.toml
@@ -14,7 +14,7 @@ grpcio = "*"
 [tool.poetry.group.dev.dependencies]
 mypy = ">=1.0"
 grpc-stubs = "^1.53"
-# Uncomment to use prerelease dependencies (requires poetry>=1.2).
+# Uncomment to use prerelease dependencies.
 # nidigital = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/nidigital"}
 # ni-measurementlink-service = {path = "../..", develop = true}
 

--- a/examples/nidigital_spi/pyproject.toml
+++ b/examples/nidigital_spi/pyproject.toml
@@ -16,8 +16,7 @@ mypy = ">=1.0"
 grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies (requires poetry>=1.2).
 # nidigital = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/nidigital"}
-# Uncomment once 1.1.0-dev2 is released
-ni-measurementlink-service = {path = "../..", develop = true}
+# ni-measurementlink-service = {path = "../..", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.2.0"]

--- a/examples/nidmm_measurement/NIDmmMeasurement.serviceconfig
+++ b/examples/nidmm_measurement/NIDmmMeasurement.serviceconfig
@@ -4,7 +4,10 @@
       "displayName": "NI-DMM Measurement (Py)",
       "serviceClass": "ni.examples.NIDmmMeasurement_Python",
       "descriptionUrl": "",
-      "providedInterfaces": [ "ni.measurementlink.measurement.v1.MeasurementService" ],
+      "providedInterfaces": [
+        "ni.measurementlink.measurement.v1.MeasurementService",
+        "ni.measurementlink.measurement.v2.MeasurementService"
+      ],
       "path": "start.bat"
     }
   ]

--- a/examples/nidmm_measurement/pyproject.toml
+++ b/examples/nidmm_measurement/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-nidmm = ">=1.4.3"
+nidmm = { version = ">=1.4.4", extras = ["grpc"] }
 ni-measurementlink-service = {version = "^1.1.0-dev2", allow-prereleases = true}
 click = ">=7.1.2"
 grpcio = "*"

--- a/examples/nidmm_measurement/pyproject.toml
+++ b/examples/nidmm_measurement/pyproject.toml
@@ -16,8 +16,7 @@ mypy = ">=1.0"
 grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies (requires poetry>=1.2).
 # nidmm = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/nidmm"}
-# TODO: Re-comment references below after we build a prerelease with enum support.
-ni-measurementlink-service = {path = "../..", develop = true}
+# ni-measurementlink-service = {path = "../..", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.2.0"]

--- a/examples/nidmm_measurement/pyproject.toml
+++ b/examples/nidmm_measurement/pyproject.toml
@@ -14,7 +14,7 @@ grpcio = "*"
 [tool.poetry.group.dev.dependencies]
 mypy = ">=1.0"
 grpc-stubs = "^1.53"
-# Uncomment to use prerelease dependencies (requires poetry>=1.2).
+# Uncomment to use prerelease dependencies.
 # nidmm = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/nidmm"}
 # ni-measurementlink-service = {path = "../..", develop = true}
 

--- a/examples/nifgen_standard_function/NIFgenStandardFunction.serviceconfig
+++ b/examples/nifgen_standard_function/NIFgenStandardFunction.serviceconfig
@@ -4,7 +4,10 @@
       "displayName": "NI-FGEN Standard Function (Py)",
       "serviceClass": "ni.examples.NIFgenStandardFunction_Python",
       "descriptionUrl": "",
-      "providedInterfaces": [ "ni.measurementlink.measurement.v1.MeasurementService" ],
+      "providedInterfaces": [
+        "ni.measurementlink.measurement.v1.MeasurementService",
+        "ni.measurementlink.measurement.v2.MeasurementService"
+      ],
       "path": "start.bat"
     }
   ]

--- a/examples/nifgen_standard_function/pyproject.toml
+++ b/examples/nifgen_standard_function/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-nifgen = ">=1.4.3"
+nifgen = { version = ">=1.4.4", extras = ["grpc"] }
 ni-measurementlink-service = {version = "^1.1.0-dev2", allow-prereleases = true}
 click = ">=7.1.2"
 grpcio = "*"

--- a/examples/nifgen_standard_function/pyproject.toml
+++ b/examples/nifgen_standard_function/pyproject.toml
@@ -16,8 +16,7 @@ mypy = ">=1.0"
 grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies (requires poetry>=1.2).
 # nifgen = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/nifgen"}
-# TODO: Re-comment references below after we build a prerelease with enum support.
-ni-measurementlink-service = {path = "../..", develop = true}
+# ni-measurementlink-service = {path = "../..", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.2.0"]

--- a/examples/nifgen_standard_function/pyproject.toml
+++ b/examples/nifgen_standard_function/pyproject.toml
@@ -14,7 +14,7 @@ grpcio = "*"
 [tool.poetry.group.dev.dependencies]
 mypy = ">=1.0"
 grpc-stubs = "^1.53"
-# Uncomment to use prerelease dependencies (requires poetry>=1.2).
+# Uncomment to use prerelease dependencies.
 # nifgen = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/nifgen"}
 # ni-measurementlink-service = {path = "../..", develop = true}
 

--- a/examples/niscope_acquire_waveform/NIScopeAcquireWaveform.serviceconfig
+++ b/examples/niscope_acquire_waveform/NIScopeAcquireWaveform.serviceconfig
@@ -4,7 +4,10 @@
       "displayName": "NI-SCOPE Acquire Waveform (Py)",
       "serviceClass": "ni.examples.NIScopeAcquireWaveform_Python",
       "descriptionUrl": "",
-      "providedInterfaces": [ "ni.measurementlink.measurement.v1.MeasurementService" ],
+      "providedInterfaces": [
+        "ni.measurementlink.measurement.v1.MeasurementService",
+        "ni.measurementlink.measurement.v2.MeasurementService"
+      ],
       "path": "start.bat"
     }
   ]

--- a/examples/niscope_acquire_waveform/pyproject.toml
+++ b/examples/niscope_acquire_waveform/pyproject.toml
@@ -16,8 +16,7 @@ mypy = ">=1.0"
 grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies (requires poetry>=1.2).
 # niscope = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/niscope"}
-# TODO: Re-comment references below after we build a prerelease with enum support.
-ni-measurementlink-service = {path = "../..", develop = true}
+# ni-measurementlink-service = {path = "../..", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.2.0"]

--- a/examples/niscope_acquire_waveform/pyproject.toml
+++ b/examples/niscope_acquire_waveform/pyproject.toml
@@ -14,7 +14,7 @@ grpcio = "*"
 [tool.poetry.group.dev.dependencies]
 mypy = ">=1.0"
 grpc-stubs = "^1.53"
-# Uncomment to use prerelease dependencies (requires poetry>=1.2).
+# Uncomment to use prerelease dependencies.
 # niscope = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/niscope"}
 # ni-measurementlink-service = {path = "../..", develop = true}
 

--- a/examples/niscope_acquire_waveform/pyproject.toml
+++ b/examples/niscope_acquire_waveform/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-niscope = ">=1.4.3"
+niscope = { version = ">=1.4.4", extras = ["grpc"] }
 ni-measurementlink-service = {version = "^1.1.0-dev2", allow-prereleases = true}
 click = ">=7.1.2"
 grpcio = "*"

--- a/examples/niswitch_control_relays/NISwitchControlRelays.serviceconfig
+++ b/examples/niswitch_control_relays/NISwitchControlRelays.serviceconfig
@@ -4,7 +4,10 @@
       "displayName": "NI-SWITCH Control Relays (Py)",
       "serviceClass": "ni.examples.NISwitchControlRelays_Python",
       "descriptionUrl": "",
-      "providedInterfaces": [ "ni.measurementlink.measurement.v1.MeasurementService" ],
+      "providedInterfaces": [
+        "ni.measurementlink.measurement.v1.MeasurementService",
+        "ni.measurementlink.measurement.v2.MeasurementService"
+      ],
       "path": "start.bat"
     }
   ]

--- a/examples/niswitch_control_relays/pyproject.toml
+++ b/examples/niswitch_control_relays/pyproject.toml
@@ -16,8 +16,7 @@ mypy = ">=1.0"
 grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies (requires poetry>=1.2).
 # niswitch = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/niswitch"}
-# Uncomment once 1.1.0-dev2 is released
-ni-measurementlink-service = {path = "../..", develop = true}
+# ni-measurementlink-service = {path = "../..", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.2.0"]

--- a/examples/niswitch_control_relays/pyproject.toml
+++ b/examples/niswitch_control_relays/pyproject.toml
@@ -14,7 +14,7 @@ grpcio = "*"
 [tool.poetry.group.dev.dependencies]
 mypy = ">=1.0"
 grpc-stubs = "^1.53"
-# Uncomment to use prerelease dependencies (requires poetry>=1.2).
+# Uncomment to use prerelease dependencies.
 # niswitch = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/niswitch"}
 # ni-measurementlink-service = {path = "../..", develop = true}
 

--- a/examples/niswitch_control_relays/pyproject.toml
+++ b/examples/niswitch_control_relays/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-niswitch = ">=1.4.3"
+niswitch = { version = ">=1.4.4", extras = ["grpc"] }
 ni-measurementlink-service = {version = "^1.1.0-dev2", allow-prereleases = true}
 click = ">=7.1.2"
 grpcio = "*"

--- a/examples/nivisa_dmm_measurement/NIVisaDmmMeasurement.serviceconfig
+++ b/examples/nivisa_dmm_measurement/NIVisaDmmMeasurement.serviceconfig
@@ -4,7 +4,10 @@
       "displayName": "NI-VISA DMM Measurement (Py)",
       "serviceClass": "ni.examples.NIVisaDmmMeasurement_Python",
       "descriptionUrl": "",
-      "providedInterfaces": [ "ni.measurementlink.measurement.v1.MeasurementService" ],
+      "providedInterfaces": [
+        "ni.measurementlink.measurement.v1.MeasurementService",
+        "ni.measurementlink.measurement.v2.MeasurementService"
+      ],
       "path": "start.bat"
     }
   ]

--- a/examples/nivisa_dmm_measurement/pyproject.toml
+++ b/examples/nivisa_dmm_measurement/pyproject.toml
@@ -15,7 +15,7 @@ grpcio = "*"
 [tool.poetry.group.dev.dependencies]
 mypy = ">=1.0"
 grpc-stubs = "^1.53"
-# Uncomment to use prerelease dependencies (requires poetry>=1.2).
+# Uncomment to use prerelease dependencies.
 # ni-measurementlink-service = {path = "../..", develop = true}
 
 [build-system]

--- a/examples/nivisa_dmm_measurement/pyproject.toml
+++ b/examples/nivisa_dmm_measurement/pyproject.toml
@@ -16,8 +16,7 @@ grpcio = "*"
 mypy = ">=1.0"
 grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies (requires poetry>=1.2).
-# TODO: Re-comment references below after we build a prerelease with enum support.
-ni-measurementlink-service = {path = "../..", develop = true}
+# ni-measurementlink-service = {path = "../..", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.2.0"]

--- a/examples/sample_measurement/SampleMeasurement.serviceconfig
+++ b/examples/sample_measurement/SampleMeasurement.serviceconfig
@@ -4,7 +4,10 @@
       "displayName": "Sample Measurement (Py)",
       "serviceClass": "ni.examples.SampleMeasurement_Python",
       "descriptionUrl": "",
-      "providedInterfaces": [ "ni.measurementlink.measurement.v1.MeasurementService" ],
+      "providedInterfaces": [
+        "ni.measurementlink.measurement.v1.MeasurementService",
+        "ni.measurementlink.measurement.v2.MeasurementService"
+      ],
       "path": "start.bat"
     }
   ]

--- a/examples/sample_measurement/pyproject.toml
+++ b/examples/sample_measurement/pyproject.toml
@@ -12,7 +12,7 @@ click = ">=7.1.2"
 [tool.poetry.group.dev.dependencies]
 mypy = ">=1.0"
 grpc-stubs = "^1.53"
-# Uncomment to use prerelease dependencies (requires poetry>=1.2).
+# Uncomment to use prerelease dependencies.
 # ni-measurementlink-service = {path = "../..", develop = true}
 
 [build-system]

--- a/examples/sample_measurement/pyproject.toml
+++ b/examples/sample_measurement/pyproject.toml
@@ -13,8 +13,7 @@ click = ">=7.1.2"
 mypy = ">=1.0"
 grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies (requires poetry>=1.2).
-# TODO: Re-comment references below after we build a prerelease with enum support.
-ni-measurementlink-service = {path = "../..", develop = true}
+# ni-measurementlink-service = {path = "../..", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.2.0"]

--- a/examples/sample_streaming_measurement/pyproject.toml
+++ b/examples/sample_streaming_measurement/pyproject.toml
@@ -12,7 +12,7 @@ click = ">=7.1.2"
 [tool.poetry.group.dev.dependencies]
 mypy = ">=1.0"
 grpc-stubs = "^1.49.1"
-# Uncomment to use prerelease dependencies (requires poetry>=1.2).
+# Uncomment to use prerelease dependencies.
 # ni-measurementlink-service = {path = "../..", develop = true}
 
 [build-system]

--- a/examples/ui_progress_updates/pyproject.toml
+++ b/examples/ui_progress_updates/pyproject.toml
@@ -12,7 +12,7 @@ click = ">=7.1.2"
 [tool.poetry.group.dev.dependencies]
 mypy = ">=1.0"
 grpc-stubs = "^1.53"
-# Uncomment to use prerelease dependencies (requires poetry>=1.2).
+# Uncomment to use prerelease dependencies.
 # ni-measurementlink-service = {path = "../..", develop = true}
 
 [build-system]

--- a/ni_measurementlink_generator/ni_measurementlink_generator/templates/measurement.serviceconfig.mako
+++ b/ni_measurementlink_generator/ni_measurementlink_generator/templates/measurement.serviceconfig.mako
@@ -6,7 +6,10 @@
       "displayName": "${display_name}",
       "serviceClass": "${service_class}",
       "descriptionUrl": "${description_url}",
-      "providedInterfaces": [ "ni.measurementlink.measurement.v1.MeasurementService" ],
+      "providedInterfaces": [
+        "ni.measurementlink.measurement.v1.MeasurementService",
+        "ni.measurementlink.measurement.v2.MeasurementService"
+      ],
       "path": "start.bat"
     }
   ]

--- a/ni_measurementlink_generator/tests/test_assets/example_renders/SampleMeasurement.serviceconfig
+++ b/ni_measurementlink_generator/tests/test_assets/example_renders/SampleMeasurement.serviceconfig
@@ -4,7 +4,10 @@
       "displayName": "Sample Measurement",
       "serviceClass": "SampleMeasurement_Python",
       "descriptionUrl": "https://www.example.com/SampleMeasurement.html",
-      "providedInterfaces": [ "ni.measurementlink.measurement.v1.MeasurementService" ],
+      "providedInterfaces": [
+        "ni.measurementlink.measurement.v1.MeasurementService",
+        "ni.measurementlink.measurement.v2.MeasurementService"
+      ],
       "path": "start.bat"
     }
   ]


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update examples to download `ni-measurementlink-service` from PyPI.

Update MI examples to specify `extras = ["grpc"]` for nimi-python dependencies.

Update example `.serviceconfig` files to advertise the measurement v2 interface.

Remove a comment about Poetry 1.2 being required for `path = "../.."`. The example pyproject.toml files now use other Poetry 1.2+ features, so this is no longer relevant.

This will be cherry-picked into releases/1.1.

### Why should this Pull Request be merged?

Prepare for release

Fixes #239 

### What testing has been done?

Ran `install_examples.py` and manually tested all MI examples.