### PR TITLE
Fix the discovery service to not terminate on parent process closure

### DIFF
--- a/ni_measurementlink_service/_internal/discovery_client.py
+++ b/ni_measurementlink_service/_internal/discovery_client.py
@@ -268,7 +268,7 @@ def _start_service(
     kwargs: Dict[str, Any] = {}
     if sys.platform == "win32":
         # Terminating the measurement service should not terminate the discovery service.
-        kwargs["creationflags"] = subprocess.CREATE_BREAKAWAY_FROM_JOB
+        kwargs["creationflags"] = subprocess.CREATE_BREAKAWAY_FROM_JOB | subprocess.DETACHED_PROCESS
     discovery_service_subprocess = subprocess.Popen(
         [exe_file_path],
         cwd=exe_file_path.parent,

--- a/tests/unit/test_discovery_client.py
+++ b/tests/unit/test_discovery_client.py
@@ -193,7 +193,7 @@ def test___discovery_service_exe_unavailable___register_service___raises_file_no
 def subprocess_popen_kwargs() -> Dict[str, Any]:
     kwargs: Dict[str, Any] = {}
     if sys.platform == "win32":
-        kwargs["creationflags"] = subprocess.CREATE_BREAKAWAY_FROM_JOB
+        kwargs["creationflags"] = subprocess.CREATE_BREAKAWAY_FROM_JOB | subprocess.DETACHED_PROCESS
     return kwargs
 
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
When a measurement service is started without an existing discovery service, it starts the discovery service as a child process. If the measurement service's process(i.e. parent process of the discovery service) is killed, aborted, or by directly closing the application(without proper closure), it also results in the termination of the discovery service.

- When the measurement service console(parent process) is started on `debug mode`, it creates a separate job, which in turn spawns a child process (discovery service). The use of `CREATE_BREAKAWAY_FROM_JOB` ensures the child process is detached from the job([documentation](https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags#flags:~:text=CREATE_BREAKAWAY_FROM_JOB)), preventing the termination of the discovery service when starting and properly closing the measurement service using VS Code's Debug mode. 
- However, this flag doesn't ensure that the child process(discovery service) is detached from the parent process(measurement service's console) which results in the termination of the discovery service on killing/termination of the measurement service terminal or VS Code closure.
- To detach from the parent console process, a creation flag `DETACHED_PROCESS` is added in `discovery_client.py` which ensures that the new process does not inherit its parent's console([documentation](https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags#flags:~:text=any%20child%20processes.-,DETACHED_PROCESS,-0x00000008)).

### Why should this Pull Request be merged?

Fixes [Bug 2508628](https://dev.azure.com/ni/DevCentral/_workitems/edit/2508628): Python measurements - Discovery service is not completely detached from VSCode console/terminal and terminates on terminal closure

### What testing has been done?

Manually tested the following different cases.
- Started the measurement service in different environments such as VS Code(`Run mode`, `Debug mode`, `Terminal Run using commands`), command prompt, Windows PowerShell, and Python Idle, then either terminated or properly closed the respective processes and inferred the use cases.
- I have also listed the different test cases for starting the discovery service from the measurement service and its statuses [here](https://nio365.sharepoint.com/:x:/r/sites/TestAutomationFrameworks/Shared%20Documents/TAF-Soliton%20Collaboration/2023%20H2/Test%20cases%20for%20launching%20the%20discovery%20service%20through%20the%20measurement%20service.xlsx?d=w73c54be6580346ccb6307c0a264466bc&csf=1&web=1&e=NSi0eh).