### PR TITLE
discovery_client: When a python measurement starts discovery service, hide discovery service logs

### DIFF
--- a/ni_measurementlink_service/_internal/discovery_client.py
+++ b/ni_measurementlink_service/_internal/discovery_client.py
@@ -162,6 +162,7 @@ class DiscoveryClient:
                 _logger.info("Successfully unregistered with discovery service.")
             else:
                 _logger.info("Not registered with discovery service.")
+                return False
         except grpc.RpcError as e:
             if e.code() == grpc.StatusCode.UNAVAILABLE:
                 _logger.error(

--- a/ni_measurementlink_service/_internal/discovery_client.py
+++ b/ni_measurementlink_service/_internal/discovery_client.py
@@ -274,7 +274,7 @@ def _start_service(exe_file_path: pathlib.PurePath, key_file_path: pathlib.Path)
                 raise TimeoutError("Timed out waiting for discovery service to start")
             time.sleep(_START_SERVICE_POLLING_INTERVAL)
     except FileNotFoundError:
-       raise Exception
+        raise Exception
 
 
 def _service_already_running(key_file_path: pathlib.Path) -> bool:

--- a/ni_measurementlink_service/_internal/discovery_client.py
+++ b/ni_measurementlink_service/_internal/discovery_client.py
@@ -135,6 +135,7 @@ class DiscoveryClient:
             _logger.error(
                 "Unable to register with discovery service. Possible reason: discovery service not running."
             )
+            return False
         except Exception:
             _logger.exception("Error in registering with discovery service.")
             return False

--- a/ni_measurementlink_service/_internal/discovery_client.py
+++ b/ni_measurementlink_service/_internal/discovery_client.py
@@ -254,19 +254,27 @@ def _key_file_exists(key_file_path: pathlib.Path) -> bool:
 
 def _start_service(exe_file_path: pathlib.PurePath, key_file_path: pathlib.Path) -> None:
     """Starts the service at the specified path and wait for the service to get up and running."""
-    subprocess.Popen([exe_file_path], cwd=exe_file_path.parent)
-    # After the execution of process, check for key file existence in the path
-    # stop checking after 30 seconds have elapsed and throw error
-    timeout_time = time.time() + _START_SERVICE_TIMEOUT
-    while True:
-        try:
-            with _open_key_file(str(key_file_path)) as _:
-                return
-        except IOError:
-            pass
-        if time.time() >= timeout_time:
-            raise TimeoutError("Timed out waiting for discovery service to start")
-        time.sleep(_START_SERVICE_POLLING_INTERVAL)
+    try:
+        subprocess.Popen(
+            [exe_file_path],
+            cwd=exe_file_path.parent,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        # After the execution of process, check for key file existence in the path
+        # stop checking after 30 seconds have elapsed and throw error
+        timeout_time = time.time() + _START_SERVICE_TIMEOUT
+        while True:
+            try:
+                with _open_key_file(str(key_file_path)) as _:
+                    return
+            except IOError:
+                pass
+            if time.time() >= timeout_time:
+                raise TimeoutError("Timed out waiting for discovery service to start")
+            time.sleep(_START_SERVICE_POLLING_INTERVAL)
+    except FileNotFoundError:
+       raise Exception
 
 
 def _service_already_running(key_file_path: pathlib.Path) -> bool:

--- a/ni_measurementlink_service/_internal/discovery_client.py
+++ b/ni_measurementlink_service/_internal/discovery_client.py
@@ -173,6 +173,7 @@ class DiscoveryClient:
             _logger.error(
                 "Unable to unregister with discovery service. Possible reason: discovery service not running."
             )
+            return False
         except Exception:
             _logger.exception("Error in unregistering with discovery service.")
             return False
@@ -254,27 +255,24 @@ def _key_file_exists(key_file_path: pathlib.Path) -> bool:
 
 def _start_service(exe_file_path: pathlib.PurePath, key_file_path: pathlib.Path) -> None:
     """Starts the service at the specified path and wait for the service to get up and running."""
-    try:
-        subprocess.Popen(
-            [exe_file_path],
-            cwd=exe_file_path.parent,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-        # After the execution of process, check for key file existence in the path
-        # stop checking after 30 seconds have elapsed and throw error
-        timeout_time = time.time() + _START_SERVICE_TIMEOUT
-        while True:
-            try:
-                with _open_key_file(str(key_file_path)) as _:
-                    return
-            except IOError:
-                pass
-            if time.time() >= timeout_time:
-                raise TimeoutError("Timed out waiting for discovery service to start")
-            time.sleep(_START_SERVICE_POLLING_INTERVAL)
-    except FileNotFoundError:
-        raise Exception
+    subprocess.Popen(
+        [exe_file_path],
+        cwd=exe_file_path.parent,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    # After the execution of process, check for key file existence in the path
+    # stop checking after 30 seconds have elapsed and throw error
+    timeout_time = time.time() + _START_SERVICE_TIMEOUT
+    while True:
+        try:
+            with _open_key_file(str(key_file_path)) as _:
+                return
+        except IOError:
+            pass
+        if time.time() >= timeout_time:
+            raise TimeoutError("Timed out waiting for discovery service to start")
+        time.sleep(_START_SERVICE_POLLING_INTERVAL)
 
 
 def _service_already_running(key_file_path: pathlib.Path) -> bool:

--- a/tests/unit/test_discovery_client.py
+++ b/tests/unit/test_discovery_client.py
@@ -75,9 +75,9 @@ def test___discovery_service_available___unregister_registered_service___unregis
 def test___discovery_service_available___unregister_non_registered_service___unregistration_failure(
     discovery_client: DiscoveryClient,
 ):
-    unregistration_success_flag = discovery_client.unregister_service()
+    unregistration_failure_flag = discovery_client.unregister_service()
 
-    assert unregistration_success_flag
+    assert unregistration_failure_flag
 
 
 def test___discovery_service_unavailable___register_service_registration_failure(

--- a/tests/unit/test_discovery_client.py
+++ b/tests/unit/test_discovery_client.py
@@ -80,18 +80,6 @@ def test___discovery_service_available___unregister_non_registered_service___unr
     assert not unregistration_success_flag
 
 
-def test___discovery_service_unavailable___register_service_registration_failure(
-    discovery_client: DiscoveryClient,
-):
-    discovery_client.register_measurement_service(
-        _TEST_SERVICE_PORT, _TEST_SERVICE_INFO, _TEST_MEASUREMENT_INFO
-    )
-
-    unregistration_success_flag = discovery_client.unregister_service()
-
-    assert unregistration_success_flag
-
-
 def test___get_discovery_service_address___start_service_jit___returns_expected_value(
     mocker: MockerFixture,
     temp_discovery_key_file_path: pathlib.Path,

--- a/tests/unit/test_discovery_client.py
+++ b/tests/unit/test_discovery_client.py
@@ -192,7 +192,7 @@ def test___discovery_service_exe_unavailable___register_service___registration_f
         _TEST_SERVICE_PORT, _TEST_SERVICE_INFO, _TEST_MEASUREMENT_INFO
     )
 
-    assert registration_success_flag is False
+    assert not registration_success_flag
 
 
 @pytest.fixture

--- a/tests/unit/test_discovery_client.py
+++ b/tests/unit/test_discovery_client.py
@@ -75,9 +75,9 @@ def test___discovery_service_available___unregister_registered_service___unregis
 def test___discovery_service_available___unregister_non_registered_service___unregistration_failure(
     discovery_client: DiscoveryClient,
 ):
-    unregistration_failure_flag = discovery_client.unregister_service()
+    unregistration_success_flag = discovery_client.unregister_service()
 
-    assert unregistration_failure_flag
+    assert not unregistration_success_flag
 
 
 def test___discovery_service_unavailable___register_service_registration_failure(

--- a/tests/unit/test_discovery_client.py
+++ b/tests/unit/test_discovery_client.py
@@ -77,7 +77,7 @@ def test___discovery_service_available___unregister_non_registered_service___unr
 ):
     unregistration_success_flag = discovery_client.unregister_service()
 
-    assert ~unregistration_success_flag  # False
+    assert unregistration_success_flag
 
 
 def test___discovery_service_unavailable___register_service_registration_failure(
@@ -89,7 +89,7 @@ def test___discovery_service_unavailable___register_service_registration_failure
 
     unregistration_success_flag = discovery_client.unregister_service()
 
-    assert ~unregistration_success_flag  # False
+    assert unregistration_success_flag
 
 
 def test___get_discovery_service_address___start_service_jit___returns_expected_value(
@@ -192,7 +192,7 @@ def test___discovery_service_exe_unavailable___register_service___registration_f
         _TEST_SERVICE_PORT, _TEST_SERVICE_INFO, _TEST_MEASUREMENT_INFO
     )
 
-    assert ~registration_success_flag
+    assert registration_success_flag is False
 
 
 @pytest.fixture


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- This PR redirects the logs to /dev/null (hide logs) when a python measurement starts discovery service.
- Before:

![image](https://github.com/ni/measurementlink-python/assets/13461073/889bc72f-169d-46ba-b9d9-4127761714ea)
- After:

![image](https://github.com/ni/measurementlink-python/assets/13461073/713722f5-bad6-48b7-892a-5bedf9a78409)

- Handle `FileNotFoundError` when wrong discovery service .exe path is specified for subprocess.popen function.
- Add tests to register service function to handle `FileNotFoundError` exception.

### Why should this Pull Request be merged?
- Implements [Task 2462367](https://dev.azure.com/ni/DevCentral/_workitems/edit/2462367): When a python measurement starts discovery service, it should not show logs from discovery service to the user.

### What testing has been done?

- Verified discovery service logs are not displayed.
- While the discovery service logs are hidden, it might hide other errors that might arise while starting discovery service through python measurement. To test this case:
        -  Specified wrong discovery service .exe path to `subprocess.popen` function and noticed the log error is captured in the console: 
        
![image](https://github.com/ni/measurementlink-python/assets/13461073/1048a736-eeb3-4f97-b511-dab36783e13a)