### PR TITLE
service: Clean up service_manager.py

### DIFF
--- a/ni_measurementlink_service/measurement/service.py
+++ b/ni_measurementlink_service/measurement/service.py
@@ -220,15 +220,8 @@ class MeasurementService:
         """The location of the service on the network."""
         with self._initialization_lock:
             if self._grpc_service is None:
-                raise RuntimeError(
-                    "Measurement service not running. Call host_service() before querying the service_location."
-                )
-
-            return ServiceLocation(
-                location="localhost",
-                insecure_port=self._grpc_service.port,
-                ssl_authenticated_port="",
-            )
+                raise RuntimeError("Measurement service not running")
+            return self._grpc_service.service_location
 
     def register_measurement(self, measurement_function: _F) -> _F:
         """Register a function as the measurement function for a measurement service.
@@ -485,8 +478,5 @@ class MeasurementService:
             Exception: If service_class is not specified and there is more than one matching service
                 registered.
         """
-        service_location = self.grpc_service.discovery_client.resolve_service(
-            provided_interface, service_class
-        )
-
-        return self.channel_pool.get_channel(target=service_location.insecure_address)
+        service_location = self.discovery_client.resolve_service(provided_interface, service_class)
+        return self.channel_pool.get_channel(service_location.insecure_address)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

`service_manager.py`:
- Deprecate public attributes that shouldn't be public
- Deprecate `port` attribute and replace it with `service_location`
- Remove unnecessary details from docstrings. This class is internal.

`service.py`:
- Update `MeasurementService` to use `service_location` instead of `port`
- Shorten an error message that users are unlikely to encounter
- Use own `DiscoveryClient` instead of borrowing `GrpcService`'s `DiscoveryClient`

### Why should this Pull Request be merged?

Hide internal implementation details. The entire `GrpcService` class is an internal implementation detail, but we didn't make that clear before, so it's better to have a deprecation period before we break compatibility.

Don't assume the server has only one port.

### What testing has been done?

Ran `poetry run pytest -v`