### PR TITLE
Add message_type to ParameterMetadata and DataTypeInfo

### DIFF
--- a/ni_measurementlink_service/_datatypeinfo.py
+++ b/ni_measurementlink_service/_datatypeinfo.py
@@ -2,8 +2,8 @@ from typing import NamedTuple
 
 from google.protobuf import type_pb2
 
-from ni_measurementlink_service.measurement.info import DataType, TypeSpecialization
 from ni_measurementlink_service._internal.stubs.ni.protobuf.types import xydata_pb2
+from ni_measurementlink_service.measurement.info import DataType, TypeSpecialization
 
 
 class DataTypeInfo(NamedTuple):
@@ -20,7 +20,7 @@ class DataTypeInfo(NamedTuple):
 
         message_type (str): This is the gRPC full name of the message type.
         Required when 'grpc_field_type' is Kind.TypeMessage.
-        Ignored for any other 'type'. 
+        Ignored for any other 'type'.
 
     """
 
@@ -50,7 +50,11 @@ _DATATYPE_TO_DATATYPEINFO_LOOKUP = {
     DataType.Pin: DataTypeInfo(type_pb2.Field.TYPE_STRING, False, TypeSpecialization.Pin),
     DataType.Path: DataTypeInfo(type_pb2.Field.TYPE_STRING, False, TypeSpecialization.Path),
     DataType.Enum: DataTypeInfo(type_pb2.Field.TYPE_ENUM, False, TypeSpecialization.Enum),
-    DataType.DoubleXYData: DataTypeInfo(type_pb2.Field.TYPE_MESSAGE, False, message_type=xydata_pb2.DoubleXYData.DESCRIPTOR.full_name),
+    DataType.DoubleXYData: DataTypeInfo(
+        type_pb2.Field.TYPE_MESSAGE,
+        False,
+        message_type=xydata_pb2.DoubleXYData.DESCRIPTOR.full_name,
+    ),
     DataType.Int32Array1D: DataTypeInfo(type_pb2.Field.TYPE_INT32, True),
     DataType.Int64Array1D: DataTypeInfo(type_pb2.Field.TYPE_INT64, True),
     DataType.UInt32Array1D: DataTypeInfo(type_pb2.Field.TYPE_UINT32, True),

--- a/ni_measurementlink_service/_datatypeinfo.py
+++ b/ni_measurementlink_service/_datatypeinfo.py
@@ -3,6 +3,7 @@ from typing import NamedTuple
 from google.protobuf import type_pb2
 
 from ni_measurementlink_service.measurement.info import DataType, TypeSpecialization
+from ni_measurementlink_service._internal.stubs.ni.protobuf.types import xydata_pb2
 
 
 class DataTypeInfo(NamedTuple):
@@ -17,11 +18,16 @@ class DataTypeInfo(NamedTuple):
         type_specialization: Specific type when value_type
         can have more than one use
 
+        message_type (str): This is the gRPC full name of the message type.
+        Required when 'grpc_field_type' is Kind.TypeMessage.
+        Ignored for any other 'type'. 
+
     """
 
     grpc_field_type: type_pb2.Field.Kind.ValueType
     repeated: bool
     type_specialization: TypeSpecialization = TypeSpecialization.NoType
+    message_type: str = ""
 
 
 def get_type_info(data_type: DataType) -> DataTypeInfo:
@@ -44,6 +50,7 @@ _DATATYPE_TO_DATATYPEINFO_LOOKUP = {
     DataType.Pin: DataTypeInfo(type_pb2.Field.TYPE_STRING, False, TypeSpecialization.Pin),
     DataType.Path: DataTypeInfo(type_pb2.Field.TYPE_STRING, False, TypeSpecialization.Path),
     DataType.Enum: DataTypeInfo(type_pb2.Field.TYPE_ENUM, False, TypeSpecialization.Enum),
+    DataType.DoubleXYData: DataTypeInfo(type_pb2.Field.TYPE_MESSAGE, False, message_type=xydata_pb2.DoubleXYData.DESCRIPTOR.full_name),
     DataType.Int32Array1D: DataTypeInfo(type_pb2.Field.TYPE_INT32, True),
     DataType.Int64Array1D: DataTypeInfo(type_pb2.Field.TYPE_INT64, True),
     DataType.UInt32Array1D: DataTypeInfo(type_pb2.Field.TYPE_UINT32, True),

--- a/ni_measurementlink_service/_internal/parameter/metadata.py
+++ b/ni_measurementlink_service/_internal/parameter/metadata.py
@@ -31,7 +31,7 @@ class ParameterMetadata(NamedTuple):
 
         message_type (str): This is the gRPC full name of the message type.
         Required when 'type' is Kind.TypeMessage.
-        Ignored for any other 'type'. 
+        Ignored for any other 'type'.
 
     """
 

--- a/ni_measurementlink_service/_internal/parameter/metadata.py
+++ b/ni_measurementlink_service/_internal/parameter/metadata.py
@@ -29,6 +29,10 @@ class ParameterMetadata(NamedTuple):
 
         annotations (Dict[str,str]): Represents a set of annotations on the type.
 
+        message_type (str): This is the gRPC full name of the message type.
+        Required when 'type' is Kind.TypeMessage.
+        Ignored for any other 'type'. 
+
     """
 
     display_name: str
@@ -36,6 +40,7 @@ class ParameterMetadata(NamedTuple):
     repeated: bool
     default_value: Any
     annotations: Dict[str, str]
+    message_type: str = ""
 
 
 def validate_default_value_type(parameter_metadata: ParameterMetadata) -> None:

--- a/ni_measurementlink_service/measurement/info.py
+++ b/ni_measurementlink_service/measurement/info.py
@@ -76,6 +76,7 @@ class DataType(enum.Enum):
     Pin = 8
     Path = 9
     Enum = 10
+    DoubleXYData = 11
 
     Int32Array1D = 100
     Int64Array1D = 101

--- a/ni_measurementlink_service/measurement/service.py
+++ b/ni_measurementlink_service/measurement/service.py
@@ -310,6 +310,7 @@ class MeasurementService:
             data_type_info.repeated,
             default_value,
             annotations,
+            data_type_info.message_type
         )
         parameter_metadata.validate_default_value_type(parameter)
         self.configuration_parameter_list.append(parameter)
@@ -358,7 +359,12 @@ class MeasurementService:
             data_type_info.type_specialization, enum_type=enum_type
         )
         parameter = parameter_metadata.ParameterMetadata(
-            display_name, data_type_info.grpc_field_type, data_type_info.repeated, None, annotations
+            display_name,
+            data_type_info.grpc_field_type,
+            data_type_info.repeated,
+            None,
+            annotations,
+            data_type_info.message_type
         )
         self.output_parameter_list.append(parameter)
 

--- a/ni_measurementlink_service/measurement/service.py
+++ b/ni_measurementlink_service/measurement/service.py
@@ -310,7 +310,7 @@ class MeasurementService:
             data_type_info.repeated,
             default_value,
             annotations,
-            data_type_info.message_type
+            data_type_info.message_type,
         )
         parameter_metadata.validate_default_value_type(parameter)
         self.configuration_parameter_list.append(parameter)
@@ -364,7 +364,7 @@ class MeasurementService:
             data_type_info.repeated,
             None,
             annotations,
-            data_type_info.message_type
+            data_type_info.message_type,
         )
         self.output_parameter_list.append(parameter)
 

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -50,7 +50,7 @@ def test___measurement_service___register_measurement_method___method_registered
         ("UInt32", DataType.UInt32, 3994),
         ("UInt64", DataType.UInt64, 3456),
         ("UInt64", DataType.UInt64, False),
-        ("DoubleXYData", DataType.DoubleXYData, None)
+        ("DoubleXYData", DataType.DoubleXYData, None),
     ],
 )
 def test___measurement_service___add_configuration__configuration_added(

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -50,6 +50,7 @@ def test___measurement_service___register_measurement_method___method_registered
         ("UInt32", DataType.UInt32, 3994),
         ("UInt64", DataType.UInt64, 3456),
         ("UInt64", DataType.UInt64, False),
+        ("DoubleXYData", DataType.DoubleXYData, None)
     ],
 )
 def test___measurement_service___add_configuration__configuration_added(
@@ -66,6 +67,7 @@ def test___measurement_service___add_configuration__configuration_added(
         and param.type == data_type_info.grpc_field_type
         and param.repeated == data_type_info.repeated
         and param.default_value == default_value
+        and param.message_type == data_type_info.message_type
         for param in measurement_service.configuration_parameter_list
     )
 
@@ -233,6 +235,7 @@ def test___measurement_service___add_configuration_with_mismatch_default_value__
         ("UInt32", DataType.UInt32),
         ("UInt44", DataType.UInt64),
         ("UInt44", DataType.UInt64),
+        ("DoubleXYData", DataType.DoubleXYData),
     ],
 )
 def test___measurement_service___add_output__output_added(
@@ -245,6 +248,7 @@ def test___measurement_service___add_output__output_added(
         param.display_name == display_name
         and param.type == data_type_info.grpc_field_type
         and param.repeated == data_type_info.repeated
+        and param.message_type == data_type_info.message_type
         for param in measurement_service.output_parameter_list
     )
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

For supporting DoubleXYData, we need to support having a 'message_type' field in ParameterMetadata and DataTypeInfo. This PR adds those fields and adds a 'DoubleXYData' DataType. There is no serialization and deserialization supported for this data type yet. So errors will occur if it is used in the `configuration` or `output` decorators at this point. That is to be added shortly.

### Why should this Pull Request be merged?

Preparation step for adding full DoubleXYData support.

### What testing has been done?

Ran all tests locally. Added a configuration and output test to ensure the message_type for DoubleXYData is set on the ParameterMetadata.