### PR TITLE
examples: Make enum zero translation more readable

### DIFF
--- a/examples/nidmm_measurement/measurement.py
+++ b/examples/nidmm_measurement/measurement.py
@@ -102,13 +102,9 @@ def measure(
     ) as reservation:
         grpc_device_channel = get_grpc_device_channel(measurement_service, nidmm, service_options)
         with create_session(reservation.session_info, grpc_device_channel) as session:
-            session.configure_measurement_digits(
-                nidmm.Function(measurement_type.value)
-                if measurement_type != Function.NONE
-                else nidmm.Function.DC_VOLTS,
-                range,
-                resolution_digits,
-            )
+            # If the measurement type is not specified, use DC_VOLTS.
+            nidmm_function = nidmm.Function(measurement_type.value or Function.DC_VOLTS.value)
+            session.configure_measurement_digits(nidmm_function, range, resolution_digits)
             measured_value = session.read()
             signal_out_of_range = math.isnan(measured_value) or math.isinf(measured_value)
             absolute_resolution = session.resolution_absolute

--- a/examples/nifgen_standard_function/measurement.py
+++ b/examples/nifgen_standard_function/measurement.py
@@ -123,13 +123,9 @@ def measure(
             session.output_mode = nifgen.OutputMode.FUNC
 
             channels = session.channels[session_info.channel_list]
-            channels.configure_standard_waveform(
-                nifgen.Waveform(waveform_type.value)
-                if waveform_type != Waveform.NONE
-                else nifgen.Waveform.SINE,
-                amplitude,
-                frequency,
-            )
+            # If the waveform type is not specified, use SINE.
+            nifgen_waveform = nifgen.Waveform(waveform_type.value or Waveform.SINE.value)
+            channels.configure_standard_waveform(nifgen_waveform, amplitude, frequency)
 
             stack.enter_context(session.initiate())
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update the translation from the zero enum (e.g. `Waveform.NONE`) to be more readable and concise.

### Why should this Pull Request be merged?

Make the examples more readable.

### What testing has been done?

Manually tested both examples with default, NONE, and a non-default value, using NI IO Trace to verify the value passed to the driver.