### PR TITLE
Include game_of_life in list of examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -27,6 +27,7 @@ The TestStand sequence files associated with each example are saved in TestStand
 - `niswitch_control_relays`: Controls relays using an NI relay driver (e.g. PXI-2567).
 - `nivisa_dmm_measurement`: Performs a DMM measurement using NI-VISA and an NI Instrument Simulator v2.0.
 - `ui_progress_updates`: Generates random numbers and updates the measurement UI to show progress.
+- `game_of_life`: Displays Conway's Game of Life in a graph.
 
 For more details about a specific example, see the `README.md` file included with the example.
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds game_of_life to list of examples in readme.

### Why should this Pull Request be merged?

Missed this when I checked in the example.

### What testing has been done?

None