### PR TITLE
Fix pywintypes error during the launch of the discovery service after a fresh install of MeasurementLink

### DIFF
--- a/tests/unit/test_discovery_client.py
+++ b/tests/unit/test_discovery_client.py
@@ -9,6 +9,8 @@ from unittest.mock import Mock
 
 import grpc
 import pytest
+import win32file
+import winerror
 from pytest_mock import MockerFixture
 
 from ni_measurementlink_service._channelpool import GrpcChannelPool
@@ -16,6 +18,7 @@ from ni_measurementlink_service._internal.discovery_client import (
     DiscoveryClient,
     ServiceLocation,
     _get_discovery_service_address,
+    _open_key_file,
     _start_service,
 )
 from ni_measurementlink_service._internal.stubs.ni.measurementlink.discovery.v1.discovery_service_pb2 import (
@@ -223,10 +226,12 @@ def test___get_discovery_service_address___start_service_jit___returns_expected_
     assert _TEST_SERVICE_PORT in discovery_service_address
 
 
+@pytest.mark.parametrize("key_file_error", [IOError, WindowsError])
 def test___get_discovery_service_address___key_file_not_exist___throws_timeouterror(
     mocker: MockerFixture,
     temp_discovery_key_file_path: pathlib.Path,
     temp_registration_json_file_path: pathlib.Path,
+    key_file_error,
 ):
     mocker.patch(
         "ni_measurementlink_service._internal.discovery_client._get_key_file_path",
@@ -236,7 +241,8 @@ def test___get_discovery_service_address___key_file_not_exist___throws_timeouter
         "ni_measurementlink_service._internal.discovery_client._START_SERVICE_TIMEOUT", 5.0
     )
     mocker.patch(
-        "ni_measurementlink_service._internal.discovery_client._open_key_file", side_effect=IOError
+        "ni_measurementlink_service._internal.discovery_client._open_key_file",
+        side_effect=key_file_error,
     )
     mocker.patch(
         "ni_measurementlink_service._internal.discovery_client._get_registration_json_file_path",
@@ -247,6 +253,18 @@ def test___get_discovery_service_address___key_file_not_exist___throws_timeouter
     with pytest.raises(IOError) as exc_info:
         _get_discovery_service_address()
     assert exc_info.type is TimeoutError
+
+
+def test___key_file_not_exist___open_key_file___raises_file_not_found_error(
+    mocker: MockerFixture, temp_discovery_key_file_path: pathlib.Path
+):
+    mocker.patch(
+        "win32file.CreateFile",
+        side_effect=win32file.error(winerror.ERROR_PATH_NOT_FOUND, None, None),
+    )
+
+    with pytest.raises(FileNotFoundError):
+        _open_key_file(temp_discovery_key_file_path)
 
 
 def test___start_discovery_service___key_file_exist_after_poll___service_start_success(


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

When attempting to open the discovery service key file after a fresh install of MeasurementLink (i.e., folders such as Discovery and Logs are not present in the fresh PC installation), the `winerror.ERROR_PATH_NOT_FOUND` exception was thrown, which hadn't been handled in `_open_key_file()`. This unhandled error resulted in the exception being thrown in the command prompt during the first run of a measurement service alone.

To fix this issue, I have made the following suggestions provided by @bkeryan.
- Updated `_open_key_file` to translate `ERROR_PATH_NOT_FOUND` to `FileNotFoundError`, which is handled by its caller (`_start_service`)
- Updated `_start_service` to catch `OSError`.

### Why should this Pull Request be merged?

Fixes [Bug 2514643](https://dev.azure.com/ni/DevCentral/_workitems/edit/2514643): Auto-launching discovery service fails after clean install (GitHub Issue #369)

### What testing has been done?

Added/Updated unit tests to test the fix.