### PR TITLE
examples: Disallow click version 8.1.4

### DIFF
--- a/examples/nidaqmx_analog_input/pyproject.toml
+++ b/examples/nidaqmx_analog_input/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 python = "^3.8"
 nidaqmx = { version = ">=0.8.0-dev0", extras = ["grpc"], allow-prereleases = true }
 ni-measurementlink-service = {version = "^1.1.0-dev2", allow-prereleases = true}
-click = ">=7.1.2"
+click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 
 [tool.poetry.group.dev.dependencies]
 mypy = ">=1.0"

--- a/examples/nidcpower_source_dc_voltage/pyproject.toml
+++ b/examples/nidcpower_source_dc_voltage/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 python = "^3.8"
 nidcpower = { version = ">=1.4.4", extras = ["grpc"] }
 ni-measurementlink-service = {version = "^1.1.0-dev2", allow-prereleases = true}
-click = ">=7.1.2"
+click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/nidigital_spi/pyproject.toml
+++ b/examples/nidigital_spi/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 python = "^3.8"
 nidigital = ">=1.4.4"
 ni-measurementlink-service = {version = "^1.1.0-dev2", allow-prereleases = true}
-click = ">=7.1.2"
+click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/nidmm_measurement/pyproject.toml
+++ b/examples/nidmm_measurement/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 python = "^3.8"
 nidmm = { version = ">=1.4.4", extras = ["grpc"] }
 ni-measurementlink-service = {version = "^1.1.0-dev2", allow-prereleases = true}
-click = ">=7.1.2"
+click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/nifgen_standard_function/pyproject.toml
+++ b/examples/nifgen_standard_function/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 python = "^3.8"
 nifgen = { version = ">=1.4.4", extras = ["grpc"] }
 ni-measurementlink-service = {version = "^1.1.0-dev2", allow-prereleases = true}
-click = ">=7.1.2"
+click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/niscope_acquire_waveform/pyproject.toml
+++ b/examples/niscope_acquire_waveform/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 python = "^3.8"
 niscope = { version = ">=1.4.4", extras = ["grpc"] }
 ni-measurementlink-service = {version = "^1.1.0-dev2", allow-prereleases = true}
-click = ">=7.1.2"
+click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/niswitch_control_relays/pyproject.toml
+++ b/examples/niswitch_control_relays/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 python = "^3.8"
 niswitch = { version = ">=1.4.4", extras = ["grpc"] }
 ni-measurementlink-service = {version = "^1.1.0-dev2", allow-prereleases = true}
-click = ">=7.1.2"
+click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/nivisa_dmm_measurement/pyproject.toml
+++ b/examples/nivisa_dmm_measurement/pyproject.toml
@@ -9,7 +9,7 @@ python = "^3.8"
 ni-measurementlink-service = {version = "^1.1.0-dev2", allow-prereleases = true}
 PyVISA = "^1.13.0"
 PyVISA-sim = "^0.5.1"
-click = ">=7.1.2"
+click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/sample_measurement/pyproject.toml
+++ b/examples/sample_measurement/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 ni-measurementlink-service = {version = "^1.1.0-dev2", allow-prereleases = true}
-click = ">=7.1.2"
+click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 
 [tool.poetry.group.dev.dependencies]
 mypy = ">=1.0"

--- a/examples/sample_streaming_measurement/pyproject.toml
+++ b/examples/sample_streaming_measurement/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 ni-measurementlink-service = {version = "^1.1.0-dev0", allow-prereleases = true}
-click = ">=7.1.2"
+click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 
 [tool.poetry.group.dev.dependencies]
 mypy = ">=1.0"

--- a/examples/ui_progress_updates/pyproject.toml
+++ b/examples/ui_progress_updates/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 ni-measurementlink-service = {version = "^1.1.0-dev0", allow-prereleases = true}
-click = ">=7.1.2"
+click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 
 [tool.poetry.group.dev.dependencies]
 mypy = ">=1.0"


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update the examples and ni-measurementlink-generator to disallow click version 8.1.4, because it causes mypy errors:

```
_helpers.py:209: error: Argument 1 has incompatible type "F"; expected <nothing>  [arg-type]
_helpers.py:214: error: Need type annotation for "use_grpc_device_option"  [var-annotated]
_helpers.py:220: error: Need type annotation for "grpc_device_address_option"  [var-annotated]
```

### Why should this Pull Request be merged?

Fix "check examples" workflow.

### What testing has been done?

PR build