### PR TITLE
Added Creation flag CREATE_BREAKAWAY_FROM_JOB to stop Discovery service terminating in Debug mode

### DIFF
--- a/ni_measurementlink_service/_internal/discovery_client.py
+++ b/ni_measurementlink_service/_internal/discovery_client.py
@@ -8,7 +8,6 @@ import subprocess
 import sys
 import time
 import typing
-from subprocess import CREATE_BREAKAWAY_FROM_JOB
 from typing import Optional
 
 import grpc
@@ -18,6 +17,7 @@ from ni_measurementlink_service._internal.stubs.ni.measurementlink.discovery.v1 
     discovery_service_pb2_grpc,
 )
 from ni_measurementlink_service.measurement.info import MeasurementInfo, ServiceInfo
+from subprocess import CREATE_BREAKAWAY_FROM_JOB
 
 if sys.platform == "win32":
     import errno
@@ -261,12 +261,15 @@ def _key_file_exists(key_file_path: pathlib.Path) -> bool:
 def _start_service(exe_file_path: pathlib.PurePath, key_file_path: pathlib.Path) -> None:
     """Starts the service at the specified path and wait for the service to get up and running."""
     global _discovery_service_subprocess  # save Popen object to avoid ResourceWarning
+
+    # Added hexadecimal equivalent of subprocess.CREATE_BREAKAWAY_FROM_JOB to avoid
+    # Mypy error 'Module subprocess has no attribute CREATE_BREAKAWAY_FROM_JOB'.
     _discovery_service_subprocess = subprocess.Popen(
         [exe_file_path],
         cwd=exe_file_path.parent,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
-        creationflags=CREATE_BREAKAWAY_FROM_JOB,
+        creationflags=0x1000000,
     )
     # After the execution of process, check for key file existence in the path
     # stop checking after 30 seconds have elapsed and throw error

--- a/ni_measurementlink_service/_internal/discovery_client.py
+++ b/ni_measurementlink_service/_internal/discovery_client.py
@@ -1,5 +1,6 @@
 """ Contains API to register and un-register measurement service with discovery service.
 """
+import _winapi
 import json
 import logging
 import os
@@ -260,13 +261,12 @@ def _key_file_exists(key_file_path: pathlib.Path) -> bool:
 def _start_service(exe_file_path: pathlib.PurePath, key_file_path: pathlib.Path) -> None:
     """Starts the service at the specified path and wait for the service to get up and running."""
     global _discovery_service_subprocess  # save Popen object to avoid ResourceWarning
-    creationflags = subprocess.CREATE_BREAKAWAY_FROM_JOB
     _discovery_service_subprocess = subprocess.Popen(
         [exe_file_path],
         cwd=exe_file_path.parent,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
-        creationflags=creationflags,
+        creationflags=_winapi.CREATE_BREAKAWAY_FROM_JOB,
     )
     # After the execution of process, check for key file existence in the path
     # stop checking after 30 seconds have elapsed and throw error

--- a/ni_measurementlink_service/_internal/discovery_client.py
+++ b/ni_measurementlink_service/_internal/discovery_client.py
@@ -17,6 +17,7 @@ from ni_measurementlink_service._internal.stubs.ni.measurementlink.discovery.v1 
     discovery_service_pb2_grpc,
 )
 from ni_measurementlink_service.measurement.info import MeasurementInfo, ServiceInfo
+from subprocess import CREATE_BREAKAWAY_FROM_JOB
 
 if sys.platform == "win32":
     import errno
@@ -265,7 +266,7 @@ def _start_service(exe_file_path: pathlib.PurePath, key_file_path: pathlib.Path)
         cwd=exe_file_path.parent,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
-        creationflags=0x1000000,
+        creationflags=CREATE_BREAKAWAY_FROM_JOB,
     )
     # After the execution of process, check for key file existence in the path
     # stop checking after 30 seconds have elapsed and throw error

--- a/ni_measurementlink_service/_internal/discovery_client.py
+++ b/ni_measurementlink_service/_internal/discovery_client.py
@@ -265,6 +265,7 @@ def _start_service(exe_file_path: pathlib.PurePath, key_file_path: pathlib.Path)
         cwd=exe_file_path.parent,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
+        creationflags=subprocess.CREATE_BREAKAWAY_FROM_JOB,
     )
     # After the execution of process, check for key file existence in the path
     # stop checking after 30 seconds have elapsed and throw error

--- a/ni_measurementlink_service/_internal/discovery_client.py
+++ b/ni_measurementlink_service/_internal/discovery_client.py
@@ -17,7 +17,6 @@ from ni_measurementlink_service._internal.stubs.ni.measurementlink.discovery.v1 
     discovery_service_pb2_grpc,
 )
 from ni_measurementlink_service.measurement.info import MeasurementInfo, ServiceInfo
-from subprocess import CREATE_BREAKAWAY_FROM_JOB
 
 if sys.platform == "win32":
     import errno

--- a/ni_measurementlink_service/_internal/discovery_client.py
+++ b/ni_measurementlink_service/_internal/discovery_client.py
@@ -1,6 +1,5 @@
 """ Contains API to register and un-register measurement service with discovery service.
 """
-import _winapi
 import json
 import logging
 import os
@@ -266,7 +265,7 @@ def _start_service(exe_file_path: pathlib.PurePath, key_file_path: pathlib.Path)
         cwd=exe_file_path.parent,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
-        creationflags=_winapi.CREATE_BREAKAWAY_FROM_JOB,
+        creationflags=0x1000000,
     )
     # After the execution of process, check for key file existence in the path
     # stop checking after 30 seconds have elapsed and throw error

--- a/ni_measurementlink_service/_internal/discovery_client.py
+++ b/ni_measurementlink_service/_internal/discovery_client.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import time
 import typing
+from subprocess import CREATE_BREAKAWAY_FROM_JOB
 from typing import Optional
 
 import grpc
@@ -17,7 +18,6 @@ from ni_measurementlink_service._internal.stubs.ni.measurementlink.discovery.v1 
     discovery_service_pb2_grpc,
 )
 from ni_measurementlink_service.measurement.info import MeasurementInfo, ServiceInfo
-from subprocess import CREATE_BREAKAWAY_FROM_JOB
 
 if sys.platform == "win32":
     import errno

--- a/ni_measurementlink_service/_internal/discovery_client.py
+++ b/ni_measurementlink_service/_internal/discovery_client.py
@@ -260,12 +260,13 @@ def _key_file_exists(key_file_path: pathlib.Path) -> bool:
 def _start_service(exe_file_path: pathlib.PurePath, key_file_path: pathlib.Path) -> None:
     """Starts the service at the specified path and wait for the service to get up and running."""
     global _discovery_service_subprocess  # save Popen object to avoid ResourceWarning
+    creationflags = subprocess.CREATE_BREAKAWAY_FROM_JOB
     _discovery_service_subprocess = subprocess.Popen(
         [exe_file_path],
         cwd=exe_file_path.parent,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
-        creationflags=subprocess.CREATE_BREAKAWAY_FROM_JOB,
+        creationflags=creationflags,
     )
     # After the execution of process, check for key file existence in the path
     # stop checking after 30 seconds have elapsed and throw error

--- a/tests/unit/test_discovery_client.py
+++ b/tests/unit/test_discovery_client.py
@@ -86,7 +86,7 @@ def test___get_discovery_service_address___start_service_jit___returns_expected_
     temp_discovery_key_file_path: pathlib.Path,
     temp_registration_json_file_path: pathlib.Path,
     temp_directory: pathlib.Path,
-    subprocess_popen_creationflags: Dict[str, Any],
+    subprocess_popen_kwargs: Dict[str, Any],
 ):
     mocker.patch(
         "ni_measurementlink_service._internal.discovery_client._get_key_file_path",
@@ -111,7 +111,7 @@ def test___get_discovery_service_address___start_service_jit___returns_expected_
         cwd=exe_file_path.parent,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
-        **subprocess_popen_creationflags,
+        **subprocess_popen_kwargs,
     )
     assert _TEST_SERVICE_PORT in discovery_service_address
 
@@ -146,7 +146,7 @@ def test___start_discovery_service___key_file_exist_after_poll___service_start_s
     mocker: MockerFixture,
     temp_directory: pathlib.Path,
     temp_discovery_key_file_path: pathlib.Path,
-    subprocess_popen_creationflags: Dict[str, Any],
+    subprocess_popen_kwargs: Dict[str, Any],
 ):
     exe_file_path = temp_directory / _MOCK_REGISTRATION_FILE_CONTENT["discovery"]["path"]
 
@@ -163,7 +163,7 @@ def test___start_discovery_service___key_file_exist_after_poll___service_start_s
         cwd=exe_file_path.parent,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
-        **subprocess_popen_creationflags,
+        **subprocess_popen_kwargs,
     )
 
 
@@ -191,7 +191,7 @@ def test___discovery_service_exe_unavailable___register_service___registration_f
 
 
 @pytest.fixture(scope="module")
-def subprocess_popen_creationflags() -> Dict[str, Any]:
+def subprocess_popen_kwargs() -> Dict[str, Any]:
     kwargs: Dict[str, Any] = {}
     if sys.platform == "win32":
         kwargs["creationflags"] = subprocess.CREATE_BREAKAWAY_FROM_JOB

--- a/tests/unit/test_discovery_client.py
+++ b/tests/unit/test_discovery_client.py
@@ -109,6 +109,7 @@ def test___get_discovery_service_address___start_service_jit___returns_expected_
         cwd=exe_file_path.parent,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
+        creationflags=subprocess.CREATE_BREAKAWAY_FROM_JOB,
     )
     assert _TEST_SERVICE_PORT in discovery_service_address
 
@@ -157,6 +158,7 @@ def test___start_discovery_service___key_file_exist_after_poll___service_start_s
         cwd=exe_file_path.parent,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
+        creationflags=subprocess.CREATE_BREAKAWAY_FROM_JOB,
     )
 
 

--- a/tests/unit/test_discovery_client.py
+++ b/tests/unit/test_discovery_client.py
@@ -3,7 +3,8 @@
 import json
 import pathlib
 import subprocess
-from typing import cast
+import sys
+from typing import Any, Dict, cast
 
 import pytest
 from pytest_mock import MockerFixture
@@ -85,6 +86,7 @@ def test___get_discovery_service_address___start_service_jit___returns_expected_
     temp_discovery_key_file_path: pathlib.Path,
     temp_registration_json_file_path: pathlib.Path,
     temp_directory: pathlib.Path,
+    add_subprocess_popen_creationflags: Dict[str, Any],
 ):
     mocker.patch(
         "ni_measurementlink_service._internal.discovery_client._get_key_file_path",
@@ -109,7 +111,7 @@ def test___get_discovery_service_address___start_service_jit___returns_expected_
         cwd=exe_file_path.parent,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
-        creationflags=0x1000000,
+        **add_subprocess_popen_creationflags,
     )
     assert _TEST_SERVICE_PORT in discovery_service_address
 
@@ -141,7 +143,10 @@ def test___get_discovery_service_address___key_file_not_exist___throws_timeouter
 
 
 def test___start_discovery_service___key_file_exist_after_poll___service_start_success(
-    mocker: MockerFixture, temp_directory: pathlib.Path, temp_discovery_key_file_path: pathlib.Path
+    mocker: MockerFixture,
+    temp_directory: pathlib.Path,
+    temp_discovery_key_file_path: pathlib.Path,
+    add_subprocess_popen_creationflags: Dict[str, Any],
 ):
     exe_file_path = temp_directory / _MOCK_REGISTRATION_FILE_CONTENT["discovery"]["path"]
 
@@ -158,7 +163,7 @@ def test___start_discovery_service___key_file_exist_after_poll___service_start_s
         cwd=exe_file_path.parent,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
-        creationflags=0x1000000,
+        **add_subprocess_popen_creationflags,
     )
 
 
@@ -183,6 +188,14 @@ def test___discovery_service_exe_unavailable___register_service___registration_f
     )
 
     assert not registration_success_flag
+
+
+@pytest.fixture(scope="module")
+def add_subprocess_popen_creationflags() -> Dict[str, Any]:
+    kwargs: Dict[str, Any] = {}
+    if sys.platform == "win32":
+        kwargs["creationflags"] = subprocess.CREATE_BREAKAWAY_FROM_JOB
+    return kwargs
 
 
 @pytest.fixture

--- a/tests/unit/test_discovery_client.py
+++ b/tests/unit/test_discovery_client.py
@@ -86,7 +86,7 @@ def test___get_discovery_service_address___start_service_jit___returns_expected_
     temp_discovery_key_file_path: pathlib.Path,
     temp_registration_json_file_path: pathlib.Path,
     temp_directory: pathlib.Path,
-    add_subprocess_popen_creationflags: Dict[str, Any],
+    subprocess_popen_creationflags: Dict[str, Any],
 ):
     mocker.patch(
         "ni_measurementlink_service._internal.discovery_client._get_key_file_path",
@@ -111,7 +111,7 @@ def test___get_discovery_service_address___start_service_jit___returns_expected_
         cwd=exe_file_path.parent,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
-        **add_subprocess_popen_creationflags,
+        **subprocess_popen_creationflags,
     )
     assert _TEST_SERVICE_PORT in discovery_service_address
 
@@ -146,7 +146,7 @@ def test___start_discovery_service___key_file_exist_after_poll___service_start_s
     mocker: MockerFixture,
     temp_directory: pathlib.Path,
     temp_discovery_key_file_path: pathlib.Path,
-    add_subprocess_popen_creationflags: Dict[str, Any],
+    subprocess_popen_creationflags: Dict[str, Any],
 ):
     exe_file_path = temp_directory / _MOCK_REGISTRATION_FILE_CONTENT["discovery"]["path"]
 
@@ -163,7 +163,7 @@ def test___start_discovery_service___key_file_exist_after_poll___service_start_s
         cwd=exe_file_path.parent,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
-        **add_subprocess_popen_creationflags,
+        **subprocess_popen_creationflags,
     )
 
 
@@ -191,7 +191,7 @@ def test___discovery_service_exe_unavailable___register_service___registration_f
 
 
 @pytest.fixture(scope="module")
-def add_subprocess_popen_creationflags() -> Dict[str, Any]:
+def subprocess_popen_creationflags() -> Dict[str, Any]:
     kwargs: Dict[str, Any] = {}
     if sys.platform == "win32":
         kwargs["creationflags"] = subprocess.CREATE_BREAKAWAY_FROM_JOB

--- a/tests/unit/test_discovery_client.py
+++ b/tests/unit/test_discovery_client.py
@@ -109,7 +109,7 @@ def test___get_discovery_service_address___start_service_jit___returns_expected_
         cwd=exe_file_path.parent,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
-        creationflags=subprocess.CREATE_BREAKAWAY_FROM_JOB,
+        creationflags=0x1000000,
     )
     assert _TEST_SERVICE_PORT in discovery_service_address
 
@@ -158,7 +158,7 @@ def test___start_discovery_service___key_file_exist_after_poll___service_start_s
         cwd=exe_file_path.parent,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
-        creationflags=subprocess.CREATE_BREAKAWAY_FROM_JOB,
+        creationflags=0x1000000,
     )
 
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
When a measurement and Discovery Service are started in `Debug mode`, the Discovery service from task manager is killed/terminated as soon as the measurement is stopped. So to stop Discovery Service from terminating the following changes are made.
1) Added  a `creationflags` parameter to `subprocess.Popen` in `discovery_client.py`.
2) Set the `creationflags` to `subprocess.CREATE_BREAKAWAY_FROM_JOB`.
3) Updated tests in `test_discovery_client.py` with `creationflags` parameter.

### Why should this Pull Request be merged?
This PR fixes [Bug 2474096](https://dev.azure.com/ni/DevCentral/_workitems/edit/2474096): Discovery Service is terminated when measurement service is stopped in debug mode

### What testing has been done?
Tested these scenarios
![image](https://github.com/ni/measurementlink-python/assets/126869186/b75c0419-8eb0-4987-be2a-334e12cc1adb)
Ran `poetry run pytest`. All tests passed.
Ran the tests in debug mode and observed Discovery Service is not terminated after test run ends.