### PR TITLE
Removing reservation timeout and instrument ID from reserve_session c…

### DIFF
--- a/examples/nidaqmx_analog_input/measurement.py
+++ b/examples/nidaqmx_analog_input/measurement.py
@@ -31,14 +31,6 @@ measurement_service = nims.MeasurementService(
 service_options = ServiceOptions()
 
 
-RESERVATION_TIMEOUT_IN_SECONDS = 60.0
-"""
-If another measurement is using the session, the reserve function will wait
-for it to complete. Specify a reservation timeout to aid in debugging missed
-unreserve calls. Long measurements may require a longer timeout.
-"""
-
-
 @measurement_service.register_measurement
 @measurement_service.configuration(
     "pin_name",
@@ -59,10 +51,7 @@ def measure(pin_name: str, sample_rate: float, number_of_samples: int) -> Tuple[
     )
     session_management_client = create_session_management_client(measurement_service)
     with session_management_client.reserve_session(
-        context=measurement_service.context.pin_map_context,
-        pin_or_relay_names=[pin_name],
-        instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_DAQMX,
-        timeout=RESERVATION_TIMEOUT_IN_SECONDS,
+        context=measurement_service.context.pin_map_context, pin_or_relay_names=[pin_name]
     ) as reservation:
         task: Optional[nidaqmx.Task] = None
 

--- a/examples/nidaqmx_analog_input/teststand_fixture.py
+++ b/examples/nidaqmx_analog_input/teststand_fixture.py
@@ -76,8 +76,6 @@ def destroy_nidaqmx_tasks() -> None:
         )
         with session_management_client.reserve_all_registered_sessions(
             instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_DAQMX,
-            # This code module sets up the sessions, so error immediately if they are in use.
-            timeout=0,
         ) as reservation:
             session_management_client.unregister_sessions(reservation.session_info)
 

--- a/examples/nidaqmx_analog_input/teststand_fixture.py
+++ b/examples/nidaqmx_analog_input/teststand_fixture.py
@@ -53,8 +53,6 @@ def create_nidaqmx_tasks(sequence_context: Any) -> None:
         with session_management_client.reserve_sessions(
             context=pin_map_context,
             instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_DAQMX,
-            # This code module sets up the sessions, so error immediately if they are in use.
-            timeout=0,
         ) as reservation:
             for session_info in reservation.session_info:
                 task = create_task(

--- a/examples/nidcpower_source_dc_voltage/measurement.py
+++ b/examples/nidcpower_source_dc_voltage/measurement.py
@@ -41,13 +41,6 @@ measurement_service = nims.MeasurementService(
 )
 service_options = ServiceOptions()
 
-RESERVATION_TIMEOUT_IN_SECONDS = 60.0
-"""
-If another measurement is using the session, the reserve function will wait
-for it to complete. Specify a reservation timeout to aid in debugging missed
-unreserve calls. Long measurements may require a longer timeout.
-"""
-
 
 @measurement_service.register_measurement
 @measurement_service.configuration(
@@ -80,10 +73,7 @@ def measure(
     session_management_client = create_session_management_client(measurement_service)
 
     with session_management_client.reserve_session(
-        context=measurement_service.context.pin_map_context,
-        pin_or_relay_names=pin_names,
-        instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_DCPOWER,
-        timeout=RESERVATION_TIMEOUT_IN_SECONDS,
+        context=measurement_service.context.pin_map_context, pin_or_relay_names=pin_names
     ) as reservation:
         grpc_device_channel = get_grpc_device_channel(
             measurement_service, nidcpower, service_options

--- a/examples/nidcpower_source_dc_voltage/teststand_fixture.py
+++ b/examples/nidcpower_source_dc_voltage/teststand_fixture.py
@@ -75,8 +75,6 @@ def destroy_nidcpower_sessions() -> None:
         )
         with session_management_client.reserve_all_registered_sessions(
             instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_DCPOWER,
-            # This code module sets up the sessions, so error immediately if they are in use.
-            timeout=0,
         ) as reservation:
             session_management_client.unregister_sessions(reservation.session_info)
 

--- a/examples/nidcpower_source_dc_voltage/teststand_fixture.py
+++ b/examples/nidcpower_source_dc_voltage/teststand_fixture.py
@@ -53,10 +53,6 @@ def create_nidcpower_sessions(sequence_context: Any) -> None:
         with session_management_client.reserve_sessions(
             context=pin_map_context,
             instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_DCPOWER,
-            # If another measurement is using the session, wait for it to complete.
-            # Specify a timeout to aid in debugging missed unreserve calls.
-            # Long measurements may require a longer timeout.
-            timeout=60,
         ) as reservation:
             for session_info in reservation.session_info:
                 # Leave session open

--- a/examples/nidigital_spi/measurement.py
+++ b/examples/nidigital_spi/measurement.py
@@ -31,13 +31,6 @@ measurement_service = nims.MeasurementService(
 )
 service_options = ServiceOptions()
 
-RESERVATION_TIMEOUT_IN_SECONDS = 60.0
-"""
-If another measurement is using the session, the reserve function will wait
-for it to complete. Specify a reservation timeout to aid in debugging missed
-unreserve calls. Long measurements may require a longer timeout.
-"""
-
 
 @measurement_service.register_measurement
 @measurement_service.configuration(
@@ -68,10 +61,7 @@ def measure(
     session_management_client = create_session_management_client(measurement_service)
 
     with session_management_client.reserve_session(
-        context=measurement_service.context.pin_map_context,
-        pin_or_relay_names=pin_names,
-        instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_DIGITAL_PATTERN,
-        timeout=RESERVATION_TIMEOUT_IN_SECONDS,
+        context=measurement_service.context.pin_map_context, pin_or_relay_names=pin_names
     ) as reservation:
         grpc_device_channel = get_grpc_device_channel(
             measurement_service, nidigital, service_options

--- a/examples/nidigital_spi/teststand_fixture.py
+++ b/examples/nidigital_spi/teststand_fixture.py
@@ -164,8 +164,6 @@ def destroy_nidigital_sessions() -> None:
         )
         with session_management_client.reserve_all_registered_sessions(
             instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_DIGITAL_PATTERN,
-            # This code module sets up the sessions, so error immediately if they are in use.
-            timeout=0,
         ) as reservation:
             session_management_client.unregister_sessions(reservation.session_info)
 

--- a/examples/nidigital_spi/teststand_fixture.py
+++ b/examples/nidigital_spi/teststand_fixture.py
@@ -182,10 +182,7 @@ def _reserve_sessions(
     pin_map_context = nims.session_management.PinMapContext(pin_map_id=pin_map_id, sites=None)
 
     return session_management_client.reserve_sessions(
-        context=pin_map_context,
-        instrument_type_id=instrument_type_id,
-        # This code module sets up the sessions, so error immediately if they are in use.
-        timeout=0,
+        context=pin_map_context, instrument_type_id=instrument_type_id
     )
 
 

--- a/examples/nidmm_measurement/measurement.py
+++ b/examples/nidmm_measurement/measurement.py
@@ -33,13 +33,6 @@ measurement_service = nims.MeasurementService(
 )
 service_options = ServiceOptions()
 
-RESERVATION_TIMEOUT_IN_SECONDS = 60.0
-"""
-If another measurement is using the session, the reserve function will wait
-for it to complete. Specify a reservation timeout to aid in debugging missed
-unreserve calls. Long measurements may require a longer timeout.
-"""
-
 
 class Function(Enum):
     """Wrapper enum that contains a zero value."""
@@ -95,10 +88,7 @@ def measure(
     session_management_client = create_session_management_client(measurement_service)
 
     with session_management_client.reserve_session(
-        context=measurement_service.context.pin_map_context,
-        pin_or_relay_names=[pin_name],
-        instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_DMM,
-        timeout=RESERVATION_TIMEOUT_IN_SECONDS,
+        context=measurement_service.context.pin_map_context, pin_or_relay_names=[pin_name]
     ) as reservation:
         grpc_device_channel = get_grpc_device_channel(measurement_service, nidmm, service_options)
         with create_session(reservation.session_info, grpc_device_channel) as session:

--- a/examples/nidmm_measurement/teststand_fixture.py
+++ b/examples/nidmm_measurement/teststand_fixture.py
@@ -52,8 +52,6 @@ def create_nidmm_sessions(sequence_context: Any) -> None:
         with session_management_client.reserve_sessions(
             context=pin_map_context,
             instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_DMM,
-            # This code module sets up the sessions, so error immediately if they are in use.
-            timeout=0,
         ) as reservation:
             for session_info in reservation.session_info:
                 # Leave session open

--- a/examples/nidmm_measurement/teststand_fixture.py
+++ b/examples/nidmm_measurement/teststand_fixture.py
@@ -75,8 +75,6 @@ def destroy_nidmm_sessions() -> None:
         )
         with session_management_client.reserve_all_registered_sessions(
             instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_DMM,
-            # This code module sets up the sessions, so error immediately if they are in use.
-            timeout=0,
         ) as reservation:
             session_management_client.unregister_sessions(reservation.session_info)
             for session_info in reservation.session_info:

--- a/examples/nifgen_standard_function/measurement.py
+++ b/examples/nifgen_standard_function/measurement.py
@@ -40,13 +40,6 @@ measurement_service = nims.MeasurementService(
 )
 service_options = ServiceOptions()
 
-RESERVATION_TIMEOUT_IN_SECONDS = 60.0
-"""
-If another measurement is using the session, the reserve function will wait
-for it to complete. Specify a reservation timeout to aid in debugging missed
-unreserve calls. Long measurements may require a longer timeout.
-"""
-
 
 class Waveform(Enum):
     """Wrapper enum that contains a zero value."""
@@ -100,10 +93,7 @@ def measure(
     with contextlib.ExitStack() as stack:
         reservation = stack.enter_context(
             session_management_client.reserve_sessions(
-                context=measurement_service.context.pin_map_context,
-                pin_or_relay_names=[pin_name],
-                instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_FGEN,
-                timeout=RESERVATION_TIMEOUT_IN_SECONDS,
+                context=measurement_service.context.pin_map_context, pin_or_relay_names=[pin_name]
             )
         )
 

--- a/examples/nifgen_standard_function/teststand_fixture.py
+++ b/examples/nifgen_standard_function/teststand_fixture.py
@@ -75,8 +75,6 @@ def destroy_nifgen_sessions() -> None:
         )
         with session_management_client.reserve_all_registered_sessions(
             instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_FGEN,
-            # This code module sets up the sessions, so error immediately if they are in use.
-            timeout=0,
         ) as reservation:
             session_management_client.unregister_sessions(reservation.session_info)
             for session_info in reservation.session_info:

--- a/examples/nifgen_standard_function/teststand_fixture.py
+++ b/examples/nifgen_standard_function/teststand_fixture.py
@@ -52,8 +52,6 @@ def create_nifgen_sessions(sequence_context: Any) -> None:
         with session_management_client.reserve_sessions(
             context=pin_map_context,
             instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_FGEN,
-            # This code module sets up the sessions, so error immediately if they are in use.
-            timeout=0,
         ) as reservation:
             for session_info in reservation.session_info:
                 # Leave session open

--- a/examples/niscope_acquire_waveform/measurement.py
+++ b/examples/niscope_acquire_waveform/measurement.py
@@ -34,13 +34,6 @@ measurement_service = nims.MeasurementService(
 )
 service_options = ServiceOptions()
 
-RESERVATION_TIMEOUT_IN_SECONDS = 60.0
-"""
-If another measurement is using the session, the reserve function will wait
-for it to complete. Specify a reservation timeout to aid in debugging missed
-unreserve calls. Long measurements may require a longer timeout.
-"""
-
 
 @measurement_service.register_measurement
 @measurement_service.configuration(
@@ -113,10 +106,7 @@ def measure(
     session_management_client = create_session_management_client(measurement_service)
 
     with session_management_client.reserve_session(
-        context=measurement_service.context.pin_map_context,
-        pin_or_relay_names=pin_names,
-        instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_SCOPE,
-        timeout=RESERVATION_TIMEOUT_IN_SECONDS,
+        context=measurement_service.context.pin_map_context, pin_or_relay_names=pin_names
     ) as reservation:
         channel_names = reservation.session_info.channel_list
         pin_to_channel = {

--- a/examples/niscope_acquire_waveform/teststand_fixture.py
+++ b/examples/niscope_acquire_waveform/teststand_fixture.py
@@ -53,8 +53,6 @@ def create_niscope_sessions(sequence_context: Any) -> None:
         with session_management_client.reserve_sessions(
             context=pin_map_context,
             instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_SCOPE,
-            # This code module sets up the sessions, so error immediately if they are in use.
-            timeout=0,
         ) as reservation:
             for session_info in reservation.session_info:
                 # Leave session open

--- a/examples/niscope_acquire_waveform/teststand_fixture.py
+++ b/examples/niscope_acquire_waveform/teststand_fixture.py
@@ -76,8 +76,6 @@ def destroy_niscope_sessions() -> None:
         )
         with session_management_client.reserve_all_registered_sessions(
             instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_SCOPE,
-            # This code module sets up the sessions, so error immediately if they are in use.
-            timeout=0,
         ) as reservation:
             session_management_client.unregister_sessions(reservation.session_info)
 

--- a/examples/niswitch_control_relays/measurement.py
+++ b/examples/niswitch_control_relays/measurement.py
@@ -32,13 +32,6 @@ measurement_service = nims.MeasurementService(
 )
 service_options = ServiceOptions()
 
-RESERVATION_TIMEOUT_IN_SECONDS = 60.0
-"""
-If another measurement is using the session, the reserve function will wait
-for it to complete. Specify a reservation timeout to aid in debugging missed
-unreserve calls. Long measurements may require a longer timeout.
-"""
-
 
 @measurement_service.register_measurement
 @measurement_service.configuration("relay_names", nims.DataType.String, "SiteRelay1")
@@ -60,10 +53,7 @@ def measure(
         relay_list = [r.strip() for r in relay_names.split(",")]
         reservation = stack.enter_context(
             session_management_client.reserve_sessions(
-                context=measurement_service.context.pin_map_context,
-                pin_or_relay_names=relay_list,
-                instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_RELAY_DRIVER,
-                timeout=RESERVATION_TIMEOUT_IN_SECONDS,
+                context=measurement_service.context.pin_map_context, pin_or_relay_names=relay_list
             )
         )
 

--- a/examples/niswitch_control_relays/teststand_fixture.py
+++ b/examples/niswitch_control_relays/teststand_fixture.py
@@ -76,8 +76,6 @@ def destroy_niswitch_sessions() -> None:
         )
         with session_management_client.reserve_all_registered_sessions(
             instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_RELAY_DRIVER,
-            # This code module sets up the sessions, so error immediately if they are in use.
-            timeout=0,
         ) as reservation:
             session_management_client.unregister_sessions(reservation.session_info)
 

--- a/examples/niswitch_control_relays/teststand_fixture.py
+++ b/examples/niswitch_control_relays/teststand_fixture.py
@@ -53,8 +53,6 @@ def create_niswitch_sessions(sequence_context: Any) -> None:
         with session_management_client.reserve_sessions(
             context=pin_map_context,
             instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_RELAY_DRIVER,
-            # This code module sets up the sessions, so error immediately if they are in use.
-            timeout=0,
         ) as reservation:
             for session_info in reservation.session_info:
                 # Leave session open

--- a/examples/nivisa_dmm_measurement/measurement.py
+++ b/examples/nivisa_dmm_measurement/measurement.py
@@ -37,12 +37,6 @@ measurement_service = nims.MeasurementService(
 )
 service_options = ServiceOptions()
 
-RESERVATION_TIMEOUT_IN_SECONDS = 60.0
-"""
-If another measurement is using the session, the reserve function will wait
-for it to complete. Specify a reservation timeout to aid in debugging missed
-unreserve calls. Long measurements may require a longer timeout.
-"""
 
 RESOLUTION_DIGITS_TO_VALUE = {"3.5": 0.001, "4.5": 0.0001, "5.5": 1e-5, "6.5": 1e-6}
 
@@ -88,10 +82,7 @@ def measure(
     session_management_client = create_session_management_client(measurement_service)
 
     with session_management_client.reserve_session(
-        context=measurement_service.context.pin_map_context,
-        pin_or_relay_names=[pin_name],
-        instrument_type_id=INSTRUMENT_TYPE_DMM_SIMULATOR,
-        timeout=RESERVATION_TIMEOUT_IN_SECONDS,
+        context=measurement_service.context.pin_map_context, pin_or_relay_names=[pin_name]
     ) as reservation:
         resource_manager = create_visa_resource_manager(service_options.use_simulation)
         with create_visa_session(

--- a/examples/nivisa_dmm_measurement/teststand_fixture.py
+++ b/examples/nivisa_dmm_measurement/teststand_fixture.py
@@ -79,7 +79,5 @@ def destroy_nivisa_dmm_sessions() -> None:
 
         with session_management_client.reserve_all_registered_sessions(
             instrument_type_id=INSTRUMENT_TYPE_DMM_SIMULATOR,
-            # This code module sets up the sessions, so error immediately if they are in use.
-            timeout=0,
         ) as reservation:
             session_management_client.unregister_sessions(reservation.session_info)

--- a/examples/nivisa_dmm_measurement/teststand_fixture.py
+++ b/examples/nivisa_dmm_measurement/teststand_fixture.py
@@ -55,10 +55,7 @@ def create_nivisa_dmm_sessions(sequence_context: Any) -> None:
 
         pin_map_context = nims.session_management.PinMapContext(pin_map_id=pin_map_id, sites=None)
         with session_management_client.reserve_sessions(
-            context=pin_map_context,
-            instrument_type_id=INSTRUMENT_TYPE_DMM_SIMULATOR,
-            # This code module sets up the sessions, so error immediately if they are in use.
-            timeout=0,
+            context=pin_map_context, instrument_type_id=INSTRUMENT_TYPE_DMM_SIMULATOR
         ) as reservation:
             resource_manager = create_visa_resource_manager(USE_SIMULATION)
 

--- a/examples/output_voltage_measurement/measurement.py
+++ b/examples/output_voltage_measurement/measurement.py
@@ -44,13 +44,6 @@ measurement_service = nims.MeasurementService(
 
 service_options = ServiceOptions()
 
-RESERVATION_TIMEOUT_IN_SECONDS = 60.0
-"""
-If another measurement is using the session, the reserve function will wait
-for it to complete. Specify a reservation timeout to aid in debugging missed
-unreserve calls. Long measurements may require a longer timeout.
-"""
-
 
 class Function(Enum):
     """Function that represents the measurement type."""
@@ -118,7 +111,6 @@ def measure(
     with session_management_client.reserve_sessions(
         context=measurement_service.context.pin_map_context,
         pin_or_relay_names=[input_pin, output_pin],
-        timeout=RESERVATION_TIMEOUT_IN_SECONDS,
     ) as reservation:
         grpc_device_channel = get_grpc_device_channel(
             measurement_service, nidcpower, service_options

--- a/examples/output_voltage_measurement/teststand_nidcpower.py
+++ b/examples/output_voltage_measurement/teststand_nidcpower.py
@@ -25,10 +25,6 @@ def create_nidcpower_sessions(sequence_context: Any) -> None:
         with session_management_client.reserve_sessions(
             context=pin_map_context,
             instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_DCPOWER,
-            # If another measurement is using the session, wait for it to complete.
-            # Specify a timeout to aid in debugging missed unreserve calls.
-            # Long measurements may require a longer timeout.
-            timeout=60,
         ) as reservation:
             for session_info in reservation.session_info:
                 # Leave session open

--- a/examples/output_voltage_measurement/teststand_nidcpower.py
+++ b/examples/output_voltage_measurement/teststand_nidcpower.py
@@ -48,8 +48,6 @@ def destroy_nidcpower_sessions() -> None:
         )
         with session_management_client.reserve_all_registered_sessions(
             instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_DCPOWER,
-            # This code module sets up the sessions, so error immediately if they are in use.
-            timeout=0,
         ) as reservation:
             session_management_client.unregister_sessions(reservation.session_info)
 

--- a/examples/output_voltage_measurement/teststand_nivisa_dmm.py
+++ b/examples/output_voltage_measurement/teststand_nivisa_dmm.py
@@ -57,7 +57,5 @@ def destroy_nivisa_dmm_sessions() -> None:
 
         with session_management_client.reserve_all_registered_sessions(
             instrument_type_id=INSTRUMENT_TYPE_DMM_SIMULATOR,
-            # This code module sets up the sessions, so error immediately if they are in use.
-            timeout=0,
         ) as reservation:
             session_management_client.unregister_sessions(reservation.session_info)

--- a/examples/output_voltage_measurement/teststand_nivisa_dmm.py
+++ b/examples/output_voltage_measurement/teststand_nivisa_dmm.py
@@ -33,10 +33,7 @@ def create_nivisa_dmm_sessions(sequence_context: Any) -> None:
 
         pin_map_context = nims.session_management.PinMapContext(pin_map_id=pin_map_id, sites=None)
         with session_management_client.reserve_sessions(
-            context=pin_map_context,
-            instrument_type_id=INSTRUMENT_TYPE_DMM_SIMULATOR,
-            # This code module sets up the sessions, so error immediately if they are in use.
-            timeout=0,
+            context=pin_map_context, instrument_type_id=INSTRUMENT_TYPE_DMM_SIMULATOR
         ) as reservation:
             resource_manager = create_resource_manager(USE_SIMULATION)
 


### PR DESCRIPTION
…alls in our examples.

- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Removing the reservation timeout and instrument id parameters from our reserve_session calls in our examples.

### Why should this Pull Request be merged?

[AB#2524066](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2524066)

Removing these parameters shorten and simply our examples. 

`instrument_type_id` can be removed for the following reasons:
- InstrumentStudio pin controls already filter by instrument type.
- In TestStand you will get an error if you specify a pin that is connected to the wrong instrument type.
- Connecting one pin to multiple instruments is an advanced use case.

Note that we are leaving this in the TestStand code modules. 

`timeout` has added 7 lines of boilerplate to our example. A reservation of 0 seconds (the default) should be sufficient for single-site, single-threaded test sequences.

### What testing has been done?

Tested the following examples in InstrumentStudio and TestStand:
- NI-DAQmx Analog Input
- NI-DCPower Source DC Voltage.
- NI-Digital SPI
- NI-DMM Measurement
- NI-FGEN Standard Function
- NI-Scope Acquire Waveform
- NI Switch Control Relays
- NI-VISA DMM Measurement
- Output Voltage Measurement