### PR TITLE
generator: Generate JSON using the `json` module

### DIFF
--- a/ni_measurementlink_generator/ni_measurementlink_generator/templates/measurement.serviceconfig.mako
+++ b/ni_measurementlink_generator/ni_measurementlink_generator/templates/measurement.serviceconfig.mako
@@ -1,16 +1,20 @@
 <%page args="display_name, service_class, description_url"/>\
-\
-{
-  "services": [
-    {
-      "displayName": "${display_name}",
-      "serviceClass": "${service_class}",
-      "descriptionUrl": "${description_url}",
-      "providedInterfaces": [
-        "ni.measurementlink.measurement.v1.MeasurementService",
-        "ni.measurementlink.measurement.v2.MeasurementService"
-      ],
-      "path": "start.bat"
+<%
+    import json
+
+    service_config = {
+        "services": [
+            {
+                "displayName": display_name,
+                "serviceClass": service_class,
+                "descriptionUrl": description_url,
+                "providedInterfaces": [
+                    "ni.measurementlink.measurement.v1.MeasurementService",
+                    "ni.measurementlink.measurement.v2.MeasurementService",                   
+                ],
+                "path": "start.bat",
+            }
+        ]
     }
-  ]
-}
+%>\
+${json.dumps(service_config, indent=2)}


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Generate JSON using the `json` module instead of manually generating it in the template.

### Why should this Pull Request be merged?

Always produces well-formed JSON, even when string escaping is required.

Simplifies maintenance: no need to quote strings, avoid trailing commas, etc.

### What testing has been done?

Ran unit tests.