### PR TITLE
service: Clean up grpc_servicer.py

### DIFF
--- a/ni_measurementlink_service/_internal/grpc_servicer.py
+++ b/ni_measurementlink_service/_internal/grpc_servicer.py
@@ -35,9 +35,9 @@ class MeasurementServiceContext:
         pin_map_context: PinMapContext,
     ) -> None:
         """Initialize the measurement service context."""
-        self._grpc_context: grpc.ServicerContext = grpc_context
-        self._pin_map_context: PinMapContext = pin_map_context
-        self._is_complete: bool = False
+        self._grpc_context = grpc_context
+        self._pin_map_context = pin_map_context
+        self._is_complete = False
 
     def mark_complete(self) -> None:
         """Mark the current RPC as complete."""


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

`grpc_servicer.py`:
- Remove unnecessary content from docstrings. This class is internal, so we don't need to document each attribute and parameter.
- Delete low-value, "play-by-play" comments
- Delete random capitalization
- Use kwargs to initialize protobuf fields when convenient to do so
- Single-source `_frame_metadata_dict()`
- Prefix member variables with underscore to indicate that they are private
- Remove unnecessary type hints for member variables (the type checker can infer these)

### Why should this Pull Request be merged?

Make `grpc_servicer.py` easier to read and edit.

### What testing has been done?

Ran `poetry run pytest -v`