### PR TITLE
Fix double quotes on Annotations

### DIFF
--- a/ni_measurementlink_service/measurement/service.py
+++ b/ni_measurementlink_service/measurement/service.py
@@ -181,8 +181,13 @@ class MeasurementService:
             ui_file_paths=ui_file_paths,
         )
 
+        def removeDoubleQuote(string: str):
+            if string and string[0] == string[-1] == '"':
+                    string = string[1:-1]
+            return string
+
         service_annotations_string = {
-            key: json.dumps(value, separators=(",", ":"))
+            key: removeDoubleQuote(json.dumps(value, separators=(",", ":")))
             for key, value in service.get("annotations", {}).items()
         }
 

--- a/ni_measurementlink_service/measurement/service.py
+++ b/ni_measurementlink_service/measurement/service.py
@@ -181,13 +181,14 @@ class MeasurementService:
             ui_file_paths=ui_file_paths,
         )
 
-        def process_annotations(value: object):
+        def convert_value_to_str(value: object) -> str:
             if isinstance(value, str):
                 return value
             return json.dumps(value, separators=(",", ":"))
 
         service_annotations_string = {
-            key: process_annotations(value) for key, value in service.get("annotations", {}).items()
+            key: convert_value_to_str(value)
+            for key, value in service.get("annotations", {}).items()
         }
 
         self.service_info = ServiceInfo(

--- a/ni_measurementlink_service/measurement/service.py
+++ b/ni_measurementlink_service/measurement/service.py
@@ -181,13 +181,13 @@ class MeasurementService:
             ui_file_paths=ui_file_paths,
         )
 
-        def removeDoubleQuote(string: str):
+        def remove_double_quotes(string: str):
             if string and string[0] == string[-1] == '"':
                 string = string[1:-1]
             return string
 
         service_annotations_string = {
-            key: removeDoubleQuote(json.dumps(value, separators=(",", ":")))
+            key: remove_double_quotes(json.dumps(value, separators=(",", ":")))
             for key, value in service.get("annotations", {}).items()
         }
 

--- a/ni_measurementlink_service/measurement/service.py
+++ b/ni_measurementlink_service/measurement/service.py
@@ -183,7 +183,7 @@ class MeasurementService:
 
         def removeDoubleQuote(string: str):
             if string and string[0] == string[-1] == '"':
-                    string = string[1:-1]
+                string = string[1:-1]
             return string
 
         service_annotations_string = {

--- a/ni_measurementlink_service/measurement/service.py
+++ b/ni_measurementlink_service/measurement/service.py
@@ -181,14 +181,13 @@ class MeasurementService:
             ui_file_paths=ui_file_paths,
         )
 
-        def remove_double_quotes(string: str):
-            if string and string[0] == string[-1] == '"':
-                string = string[1:-1]
-            return string
+        def process_annotations(value: object):
+            if isinstance(value, str):
+                return value
+            return json.dumps(value, separators=(",", ":"))
 
         service_annotations_string = {
-            key: remove_double_quotes(json.dumps(value, separators=(",", ":")))
-            for key, value in service.get("annotations", {}).items()
+            key: process_annotations(value) for key, value in service.get("annotations", {}).items()
         }
 
         self.service_info = ServiceInfo(

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -261,8 +261,8 @@ no_annotations: typing.Dict[str, str] = {}
                 "ni.measurementlink.measurement.v2.MeasurementService",
             ],
             {
-                "ni/service.description": '"Measure inrush current with a shorted load and validate results against configured limits."',
-                "ni/service.collection": '"CurrentTests.Inrush"',
+                "ni/service.description": "Measure inrush current with a shorted load and validate results against configured limits.",
+                "ni/service.collection": "CurrentTests.Inrush",
                 "ni/service.tags": '["powerup","current"]',
             },
         ),
@@ -279,7 +279,7 @@ no_annotations: typing.Dict[str, str] = {}
         (
             "example.OnlyCollection.serviceconfig",
             ["ni.measurementlink.measurement.v2.MeasurementService"],
-            {"ni/service.collection": '"CurrentTests.Inrush"'},
+            {"ni/service.collection": "CurrentTests.Inrush"},
         ),
         (
             "example.OnlyTags.serviceconfig",
@@ -290,7 +290,7 @@ no_annotations: typing.Dict[str, str] = {}
             "example.AllAnnotations.serviceconfig",
             ["ni.measurementlink.measurement.v2.MeasurementService"],
             {
-                "ni/service.description": '"Testing extra Client info"',
+                "ni/service.description": "Testing extra Client info",
                 "client/extra.NumberID": "500",
                 "client/extra.Parts": '["A25898","A25412"]',
                 "client/extra.GroupName": '{"SpeakerType":"true","PhoneType":"false"}',
@@ -300,8 +300,8 @@ no_annotations: typing.Dict[str, str] = {}
             "example.CustomAnnotations.serviceconfig",
             ["ni.measurementlink.measurement.v1.MeasurementService"],
             {
-                "description": '"An annotated test measurement service."',
-                "collection": '"Tests.Measurements"',
+                "description": "An annotated test measurement service.",
+                "collection": "Tests.Measurements",
                 "tags": '["test","measurement"]',
                 "custom": '{"foo":"bar","baz":["qux","quux","quuux"],"snork":{"blarg":"flarp","oogle":'
                 + '["foogle","boogle"],"ork":["zork","gork","bork"]}}',


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Removes the double quotes (") from the annotations whenever they are a string. 

The problem happened because - our Annotations are not all strings we allowed arrays for  Tags and wanted to allow customers to add dictionaries too.  I am using "json.dumps" to help manage that, but the problem is that it also adds quotes to the strings. I tried multiple fixes but this was the simplest I can come up. 

### Why should this Pull Request be merged?

We do not want to display the description or the Title with double quotes. 

### What testing has been done?

Fix and reran tests. 
Manually look at the example: 

![image](https://github.com/ni/measurementlink-python/assets/111389775/9618e851-1a65-4ea6-a949-b6a8f10bca3c)
![image](https://github.com/ni/measurementlink-python/assets/111389775/effe97da-15c4-4356-b4fc-9790eaf304f0)
