### PR TITLE
service: Split GrpcChannelPool into a separate submodule

### DIFF
--- a/ni_measurementlink_service/_channelpool.py
+++ b/ni_measurementlink_service/_channelpool.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from threading import Lock
 from types import TracebackType
 from typing import (
@@ -7,16 +8,18 @@ from typing import (
     Literal,
     Optional,
     Type,
-    TypeVar,
+    TYPE_CHECKING,
 )
 
 import grpc
 
 from ni_measurementlink_service._loggers import ClientLogger
 
-
-# Eventually, these can be replaced with typing.Self (Python >= 3.11).
-_TGrpcChannelPool = TypeVar("_TGrpcChannelPool", bound="GrpcChannelPool")
+if TYPE_CHECKING:
+    if sys.version_info >= (3, 11):
+        from typing import Self
+    else:
+        from typing_extensions import Self
 
 
 class GrpcChannelPool(object):
@@ -27,7 +30,7 @@ class GrpcChannelPool(object):
         self._lock: Lock = Lock()
         self._channel_cache: Dict[str, grpc.Channel] = {}
 
-    def __enter__(self: _TGrpcChannelPool) -> _TGrpcChannelPool:
+    def __enter__(self: Self) -> Self:
         """Enter the runtime context of the GrpcChannelPool."""
         return self
 

--- a/ni_measurementlink_service/_channelpool.py
+++ b/ni_measurementlink_service/_channelpool.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from threading import Lock
+from types import TracebackType
+from typing import (
+    Dict,
+    Literal,
+    Optional,
+    Type,
+    TypeVar,
+)
+
+import grpc
+
+from ni_measurementlink_service._loggers import ClientLogger
+
+
+# Eventually, these can be replaced with typing.Self (Python >= 3.11).
+_TGrpcChannelPool = TypeVar("_TGrpcChannelPool", bound="GrpcChannelPool")
+
+
+class GrpcChannelPool(object):
+    """Class that manages gRPC channel lifetimes."""
+
+    def __init__(self) -> None:
+        """Initialize the GrpcChannelPool object."""
+        self._lock: Lock = Lock()
+        self._channel_cache: Dict[str, grpc.Channel] = {}
+
+    def __enter__(self: _TGrpcChannelPool) -> _TGrpcChannelPool:
+        """Enter the runtime context of the GrpcChannelPool."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> Literal[False]:
+        """Exit the runtime context of the GrpcChannelPool."""
+        self.close()
+        return False
+
+    def get_channel(self, target: str) -> grpc.Channel:
+        """Return a gRPC channel.
+
+        Args:
+            target (str): The server address
+
+        """
+        new_channel = None
+        with self._lock:
+            if target not in self._channel_cache:
+                self._lock.release()
+                new_channel = grpc.insecure_channel(target)
+                if ClientLogger.is_enabled():
+                    new_channel = grpc.intercept_channel(new_channel, ClientLogger())
+                self._lock.acquire()
+                if target not in self._channel_cache:
+                    self._channel_cache[target] = new_channel
+                    new_channel = None
+            channel = self._channel_cache[target]
+
+        # Close new_channel if it was not stored in _channel_cache.
+        if new_channel is not None:
+            new_channel.close()
+
+        return channel
+
+    def close(self) -> None:
+        """Close channels opened by get_channel()."""
+        with self._lock:
+            for channel in self._channel_cache.values():
+                channel.close()
+            self._channel_cache.clear()

--- a/ni_measurementlink_service/measurement/service.py
+++ b/ni_measurementlink_service/measurement/service.py
@@ -17,7 +17,6 @@ from typing import (
     Literal,
     Optional,
     Type,
-    TypeVar,
     Union,
 )
 
@@ -25,7 +24,9 @@ import grpc
 from google.protobuf.descriptor import EnumDescriptor
 
 from ni_measurementlink_service import _datatypeinfo
-from ni_measurementlink_service._channelpool import GrpcChannelPool as GrpcChannelPool  # re-export
+from ni_measurementlink_service._channelpool import (  # re-export
+    GrpcChannelPool as GrpcChannelPool,
+)
 from ni_measurementlink_service._internal import grpc_servicer
 from ni_measurementlink_service._internal.discovery_client import DiscoveryClient
 from ni_measurementlink_service._internal.parameter import (

--- a/ni_measurementlink_service/measurement/service.py
+++ b/ni_measurementlink_service/measurement/service.py
@@ -48,6 +48,11 @@ if TYPE_CHECKING:
     else:
         from typing_extensions import TypeGuard
 
+    if sys.version_info >= (3, 11):
+        from typing import Self
+    else:
+        from typing_extensions import Self
+
     SupportedEnumType = Union[Type[Enum], _EnumTypeWrapper]
 
 
@@ -80,10 +85,6 @@ class MeasurementContext:
     def abort(self, code: grpc.StatusCode, details: str) -> None:
         """Aborts the RPC."""
         grpc_servicer.measurement_service_context.get().abort(code, details)
-
-
-# Eventually, these can be replaced with typing.Self (Python >= 3.11).
-_TMeasurementService = TypeVar("_TMeasurementService", bound="MeasurementService")
 
 
 class MeasurementService:
@@ -393,7 +394,7 @@ class MeasurementService:
         self.grpc_service.stop()
         self.channel_pool.close()
 
-    def __enter__(self: _TMeasurementService) -> _TMeasurementService:
+    def __enter__(self: Self) -> Self:
         """Enter the runtime context related to the measurement service."""
         return self
 

--- a/ni_measurementlink_service/measurement/service.py
+++ b/ni_measurementlink_service/measurement/service.py
@@ -7,7 +7,6 @@ import sys
 from enum import Enum, EnumMeta
 from os import path
 from pathlib import Path
-from threading import Lock
 from types import TracebackType
 from typing import (
     TYPE_CHECKING,
@@ -26,13 +25,13 @@ import grpc
 from google.protobuf.descriptor import EnumDescriptor
 
 from ni_measurementlink_service import _datatypeinfo
+from ni_measurementlink_service._channelpool import GrpcChannelPool as GrpcChannelPool  # re-export
 from ni_measurementlink_service._internal import grpc_servicer
 from ni_measurementlink_service._internal.discovery_client import DiscoveryClient
 from ni_measurementlink_service._internal.parameter import (
     metadata as parameter_metadata,
 )
 from ni_measurementlink_service._internal.service_manager import GrpcService
-from ni_measurementlink_service._loggers import ClientLogger
 from ni_measurementlink_service.measurement.info import (
     DataType,
     MeasurementInfo,
@@ -84,64 +83,7 @@ class MeasurementContext:
 
 
 # Eventually, these can be replaced with typing.Self (Python >= 3.11).
-_TGrpcChannelPool = TypeVar("_TGrpcChannelPool", bound="GrpcChannelPool")
 _TMeasurementService = TypeVar("_TMeasurementService", bound="MeasurementService")
-
-
-class GrpcChannelPool(object):
-    """Class that manages gRPC channel lifetimes."""
-
-    def __init__(self) -> None:
-        """Initialize the GrpcChannelPool object."""
-        self._lock: Lock = Lock()
-        self._channel_cache: Dict[str, grpc.Channel] = {}
-
-    def __enter__(self: _TGrpcChannelPool) -> _TGrpcChannelPool:
-        """Enter the runtime context of the GrpcChannelPool."""
-        return self
-
-    def __exit__(
-        self,
-        exc_type: Optional[Type[BaseException]],
-        exc_val: Optional[BaseException],
-        traceback: Optional[TracebackType],
-    ) -> Literal[False]:
-        """Exit the runtime context of the GrpcChannelPool."""
-        self.close()
-        return False
-
-    def get_channel(self, target: str) -> grpc.Channel:
-        """Return a gRPC channel.
-
-        Args:
-            target (str): The server address
-
-        """
-        new_channel = None
-        with self._lock:
-            if target not in self._channel_cache:
-                self._lock.release()
-                new_channel = grpc.insecure_channel(target)
-                if ClientLogger.is_enabled():
-                    new_channel = grpc.intercept_channel(new_channel, ClientLogger())
-                self._lock.acquire()
-                if target not in self._channel_cache:
-                    self._channel_cache[target] = new_channel
-                    new_channel = None
-            channel = self._channel_cache[target]
-
-        # Close new_channel if it was not stored in _channel_cache.
-        if new_channel is not None:
-            new_channel.close()
-
-        return channel
-
-    def close(self) -> None:
-        """Close channels opened by get_channel()."""
-        with self._lock:
-            for channel in self._channel_cache.values():
-                channel.close()
-            self._channel_cache.clear()
 
 
 class MeasurementService:

--- a/ni_measurementlink_service/session_management.py
+++ b/ni_measurementlink_service/session_management.py
@@ -1,12 +1,13 @@
 """Contains methods related to managing driver sessions."""
 from __future__ import annotations
 
-import sys
 import abc
+import sys
 import warnings
 from functools import cached_property
 from types import TracebackType
 from typing import (
+    TYPE_CHECKING,
     Any,
     Iterable,
     List,
@@ -15,8 +16,6 @@ from typing import (
     Optional,
     Sequence,
     Type,
-    TypeVar,
-    TYPE_CHECKING,
 )
 
 import grpc

--- a/ni_measurementlink_service/session_management.py
+++ b/ni_measurementlink_service/session_management.py
@@ -1,6 +1,7 @@
 """Contains methods related to managing driver sessions."""
 from __future__ import annotations
 
+import sys
 import abc
 import warnings
 from functools import cached_property
@@ -15,6 +16,7 @@ from typing import (
     Sequence,
     Type,
     TypeVar,
+    TYPE_CHECKING,
 )
 
 import grpc
@@ -28,6 +30,12 @@ from ni_measurementlink_service._internal.stubs.ni.measurementlink.sessionmanage
     session_management_service_pb2,
     session_management_service_pb2_grpc,
 )
+
+if TYPE_CHECKING:
+    if sys.version_info >= (3, 11):
+        from typing import Self
+    else:
+        from typing_extensions import Self
 
 GRPC_SERVICE_INTERFACE_NAME = "ni.measurementlink.sessionmanagement.v1.SessionManagementService"
 GRPC_SERVICE_CLASS = "ni.measurementlink.sessionmanagement.v1.SessionManagementService"
@@ -175,10 +183,6 @@ def _convert_session_info_to_grpc(
     )
 
 
-# Eventually, this can be replaced with typing.Self (Python >= 3.11).
-_TReservation = TypeVar("_TReservation", bound="BaseReservation")
-
-
 class BaseReservation(abc.ABC):
     """Manages session reservation."""
 
@@ -191,7 +195,7 @@ class BaseReservation(abc.ABC):
         self._session_manager = session_manager
         self._session_info = session_info
 
-    def __enter__(self: _TReservation) -> _TReservation:
+    def __enter__(self: Self) -> Self:
         """Context management protocol. Returns self."""
         return self
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Split `GrpcChannelPool` out of `service.py` and into `_channelpool.py`.

Re-export `GrpcChannelPool` from `service.py`. 

> **Note**
>
> This uses the convention `from foo import bar as bar` to re-export, as documented in https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-no-implicit-reexport

Update context managers to use `typing_extensions.Self`.

### Why should this Pull Request be merged?

Prerequisite for updating client classes to accept a GrpcChannelPool. (Otherwise, it's a circular import.)

### What testing has been done?

Ran pytest.