### PR TITLE
examples: Fix mypy errors in decorators (Mypy static analysis (examples) check)

### DIFF
--- a/examples/nidaqmx_analog_input/_helpers.py
+++ b/examples/nidaqmx_analog_input/_helpers.py
@@ -206,18 +206,20 @@ def verbosity_option(func: F) -> F:
         "verbosity",
         count=True,
         help="Enable verbose logging. Repeat to increase verbosity.",
-    )(func)
+    )(
+        func  # type: ignore
+    )
 
 
 def grpc_device_options(func: F) -> F:
     """Decorator for NI gRPC Device Server command line options."""
-    use_grpc_device_option = click.option(
+    use_grpc_device_option: Any = click.option(
         "--use-grpc-device/--no-use-grpc-device",
         default=True,
         is_flag=True,
         help="Use the NI gRPC Device Server.",
     )
-    grpc_device_address_option = click.option(
+    grpc_device_address_option: Any = click.option(
         "--grpc-device-address",
         default="",
         help="NI gRPC Device Server address (e.g. localhost:31763). If unspecified, use the discovery service to resolve the address.",

--- a/examples/nidcpower_source_dc_voltage/_helpers.py
+++ b/examples/nidcpower_source_dc_voltage/_helpers.py
@@ -206,18 +206,20 @@ def verbosity_option(func: F) -> F:
         "verbosity",
         count=True,
         help="Enable verbose logging. Repeat to increase verbosity.",
-    )(func)
+    )(
+        func  # type: ignore
+    )
 
 
 def grpc_device_options(func: F) -> F:
     """Decorator for NI gRPC Device Server command line options."""
-    use_grpc_device_option = click.option(
+    use_grpc_device_option: Any = click.option(
         "--use-grpc-device/--no-use-grpc-device",
         default=True,
         is_flag=True,
         help="Use the NI gRPC Device Server.",
     )
-    grpc_device_address_option = click.option(
+    grpc_device_address_option: Any = click.option(
         "--grpc-device-address",
         default="",
         help="NI gRPC Device Server address (e.g. localhost:31763). If unspecified, use the discovery service to resolve the address.",

--- a/examples/nidigital_spi/_helpers.py
+++ b/examples/nidigital_spi/_helpers.py
@@ -206,18 +206,20 @@ def verbosity_option(func: F) -> F:
         "verbosity",
         count=True,
         help="Enable verbose logging. Repeat to increase verbosity.",
-    )(func)
+    )(
+        func  # type: ignore
+    )
 
 
 def grpc_device_options(func: F) -> F:
     """Decorator for NI gRPC Device Server command line options."""
-    use_grpc_device_option = click.option(
+    use_grpc_device_option: Any = click.option(
         "--use-grpc-device/--no-use-grpc-device",
         default=True,
         is_flag=True,
         help="Use the NI gRPC Device Server.",
     )
-    grpc_device_address_option = click.option(
+    grpc_device_address_option: Any = click.option(
         "--grpc-device-address",
         default="",
         help="NI gRPC Device Server address (e.g. localhost:31763). If unspecified, use the discovery service to resolve the address.",

--- a/examples/nidmm_measurement/_helpers.py
+++ b/examples/nidmm_measurement/_helpers.py
@@ -206,18 +206,20 @@ def verbosity_option(func: F) -> F:
         "verbosity",
         count=True,
         help="Enable verbose logging. Repeat to increase verbosity.",
-    )(func)
+    )(
+        func  # type: ignore
+    )
 
 
 def grpc_device_options(func: F) -> F:
     """Decorator for NI gRPC Device Server command line options."""
-    use_grpc_device_option = click.option(
+    use_grpc_device_option: Any = click.option(
         "--use-grpc-device/--no-use-grpc-device",
         default=True,
         is_flag=True,
         help="Use the NI gRPC Device Server.",
     )
-    grpc_device_address_option = click.option(
+    grpc_device_address_option: Any = click.option(
         "--grpc-device-address",
         default="",
         help="NI gRPC Device Server address (e.g. localhost:31763). If unspecified, use the discovery service to resolve the address.",

--- a/examples/nifgen_standard_function/_helpers.py
+++ b/examples/nifgen_standard_function/_helpers.py
@@ -206,18 +206,20 @@ def verbosity_option(func: F) -> F:
         "verbosity",
         count=True,
         help="Enable verbose logging. Repeat to increase verbosity.",
-    )(func)
+    )(
+        func  # type: ignore
+    )
 
 
 def grpc_device_options(func: F) -> F:
     """Decorator for NI gRPC Device Server command line options."""
-    use_grpc_device_option = click.option(
+    use_grpc_device_option: Any = click.option(
         "--use-grpc-device/--no-use-grpc-device",
         default=True,
         is_flag=True,
         help="Use the NI gRPC Device Server.",
     )
-    grpc_device_address_option = click.option(
+    grpc_device_address_option: Any = click.option(
         "--grpc-device-address",
         default="",
         help="NI gRPC Device Server address (e.g. localhost:31763). If unspecified, use the discovery service to resolve the address.",

--- a/examples/niscope_acquire_waveform/_helpers.py
+++ b/examples/niscope_acquire_waveform/_helpers.py
@@ -206,18 +206,20 @@ def verbosity_option(func: F) -> F:
         "verbosity",
         count=True,
         help="Enable verbose logging. Repeat to increase verbosity.",
-    )(func)
+    )(
+        func  # type: ignore
+    )
 
 
 def grpc_device_options(func: F) -> F:
     """Decorator for NI gRPC Device Server command line options."""
-    use_grpc_device_option = click.option(
+    use_grpc_device_option: Any = click.option(
         "--use-grpc-device/--no-use-grpc-device",
         default=True,
         is_flag=True,
         help="Use the NI gRPC Device Server.",
     )
-    grpc_device_address_option = click.option(
+    grpc_device_address_option: Any = click.option(
         "--grpc-device-address",
         default="",
         help="NI gRPC Device Server address (e.g. localhost:31763). If unspecified, use the discovery service to resolve the address.",

--- a/examples/niswitch_control_relays/_helpers.py
+++ b/examples/niswitch_control_relays/_helpers.py
@@ -206,18 +206,20 @@ def verbosity_option(func: F) -> F:
         "verbosity",
         count=True,
         help="Enable verbose logging. Repeat to increase verbosity.",
-    )(func)
+    )(
+        func  # type: ignore
+    )
 
 
 def grpc_device_options(func: F) -> F:
     """Decorator for NI gRPC Device Server command line options."""
-    use_grpc_device_option = click.option(
+    use_grpc_device_option: Any = click.option(
         "--use-grpc-device/--no-use-grpc-device",
         default=True,
         is_flag=True,
         help="Use the NI gRPC Device Server.",
     )
-    grpc_device_address_option = click.option(
+    grpc_device_address_option: Any = click.option(
         "--grpc-device-address",
         default="",
         help="NI gRPC Device Server address (e.g. localhost:31763). If unspecified, use the discovery service to resolve the address.",

--- a/examples/nivisa_dmm_measurement/_helpers.py
+++ b/examples/nivisa_dmm_measurement/_helpers.py
@@ -206,18 +206,20 @@ def verbosity_option(func: F) -> F:
         "verbosity",
         count=True,
         help="Enable verbose logging. Repeat to increase verbosity.",
-    )(func)
+    )(
+        func  # type: ignore
+    )
 
 
 def grpc_device_options(func: F) -> F:
     """Decorator for NI gRPC Device Server command line options."""
-    use_grpc_device_option = click.option(
+    use_grpc_device_option: Any = click.option(
         "--use-grpc-device/--no-use-grpc-device",
         default=True,
         is_flag=True,
         help="Use the NI gRPC Device Server.",
     )
-    grpc_device_address_option = click.option(
+    grpc_device_address_option: Any = click.option(
         "--grpc-device-address",
         default="",
         help="NI gRPC Device Server address (e.g. localhost:31763). If unspecified, use the discovery service to resolve the address.",

--- a/examples/sample_measurement/measurement.py
+++ b/examples/sample_measurement/measurement.py
@@ -74,7 +74,7 @@ def measure(float_input, double_array_input, bool_input, string_input, enum_inpu
     )
 
 
-@click.command
+@click.command  # type: ignore
 @click.option(
     "-v",
     "--verbose",

--- a/examples/sample_streaming_measurement/measurement.py
+++ b/examples/sample_streaming_measurement/measurement.py
@@ -75,7 +75,7 @@ def measure(
     logging.info("Completed measurement")
 
 
-@click.command
+@click.command  # type: ignore
 @click.option(
     "-v",
     "--verbose",

--- a/examples/ui_progress_updates/measurement.py
+++ b/examples/ui_progress_updates/measurement.py
@@ -85,7 +85,7 @@ def _generate_random_numbers(count: int) -> Generator[float, None, None]:
         yield RANDOM_NUMBER_RANGE * (2.0 * random.random() - 1.0)
 
 
-@click.command
+@click.command  # type: ignore
 @click.option(
     "-v",
     "--verbose",


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Add type annotation for decorators used in example measurements.
- Ignore type check for `verbosity_option` decorator function argument.

### Why should this Pull Request be merged?

- Fixes the build failure happening in open PR's
https://github.com/ni/measurementlink-python/pull/323
https://github.com/ni/measurementlink-python/pull/315

### What testing has been done?

- Ran `mypy` to verify no more incompatible issues.