### PR TITLE
discovery_client: Fix auto-launching discovery service producing a ResourceWarning

### DIFF
--- a/ni_measurementlink_service/_internal/discovery_client.py
+++ b/ni_measurementlink_service/_internal/discovery_client.py
@@ -27,6 +27,9 @@ if sys.platform == "win32":
     import winerror
 
 _logger = logging.getLogger(__name__)
+# store sub-process that is running; it's only to avoid
+# "ResourceWarning: subprocess N is still running" from subprocess library
+disc_service_subprocess = None
 
 _START_SERVICE_TIMEOUT = 30.0
 _START_SERVICE_POLLING_INTERVAL = 100e-3
@@ -254,7 +257,8 @@ def _key_file_exists(key_file_path: pathlib.Path) -> bool:
 
 def _start_service(exe_file_path: pathlib.PurePath, key_file_path: pathlib.Path) -> None:
     """Starts the service at the specified path and wait for the service to get up and running."""
-    subprocess.Popen([exe_file_path], cwd=exe_file_path.parent)
+    global disc_service_subprocess # only to avoid resource warnings about subprocess still running
+    disc_service_subprocess = subprocess.Popen([exe_file_path], cwd=exe_file_path.parent)
     # After the execution of process, check for key file existence in the path
     # stop checking after 30 seconds have elapsed and throw error
     timeout_time = time.time() + _START_SERVICE_TIMEOUT

--- a/ni_measurementlink_service/_internal/discovery_client.py
+++ b/ni_measurementlink_service/_internal/discovery_client.py
@@ -257,7 +257,7 @@ def _key_file_exists(key_file_path: pathlib.Path) -> bool:
 
 def _start_service(exe_file_path: pathlib.PurePath, key_file_path: pathlib.Path) -> None:
     """Starts the service at the specified path and wait for the service to get up and running."""
-    global disc_service_subprocess # only to avoid resource warnings about subprocess still running
+    global disc_service_subprocess  # only to avoid resource warnings about subprocess still running
     disc_service_subprocess = subprocess.Popen([exe_file_path], cwd=exe_file_path.parent)
     # After the execution of process, check for key file existence in the path
     # stop checking after 30 seconds have elapsed and throw error

--- a/ni_measurementlink_service/_internal/discovery_client.py
+++ b/ni_measurementlink_service/_internal/discovery_client.py
@@ -27,9 +27,8 @@ if sys.platform == "win32":
     import winerror
 
 _logger = logging.getLogger(__name__)
-# store sub-process that is running; it's only to avoid
-# "ResourceWarning: subprocess N is still running" from subprocess library
-disc_service_subprocess = None
+# Save Popen object to avoid "ResourceWarning: subprocess N is still running"
+_discovery_service_subprocess: Optional[subprocess.Popen] = None
 
 _START_SERVICE_TIMEOUT = 30.0
 _START_SERVICE_POLLING_INTERVAL = 100e-3
@@ -257,8 +256,8 @@ def _key_file_exists(key_file_path: pathlib.Path) -> bool:
 
 def _start_service(exe_file_path: pathlib.PurePath, key_file_path: pathlib.Path) -> None:
     """Starts the service at the specified path and wait for the service to get up and running."""
-    global disc_service_subprocess  # only to avoid resource warnings about subprocess still running
-    disc_service_subprocess = subprocess.Popen([exe_file_path], cwd=exe_file_path.parent)
+    global _discovery_service_subprocess  # save Popen object to avoid ResourceWarning
+    _discovery_service_subprocess = subprocess.Popen([exe_file_path], cwd=exe_file_path.parent)
     # After the execution of process, check for key file existence in the path
     # stop checking after 30 seconds have elapsed and throw error
     timeout_time = time.time() + _START_SERVICE_TIMEOUT


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Save the reference of the `subprocess.popen` object to a global variable.
- This prevents leakage of `subprocess` which in turn denotes that the subprocess is still running and produces a `ResourceWarning`.

### Why should this Pull Request be merged?

- Fixes -- Auto-launching the discovery service leaks a `subprocess.Popen`, which produces a `ResourceWarning`. 
- Issue #331 

### What testing has been done?

1. Ran example (nidaqmx_analog_input) service and make sure it is registered with the discovery service.
2. Used Task Manager to kill the discovery service.
3. Manually launched the example service with `poetry run python measurement.py -v`.
4. Verified `ResourceWarning` doesn't happen anymore.
5. Repeated step 1 to 4 for other examples as well.
6. For other examples, in step 3 used `poetry run python -X dev measurement.py` to reproduce the `ResourceWarning`.