### PR TITLE
Remove unused TypeVar from _helpers.py

### DIFF
--- a/examples/nidaqmx_analog_input/_helpers.py
+++ b/examples/nidaqmx_analog_input/_helpers.py
@@ -48,9 +48,6 @@ def get_service_options(**kwargs) -> ServiceOptions:
     )
 
 
-T = TypeVar("T")
-
-
 class PinMapClient(object):
     """Class that communicates with the pin map service."""
 

--- a/examples/nidcpower_source_dc_voltage/_helpers.py
+++ b/examples/nidcpower_source_dc_voltage/_helpers.py
@@ -48,9 +48,6 @@ def get_service_options(**kwargs) -> ServiceOptions:
     )
 
 
-T = TypeVar("T")
-
-
 class PinMapClient(object):
     """Class that communicates with the pin map service."""
 

--- a/examples/nidigital_spi/_helpers.py
+++ b/examples/nidigital_spi/_helpers.py
@@ -48,9 +48,6 @@ def get_service_options(**kwargs) -> ServiceOptions:
     )
 
 
-T = TypeVar("T")
-
-
 class PinMapClient(object):
     """Class that communicates with the pin map service."""
 

--- a/examples/nidmm_measurement/_helpers.py
+++ b/examples/nidmm_measurement/_helpers.py
@@ -48,9 +48,6 @@ def get_service_options(**kwargs) -> ServiceOptions:
     )
 
 
-T = TypeVar("T")
-
-
 class PinMapClient(object):
     """Class that communicates with the pin map service."""
 

--- a/examples/nifgen_standard_function/_helpers.py
+++ b/examples/nifgen_standard_function/_helpers.py
@@ -48,9 +48,6 @@ def get_service_options(**kwargs) -> ServiceOptions:
     )
 
 
-T = TypeVar("T")
-
-
 class PinMapClient(object):
     """Class that communicates with the pin map service."""
 

--- a/examples/niscope_acquire_waveform/_helpers.py
+++ b/examples/niscope_acquire_waveform/_helpers.py
@@ -48,9 +48,6 @@ def get_service_options(**kwargs) -> ServiceOptions:
     )
 
 
-T = TypeVar("T")
-
-
 class PinMapClient(object):
     """Class that communicates with the pin map service."""
 

--- a/examples/niswitch_control_relays/_helpers.py
+++ b/examples/niswitch_control_relays/_helpers.py
@@ -48,9 +48,6 @@ def get_service_options(**kwargs) -> ServiceOptions:
     )
 
 
-T = TypeVar("T")
-
-
 class PinMapClient(object):
     """Class that communicates with the pin map service."""
 

--- a/examples/nivisa_dmm_measurement/_helpers.py
+++ b/examples/nivisa_dmm_measurement/_helpers.py
@@ -48,9 +48,6 @@ def get_service_options(**kwargs) -> ServiceOptions:
     )
 
 
-T = TypeVar("T")
-
-
 class PinMapClient(object):
     """Class that communicates with the pin map service."""
 

--- a/examples/output_voltage_measurement/_helpers.py
+++ b/examples/output_voltage_measurement/_helpers.py
@@ -48,9 +48,6 @@ def get_service_options(**kwargs) -> ServiceOptions:
     )
 
 
-T = TypeVar("T")
-
-
 class PinMapClient(object):
     """Class that communicates with the pin map service."""
 

--- a/examples/sample_measurement/_helpers.py
+++ b/examples/sample_measurement/_helpers.py
@@ -48,9 +48,6 @@ def get_service_options(**kwargs) -> ServiceOptions:
     )
 
 
-T = TypeVar("T")
-
-
 class PinMapClient(object):
     """Class that communicates with the pin map service."""
 

--- a/examples/sample_streaming_measurement/_helpers.py
+++ b/examples/sample_streaming_measurement/_helpers.py
@@ -48,9 +48,6 @@ def get_service_options(**kwargs) -> ServiceOptions:
     )
 
 
-T = TypeVar("T")
-
-
 class PinMapClient(object):
     """Class that communicates with the pin map service."""
 

--- a/examples/ui_progress_updates/_helpers.py
+++ b/examples/ui_progress_updates/_helpers.py
@@ -48,9 +48,6 @@ def get_service_options(**kwargs) -> ServiceOptions:
     )
 
 
-T = TypeVar("T")
-
-
 class PinMapClient(object):
     """Class that communicates with the pin map service."""
 

--- a/ni_measurementlink_generator/ni_measurementlink_generator/templates/_helpers.py.mako
+++ b/ni_measurementlink_generator/ni_measurementlink_generator/templates/_helpers.py.mako
@@ -47,9 +47,6 @@ def get_service_options(**kwargs) -> ServiceOptions:
     )
 
 
-T = TypeVar("T")
-
-
 class PinMapClient(object):
     """Class that communicates with the pin map service."""
 

--- a/ni_measurementlink_generator/tests/test_assets/example_renders/measurement/_helpers.py
+++ b/ni_measurementlink_generator/tests/test_assets/example_renders/measurement/_helpers.py
@@ -47,9 +47,6 @@ def get_service_options(**kwargs) -> ServiceOptions:
     )
 
 
-T = TypeVar("T")
-
-
 class PinMapClient(object):
     """Class that communicates with the pin map service."""
 

--- a/ni_measurementlink_generator/tests/test_assets/example_renders/measurement_with_annotations/_helpers.py
+++ b/ni_measurementlink_generator/tests/test_assets/example_renders/measurement_with_annotations/_helpers.py
@@ -47,9 +47,6 @@ def get_service_options(**kwargs) -> ServiceOptions:
     )
 
 
-T = TypeVar("T")
-
-
 class PinMapClient(object):
     """Class that communicates with the pin map service."""
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

T = TypeVar("T") was unused in _helpers.py. This PR deletes it from all _helpers.py files and the templates as well.

### Why should this Pull Request be merged?

Clean up unused code from our examples and generator.

### What testing has been done?

Relying on the PR checks.