### PR TITLE
service: Add missing type hints and use __all__ to explicitly re-export names

### DIFF
--- a/ni_measurementlink_service/__init__.py
+++ b/ni_measurementlink_service/__init__.py
@@ -1,17 +1,25 @@
 """MeasurementLink Support for Python."""
 import logging
 
-from ni_measurementlink_service import (  # noqa: F401 - imported but unused
+from ni_measurementlink_service import (
     session_management,
 )
-from ni_measurementlink_service.measurement.info import (  # noqa: F401 - imported but unused
+from ni_measurementlink_service.measurement.info import (
     DataType,
     MeasurementInfo,
     ServiceInfo,
 )
-from ni_measurementlink_service.measurement.service import (  # noqa: F401 - imported but unused
+from ni_measurementlink_service.measurement.service import (
     MeasurementService,
 )
+
+__all__ = [
+    "session_management",
+    "DataType",
+    "MeasurementInfo",
+    "ServiceInfo",
+    "MeasurementService",
+]
 
 _logger = logging.getLogger(__name__)
 _logger.addHandler(logging.NullHandler())

--- a/ni_measurementlink_service/_internal/discovery_client.py
+++ b/ni_measurementlink_service/_internal/discovery_client.py
@@ -62,7 +62,9 @@ class DiscoveryClient:
 
     """
 
-    def __init__(self, stub: Optional[discovery_service_pb2_grpc.DiscoveryServiceStub] = None):
+    def __init__(
+        self, stub: Optional[discovery_service_pb2_grpc.DiscoveryServiceStub] = None
+    ) -> None:
         """Initialize the Discovery Client with provided registry service stub.
 
         Args:

--- a/ni_measurementlink_service/measurement/service.py
+++ b/ni_measurementlink_service/measurement/service.py
@@ -8,7 +8,7 @@ from os import path
 from pathlib import Path
 from threading import Lock
 from types import TracebackType
-from typing import Any, Callable, Dict, List, Optional, Type, TypeVar
+from typing import Any, Callable, Dict, List, Literal, Optional, Type, TypeVar
 
 import grpc
 
@@ -80,7 +80,7 @@ class GrpcChannelPool(object):
         exc_type: Optional[Type[BaseException]],
         exc_val: Optional[BaseException],
         traceback: Optional[TracebackType],
-    ) -> bool:
+    ) -> Literal[False]:
         """Exit the runtime context of the GrpcChannelPool."""
         self.close()
         return False
@@ -399,7 +399,7 @@ class MeasurementService:
         exc_type: Optional[Type[BaseException]],
         exc_val: Optional[BaseException],
         traceback: Optional[TracebackType],
-    ) -> bool:
+    ) -> Literal[False]:
         """Exit the runtime context related to the measurement service."""
         self.close_service()
         return False

--- a/ni_measurementlink_service/measurement/service.py
+++ b/ni_measurementlink_service/measurement/service.py
@@ -7,6 +7,7 @@ from enum import Enum
 from os import path
 from pathlib import Path
 from threading import Lock
+from types import TracebackType
 from typing import Any, Callable, Dict, List, Optional, Type, TypeVar
 
 import grpc
@@ -65,7 +66,7 @@ _TMeasurementService = TypeVar("_TMeasurementService", bound="MeasurementService
 class GrpcChannelPool(object):
     """Class that manages gRPC channel lifetimes."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the GrpcChannelPool object."""
         self._lock: Lock = Lock()
         self._channel_cache: Dict[str, grpc.Channel] = {}
@@ -74,9 +75,15 @@ class GrpcChannelPool(object):
         """Enter the runtime context of the GrpcChannelPool."""
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> bool:
         """Exit the runtime context of the GrpcChannelPool."""
         self.close()
+        return False
 
     def get_channel(self, target: str) -> grpc.Channel:
         """Return a gRPC channel.
@@ -193,8 +200,8 @@ class MeasurementService:
             annotations=service_annotations_string,
         )
 
-        self.configuration_parameter_list: list = []
-        self.output_parameter_list: list = []
+        self.configuration_parameter_list: List[Any] = []
+        self.output_parameter_list: List[Any] = []
         self.grpc_service = GrpcService()
         self.context: MeasurementContext = MeasurementContext()
         self.discovery_client: DiscoveryClient = self.grpc_service.discovery_client
@@ -387,9 +394,15 @@ class MeasurementService:
         """Enter the runtime context related to the measurement service."""
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> bool:
         """Exit the runtime context related to the measurement service."""
         self.close_service()
+        return False
 
     def get_channel(self, provided_interface: str, service_class: str = "") -> grpc.Channel:
         """Return gRPC channel to specified service.

--- a/ni_measurementlink_service/session_management.py
+++ b/ni_measurementlink_service/session_management.py
@@ -4,15 +4,8 @@ from __future__ import annotations
 import abc
 import warnings
 from functools import cached_property
-from typing import (
-    Any,
-    Iterable,
-    List,
-    NamedTuple,
-    Optional,
-    Sequence,
-    TypeVar,
-)
+from types import TracebackType
+from typing import Any, Iterable, List, NamedTuple, Optional, Sequence, Type, TypeVar
 
 import grpc
 from deprecation import DeprecatedWarning
@@ -183,7 +176,7 @@ class BaseReservation(abc.ABC):
         self,
         session_manager: Client,
         session_info: Sequence[session_management_service_pb2.SessionInformation],
-    ):
+    ) -> None:
         """Initialize reservation object."""
         self._session_manager = session_manager
         self._session_info = session_info
@@ -192,12 +185,17 @@ class BaseReservation(abc.ABC):
         """Context management protocol. Returns self."""
         return self
 
-    def __exit__(self, *exc):
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> bool:
         """Context management protocol. Calls unreserve()."""
         self.unreserve()
         return False
 
-    def unreserve(self):
+    def unreserve(self) -> None:
         """Unreserve sessions."""
         self._session_manager._unreserve_sessions(self._session_info)
 
@@ -240,7 +238,7 @@ def __getattr__(name: str) -> Any:
 class Client(object):
     """Class that manages driver sessions."""
 
-    def __init__(self, *, grpc_channel: grpc.Channel):
+    def __init__(self, *, grpc_channel: grpc.Channel) -> None:
         """Initialize session manangement client."""
         self._client: session_management_service_pb2_grpc.SessionManagementServiceStub = (
             session_management_service_pb2_grpc.SessionManagementServiceStub(grpc_channel)
@@ -388,12 +386,12 @@ class Client(object):
 
     def _unreserve_sessions(
         self, session_info: Iterable[session_management_service_pb2.SessionInformation]
-    ):
+    ) -> None:
         """Unreserves sessions so they can be accessed by other clients."""
         request = session_management_service_pb2.UnreserveSessionsRequest(sessions=session_info)
         self._client.UnreserveSessions(request)
 
-    def register_sessions(self, session_info: Iterable[SessionInformation]):
+    def register_sessions(self, session_info: Iterable[SessionInformation]) -> None:
         """Register the sessions with the Session Manager.
 
         Indicates that the sessions are open and will need to be closed later.
@@ -430,7 +428,7 @@ class Client(object):
         )
         self._client.RegisterSessions(request)
 
-    def unregister_sessions(self, session_info: Iterable[SessionInformation]):
+    def unregister_sessions(self, session_info: Iterable[SessionInformation]) -> None:
         """Unregisters the sessions from the Session Manager.
 
         Indicates that the sessions have been closed and will need to be reopened before they can be

--- a/ni_measurementlink_service/session_management.py
+++ b/ni_measurementlink_service/session_management.py
@@ -5,7 +5,7 @@ import abc
 import warnings
 from functools import cached_property
 from types import TracebackType
-from typing import Any, Iterable, List, NamedTuple, Optional, Sequence, Type, TypeVar
+from typing import Any, Iterable, List, Literal, NamedTuple, Optional, Sequence, Type, TypeVar
 
 import grpc
 from deprecation import DeprecatedWarning
@@ -190,7 +190,7 @@ class BaseReservation(abc.ABC):
         exc_type: Optional[Type[BaseException]],
         exc_val: Optional[BaseException],
         traceback: Optional[TracebackType],
-    ) -> bool:
+    ) -> Literal[False]:
         """Context management protocol. Calls unreserve()."""
         self.unreserve()
         return False


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add missing type hints, identified with `pyright --verifytypes ni_measurementlink_service`.

Update `__init__.py` to use `__all__` to explicitly re-export imported names. This tells tools like flake8, mypy, and pyright that these imports are re-exported and should be considered part of the public API.

### Why should this Pull Request be merged?

Increase coverage and accuracy of type hints.

### What testing has been done?

Ran `pyright` on `ni_measurementlink_service` as well as the `nidcpower_source_dc_voltage` example. It still produces a lot of errors for partially unknown types and some other conditions, so I'm not ready to add it the GitHub check workflows.