### PR TITLE
service: Update reserve_session(s) to accept a single pin and explicitly specify default timeout

### DIFF
--- a/ni_measurementlink_service/session_management.py
+++ b/ni_measurementlink_service/session_management.py
@@ -18,6 +18,7 @@ from typing import (
     Optional,
     Sequence,
     Type,
+    Union,
 )
 
 import grpc
@@ -305,7 +306,7 @@ class SessionManagementClient(object):
     def reserve_session(
         self,
         context: PinMapContext,
-        pin_or_relay_names: Optional[Iterable[str]] = None,
+        pin_or_relay_names: Union[str, Iterable[str], None] = None,
         instrument_type_id: Optional[str] = None,
         timeout: Optional[float] = None,
     ) -> SingleSessionReservation:
@@ -356,7 +357,7 @@ class SessionManagementClient(object):
     def reserve_sessions(
         self,
         context: PinMapContext,
-        pin_or_relay_names: Optional[Iterable[str]] = None,
+        pin_or_relay_names: Union[str, Iterable[str], None] = None,
         instrument_type_id: Optional[str] = None,
         timeout: Optional[float] = None,
     ) -> MultiSessionReservation:
@@ -399,7 +400,7 @@ class SessionManagementClient(object):
     def _reserve_sessions(
         self,
         context: PinMapContext,
-        pin_or_relay_names: Optional[Iterable[str]] = None,
+        pin_or_relay_names: Union[str, Iterable[str], None] = None,
         instrument_type_id: Optional[str] = None,
         timeout: Optional[float] = None,
     ) -> Sequence[session_management_service_pb2.SessionInformation]:
@@ -412,7 +413,9 @@ class SessionManagementClient(object):
         )
         if instrument_type_id is not None:
             request.instrument_type_id = instrument_type_id
-        if pin_or_relay_names is not None:
+        if isinstance(pin_or_relay_names, str):
+            request.pin_or_relay_names.append(pin_or_relay_names)
+        elif pin_or_relay_names is not None:
             request.pin_or_relay_names.extend(pin_or_relay_names)
         if timeout is not None:
             timeout_in_ms = round(timeout * 1000)

--- a/ni_measurementlink_service/session_management.py
+++ b/ni_measurementlink_service/session_management.py
@@ -308,7 +308,7 @@ class SessionManagementClient(object):
         context: PinMapContext,
         pin_or_relay_names: Union[str, Iterable[str], None] = None,
         instrument_type_id: Optional[str] = None,
-        timeout: Optional[float] = None,
+        timeout: Optional[float] = 0.0,
     ) -> SingleSessionReservation:
         """Reserve a single session.
 
@@ -359,7 +359,7 @@ class SessionManagementClient(object):
         context: PinMapContext,
         pin_or_relay_names: Union[str, Iterable[str], None] = None,
         instrument_type_id: Optional[str] = None,
-        timeout: Optional[float] = None,
+        timeout: Optional[float] = 0.0,
     ) -> MultiSessionReservation:
         """Reserve multiple sessions.
 
@@ -402,7 +402,7 @@ class SessionManagementClient(object):
         context: PinMapContext,
         pin_or_relay_names: Union[str, Iterable[str], None] = None,
         instrument_type_id: Optional[str] = None,
-        timeout: Optional[float] = None,
+        timeout: Optional[float] = 0.0,
     ) -> Sequence[session_management_service_pb2.SessionInformation]:
         pin_map_context = pin_map_context_pb2.PinMapContext(
             pin_map_id=context.pin_map_id, sites=context.sites

--- a/tests/unit/test_session_management.py
+++ b/tests/unit/test_session_management.py
@@ -67,6 +67,29 @@ def test___no_optional_args___reserve_session___sends_request_with_defaults(
     assert request.instrument_type_id == ""
     assert request.timeout_in_milliseconds == 0.0
 
+    
+def test___explicit_none___reserve_session___sends_request_with_defaults(
+    session_management_client: SessionManagementClient, session_management_stub: Mock
+) -> None:
+    session_management_stub.ReserveSessions.return_value = (
+        session_management_service_pb2.ReserveSessionsResponse(
+            sessions=_create_grpc_session_infos(1)
+        )
+    )
+
+    _ = session_management_client.reserve_session(
+        PinMapContext("MyPinMap", [0, 1]),
+        pin_or_relay_names=None,
+        instrument_type_id=None,
+        timeout=None,
+    )
+
+    session_management_stub.ReserveSessions.assert_called_once()
+    (request,) = session_management_stub.ReserveSessions.call_args.args
+    assert request.pin_or_relay_names == []
+    assert request.instrument_type_id == ""
+    assert request.timeout_in_milliseconds == 0.0
+
 
 def test___single_pin___reserve_session___sends_request_with_single_pin(
     session_management_client: SessionManagementClient, session_management_stub: Mock
@@ -173,6 +196,27 @@ def test___no_optional_args___reserve_sessions___sends_request_with_defaults(
 
     _ = session_management_client.reserve_sessions(
         PinMapContext("MyPinMap", [0, 1]),
+    )
+
+    session_management_stub.ReserveSessions.assert_called_once()
+    (request,) = session_management_stub.ReserveSessions.call_args.args
+    assert request.pin_or_relay_names == []
+    assert request.instrument_type_id == ""
+    assert request.timeout_in_milliseconds == 0.0
+
+
+def test___explicit_none___reserve_sessions___sends_request_with_defaults(
+    session_management_client: SessionManagementClient, session_management_stub: Mock
+) -> None:
+    session_management_stub.ReserveSessions.return_value = (
+        session_management_service_pb2.ReserveSessionsResponse()
+    )
+
+    _ = session_management_client.reserve_sessions(
+        PinMapContext("MyPinMap", [0, 1]),
+        pin_or_relay_names=None,
+        instrument_type_id=None,
+        timeout=None,
     )
 
     session_management_stub.ReserveSessions.assert_called_once()

--- a/tests/unit/test_session_management.py
+++ b/tests/unit/test_session_management.py
@@ -23,7 +23,7 @@ from ni_measurementlink_service.session_management import (
 )
 
 
-def test___reserve_session___sends_request(
+def test___all_optional_args___reserve_session___sends_request_with_args(
     session_management_client: SessionManagementClient, session_management_stub: Mock
 ) -> None:
     session_management_stub.ReserveSessions.return_value = (
@@ -46,6 +46,45 @@ def test___reserve_session___sends_request(
     assert request.pin_or_relay_names == ["Pin1", "Pin2"]
     assert request.instrument_type_id == "MyInstrumentType"
     assert request.timeout_in_milliseconds == 123456
+
+
+def test___no_optional_args___reserve_session___sends_request_with_defaults(
+    session_management_client: SessionManagementClient, session_management_stub: Mock
+) -> None:
+    session_management_stub.ReserveSessions.return_value = (
+        session_management_service_pb2.ReserveSessionsResponse(
+            sessions=_create_grpc_session_infos(1)
+        )
+    )
+
+    _ = session_management_client.reserve_session(
+        PinMapContext("MyPinMap", [0, 1]),
+    )
+
+    session_management_stub.ReserveSessions.assert_called_once()
+    (request,) = session_management_stub.ReserveSessions.call_args.args
+    assert request.pin_or_relay_names == []
+    assert request.instrument_type_id == ""
+    assert request.timeout_in_milliseconds == 0.0
+
+
+def test___single_pin___reserve_session___sends_request_with_single_pin(
+    session_management_client: SessionManagementClient, session_management_stub: Mock
+) -> None:
+    session_management_stub.ReserveSessions.return_value = (
+        session_management_service_pb2.ReserveSessionsResponse(
+            sessions=_create_grpc_session_infos(1)
+        )
+    )
+
+    _ = session_management_client.reserve_session(
+        PinMapContext("MyPinMap", [0, 1]),
+        pin_or_relay_names="Pin1",
+    )
+
+    session_management_stub.ReserveSessions.assert_called_once()
+    (request,) = session_management_stub.ReserveSessions.call_args.args
+    assert request.pin_or_relay_names == ["Pin1"]
 
 
 def test___single_session___reserve_session___returns_single_session_info(
@@ -102,7 +141,7 @@ def test___too_many_sessions___reserve_session___raises_too_many_sessions_value_
         )
 
 
-def test___reserve_sessions___sends_request(
+def test___all_optional_args___reserve_sessions___sends_request_with_args(
     session_management_client: SessionManagementClient, session_management_stub: Mock
 ) -> None:
     session_management_stub.ReserveSessions.return_value = (
@@ -123,6 +162,41 @@ def test___reserve_sessions___sends_request(
     assert request.pin_or_relay_names == ["Pin1", "Pin2"]
     assert request.instrument_type_id == "MyInstrumentType"
     assert request.timeout_in_milliseconds == 123456
+
+
+def test___no_optional_args___reserve_sessions___sends_request_with_defaults(
+    session_management_client: SessionManagementClient, session_management_stub: Mock
+) -> None:
+    session_management_stub.ReserveSessions.return_value = (
+        session_management_service_pb2.ReserveSessionsResponse()
+    )
+
+    _ = session_management_client.reserve_sessions(
+        PinMapContext("MyPinMap", [0, 1]),
+    )
+
+    session_management_stub.ReserveSessions.assert_called_once()
+    (request,) = session_management_stub.ReserveSessions.call_args.args
+    assert request.pin_or_relay_names == []
+    assert request.instrument_type_id == ""
+    assert request.timeout_in_milliseconds == 0.0
+
+
+def test___single_pin___reserve_sessions___sends_request_with_single_pin(
+    session_management_client: SessionManagementClient, session_management_stub: Mock
+) -> None:
+    session_management_stub.ReserveSessions.return_value = (
+        session_management_service_pb2.ReserveSessionsResponse()
+    )
+
+    _ = session_management_client.reserve_sessions(
+        PinMapContext("MyPinMap", [0, 1]),
+        pin_or_relay_names="Pin1",
+    )
+
+    session_management_stub.ReserveSessions.assert_called_once()
+    (request,) = session_management_stub.ReserveSessions.call_args.args
+    assert request.pin_or_relay_names == ["Pin1"]
 
 
 @pytest.mark.parametrize("session_count", [0, 1, 2])

--- a/tests/unit/test_session_management.py
+++ b/tests/unit/test_session_management.py
@@ -67,7 +67,7 @@ def test___no_optional_args___reserve_session___sends_request_with_defaults(
     assert request.instrument_type_id == ""
     assert request.timeout_in_milliseconds == 0.0
 
-    
+
 def test___explicit_none___reserve_session___sends_request_with_defaults(
     session_management_client: SessionManagementClient, session_management_stub: Mock
 ) -> None:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

`SessionManagementClient`:
- Update `reserve_session(s)` to accept a single pin for the `pin_or_relay_names` argument.
- Change `reserve_session(s)` to explicitly specify a default timeout of 0.0.
- Update documentation.
- Add more unit test cases. 

### Why should this Pull Request be merged?

Accepting a single pin allows calling `reserve_session(context, "Vdd")` without wrapping the pin name in a list or tuple.

In Python, `str` is a `Iterable[str]` that iterates over the characters of the string. Before this change, `reserve_session(context, "Vdd")` would pass type checking, but at run time it translated `"Vdd"` to `["V", "d", "d"]`, which is surprising behavior.

The default timeout behavior was previously undocumented. Using a default value of `None` was ambiguous, because `None` could plausibly be interpreted as either -1 (infinite) or 0.0 (non-blocking).

### What testing has been done?

Ran `poetry run pytest -v`.
Manually tested a modified version of `nidmm_measurement.
Ran `poetry run sphinx-build _docs_source docs -b html -W --keep-going` and looked at the output.