### PR TITLE
[releases/1.1] examples: Depend on released dependencies

### DIFF
--- a/examples/nidaqmx_analog_input/pyproject.toml
+++ b/examples/nidaqmx_analog_input/pyproject.toml
@@ -6,8 +6,8 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-nidaqmx = { version = ">=0.8.0-dev0", extras = ["grpc"], allow-prereleases = true }
-ni-measurementlink-service = {version = "^1.1.0-dev2", allow-prereleases = true}
+nidaqmx = { version = ">=0.8.0", extras = ["grpc"] }
+ni-measurementlink-service = {version = "^1.1.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/nidcpower_source_dc_voltage/pyproject.toml
+++ b/examples/nidcpower_source_dc_voltage/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidcpower = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurementlink-service = {version = "^1.1.0-dev2", allow-prereleases = true}
+ni-measurementlink-service = {version = "^1.1.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/nidigital_spi/pyproject.toml
+++ b/examples/nidigital_spi/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidigital = ">=1.4.4"
-ni-measurementlink-service = {version = "^1.1.0-dev2", allow-prereleases = true}
+ni-measurementlink-service = {version = "^1.1.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/nidmm_measurement/pyproject.toml
+++ b/examples/nidmm_measurement/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidmm = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurementlink-service = {version = "^1.1.0-dev2", allow-prereleases = true}
+ni-measurementlink-service = {version = "^1.1.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/nifgen_standard_function/pyproject.toml
+++ b/examples/nifgen_standard_function/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nifgen = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurementlink-service = {version = "^1.1.0-dev2", allow-prereleases = true}
+ni-measurementlink-service = {version = "^1.1.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/niscope_acquire_waveform/pyproject.toml
+++ b/examples/niscope_acquire_waveform/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 niscope = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurementlink-service = {version = "^1.1.0-dev2", allow-prereleases = true}
+ni-measurementlink-service = {version = "^1.1.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/niswitch_control_relays/pyproject.toml
+++ b/examples/niswitch_control_relays/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 niswitch = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurementlink-service = {version = "^1.1.0-dev2", allow-prereleases = true}
+ni-measurementlink-service = {version = "^1.1.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/nivisa_dmm_measurement/pyproject.toml
+++ b/examples/nivisa_dmm_measurement/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-ni-measurementlink-service = {version = "^1.1.0-dev2", allow-prereleases = true}
+ni-measurementlink-service = {version = "^1.1.0"}
 PyVISA = "^1.13.0"
 PyVISA-sim = "^0.5.1"
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558

--- a/examples/sample_measurement/pyproject.toml
+++ b/examples/sample_measurement/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-ni-measurementlink-service = {version = "^1.1.0-dev2", allow-prereleases = true}
+ni-measurementlink-service = {version = "^1.1.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/sample_streaming_measurement/pyproject.toml
+++ b/examples/sample_streaming_measurement/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-ni-measurementlink-service = {version = "^1.1.0-dev0", allow-prereleases = true}
+ni-measurementlink-service = {version = "^1.1.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/ui_progress_updates/pyproject.toml
+++ b/examples/ui_progress_updates/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-ni-measurementlink-service = {version = "^1.1.0-dev0", allow-prereleases = true}
+ni-measurementlink-service = {version = "^1.1.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 
 [tool.poetry.group.dev.dependencies]

--- a/ni_measurementlink_generator/pyproject.toml
+++ b/ni_measurementlink_generator/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ni_measurementlink_generator"
-version = "1.1.0-dev2"
+version = "1.1.0"
 description = "MeasurementLink Code Generator for Python"
 authors = ["NI <opensource@ni.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ exclude = '''
 
 [tool.poetry]
 name = "ni_measurementlink_service"
-version = "1.1.0-dev2"
+version = "1.1.0"
 description = "MeasurementLink Support for Python"
 authors = ["NI <opensource@ni.com>"]
 readme = "README.md" # apply the repo readme to the package as well


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update dependency versions and remove `allow-prereleases`.

Update version number to 1.1.0 so it will be correct in the source zip file.

### Why should this Pull Request be merged?

Ensure that the examples in the released zip file do not automatically download pre-release versions of `ni-measurementlink-service`, `nidaqmx`, etc. from PyPI.

### What testing has been done?

This won't pass the examples check because the dependencies aren't actually released yet.