### PR TITLE
Remove use_simulation_options command line parameter from examples that don't use it

### DIFF
--- a/examples/game_of_life/_helpers.py
+++ b/examples/game_of_life/_helpers.py
@@ -27,15 +27,12 @@ class ServiceOptions(NamedTuple):
     use_grpc_device: bool = False
     grpc_device_address: str = ""
 
-    use_simulation: bool = False
-
 
 def get_service_options(**kwargs: Any) -> ServiceOptions:
     """Get service options from keyword arguments."""
     return ServiceOptions(
         use_grpc_device=kwargs.get("use_grpc_device", False),
         grpc_device_address=kwargs.get("grpc_device_address", ""),
-        use_simulation=kwargs.get("use_simulation", False),
     )
 
 
@@ -211,16 +208,6 @@ def grpc_device_options(func: F) -> F:
         help="NI gRPC Device Server address (e.g. localhost:31763). If unspecified, use the discovery service to resolve the address.",
     )
     return grpc_device_address_option(use_grpc_device_option(func))
-
-
-def use_simulation_option(default: bool) -> Callable[[F], F]:
-    """Decorator for --use-simulation command line option."""
-    return click.option(
-        "--use-simulation/--no-use-simulation",
-        default=default,
-        is_flag=True,
-        help="Use simulated instruments.",
-    )
 
 
 def get_grpc_device_channel(

--- a/examples/nidaqmx_analog_input/README.md
+++ b/examples/nidaqmx_analog_input/README.md
@@ -16,7 +16,6 @@ measurement with NI-DAQmx.
     registration and unregistration in the `Setup` and `Cleanup` sections of the main
     sequence. For **Test UUTs** and batch process model use cases, these steps should
     be moved to the `ProcessSetup` and `ProcessCleanup` callbacks.
-- Uses the NI gRPC Device Server to allow sharing instrument sessions with other measurement services when running measurements from TestStand.
 
 > **Note**
 >

--- a/examples/nidaqmx_analog_input/_helpers.py
+++ b/examples/nidaqmx_analog_input/_helpers.py
@@ -36,15 +36,12 @@ class ServiceOptions(NamedTuple):
     use_grpc_device: bool = False
     grpc_device_address: str = ""
 
-    use_simulation: bool = False
-
 
 def get_service_options(**kwargs: Any) -> ServiceOptions:
     """Get service options from keyword arguments."""
     return ServiceOptions(
         use_grpc_device=kwargs.get("use_grpc_device", False),
         grpc_device_address=kwargs.get("grpc_device_address", ""),
-        use_simulation=kwargs.get("use_simulation", False),
     )
 
 
@@ -220,16 +217,6 @@ def grpc_device_options(func: F) -> F:
         help="NI gRPC Device Server address (e.g. localhost:31763). If unspecified, use the discovery service to resolve the address.",
     )
     return grpc_device_address_option(use_grpc_device_option(func))
-
-
-def use_simulation_option(default: bool) -> Callable[[F], F]:
-    """Decorator for --use-simulation command line option."""
-    return click.option(
-        "--use-simulation/--no-use-simulation",
-        default=default,
-        is_flag=True,
-        help="Use simulated instruments.",
-    )
 
 
 def get_grpc_device_channel(

--- a/examples/nidcpower_source_dc_voltage/_constants.py
+++ b/examples/nidcpower_source_dc_voltage/_constants.py
@@ -2,6 +2,5 @@
 
 USE_SIMULATION = True
 """
-To use physical instruments, set this to False or specify
---no-use-simulation on the command line.
+To use physical instruments, set this to False
 """

--- a/examples/nidcpower_source_dc_voltage/_helpers.py
+++ b/examples/nidcpower_source_dc_voltage/_helpers.py
@@ -36,15 +36,12 @@ class ServiceOptions(NamedTuple):
     use_grpc_device: bool = False
     grpc_device_address: str = ""
 
-    use_simulation: bool = False
-
 
 def get_service_options(**kwargs: Any) -> ServiceOptions:
     """Get service options from keyword arguments."""
     return ServiceOptions(
         use_grpc_device=kwargs.get("use_grpc_device", False),
         grpc_device_address=kwargs.get("grpc_device_address", ""),
-        use_simulation=kwargs.get("use_simulation", False),
     )
 
 
@@ -220,16 +217,6 @@ def grpc_device_options(func: F) -> F:
         help="NI gRPC Device Server address (e.g. localhost:31763). If unspecified, use the discovery service to resolve the address.",
     )
     return grpc_device_address_option(use_grpc_device_option(func))
-
-
-def use_simulation_option(default: bool) -> Callable[[F], F]:
-    """Decorator for --use-simulation command line option."""
-    return click.option(
-        "--use-simulation/--no-use-simulation",
-        default=default,
-        is_flag=True,
-        help="Use simulated instruments.",
-    )
 
 
 def get_grpc_device_channel(

--- a/examples/nidcpower_source_dc_voltage/measurement.py
+++ b/examples/nidcpower_source_dc_voltage/measurement.py
@@ -169,7 +169,6 @@ def _log_measured_values(
 @click.command
 @verbosity_option
 @grpc_device_options
-@use_simulation_option(default=USE_SIMULATION)
 def main(verbosity: int, **kwargs: Any) -> None:
     """Source and measure a DC voltage with an NI SMU."""
     configure_logging(verbosity)

--- a/examples/nidcpower_source_dc_voltage/measurement.py
+++ b/examples/nidcpower_source_dc_voltage/measurement.py
@@ -11,7 +11,6 @@ import click
 import grpc
 import hightime
 import nidcpower
-from _constants import USE_SIMULATION
 from _helpers import (
     ServiceOptions,
     configure_logging,
@@ -19,7 +18,6 @@ from _helpers import (
     get_grpc_device_channel,
     get_service_options,
     grpc_device_options,
-    use_simulation_option,
     verbosity_option,
 )
 from _nidcpower_helpers import create_session

--- a/examples/nidigital_spi/_constants.py
+++ b/examples/nidigital_spi/_constants.py
@@ -2,6 +2,5 @@
 
 USE_SIMULATION = True
 """
-To use physical instruments, set this to False or specify
---no-use-simulation on the command line.
+To use physical instruments, set this to False
 """

--- a/examples/nidigital_spi/_helpers.py
+++ b/examples/nidigital_spi/_helpers.py
@@ -36,15 +36,12 @@ class ServiceOptions(NamedTuple):
     use_grpc_device: bool = False
     grpc_device_address: str = ""
 
-    use_simulation: bool = False
-
 
 def get_service_options(**kwargs: Any) -> ServiceOptions:
     """Get service options from keyword arguments."""
     return ServiceOptions(
         use_grpc_device=kwargs.get("use_grpc_device", False),
         grpc_device_address=kwargs.get("grpc_device_address", ""),
-        use_simulation=kwargs.get("use_simulation", False),
     )
 
 
@@ -220,16 +217,6 @@ def grpc_device_options(func: F) -> F:
         help="NI gRPC Device Server address (e.g. localhost:31763). If unspecified, use the discovery service to resolve the address.",
     )
     return grpc_device_address_option(use_grpc_device_option(func))
-
-
-def use_simulation_option(default: bool) -> Callable[[F], F]:
-    """Decorator for --use-simulation command line option."""
-    return click.option(
-        "--use-simulation/--no-use-simulation",
-        default=default,
-        is_flag=True,
-        help="Use simulated instruments.",
-    )
 
 
 def get_grpc_device_channel(

--- a/examples/nidigital_spi/measurement.py
+++ b/examples/nidigital_spi/measurement.py
@@ -7,7 +7,6 @@ from typing import Any, Iterable, Tuple, Union
 
 import click
 import nidigital
-from _constants import USE_SIMULATION
 from _helpers import (
     ServiceOptions,
     configure_logging,
@@ -15,7 +14,6 @@ from _helpers import (
     get_grpc_device_channel,
     get_service_options,
     grpc_device_options,
-    use_simulation_option,
     verbosity_option,
 )
 from _nidigital_helpers import create_session

--- a/examples/nidigital_spi/measurement.py
+++ b/examples/nidigital_spi/measurement.py
@@ -120,7 +120,6 @@ def _resolve_relative_path(
 @click.command
 @verbosity_option
 @grpc_device_options
-@use_simulation_option(default=USE_SIMULATION)
 def main(verbosity: int, **kwargs: Any) -> None:
     """Test a SPI device using an NI Digital Pattern instrument."""
     configure_logging(verbosity)

--- a/examples/nidmm_measurement/_constants.py
+++ b/examples/nidmm_measurement/_constants.py
@@ -2,6 +2,5 @@
 
 USE_SIMULATION = True
 """
-To use physical instruments, set this to False or specify
---no-use-simulation on the command line.
+To use physical instruments, set this to False
 """

--- a/examples/nidmm_measurement/_helpers.py
+++ b/examples/nidmm_measurement/_helpers.py
@@ -36,15 +36,12 @@ class ServiceOptions(NamedTuple):
     use_grpc_device: bool = False
     grpc_device_address: str = ""
 
-    use_simulation: bool = False
-
 
 def get_service_options(**kwargs: Any) -> ServiceOptions:
     """Get service options from keyword arguments."""
     return ServiceOptions(
         use_grpc_device=kwargs.get("use_grpc_device", False),
         grpc_device_address=kwargs.get("grpc_device_address", ""),
-        use_simulation=kwargs.get("use_simulation", False),
     )
 
 
@@ -220,16 +217,6 @@ def grpc_device_options(func: F) -> F:
         help="NI gRPC Device Server address (e.g. localhost:31763). If unspecified, use the discovery service to resolve the address.",
     )
     return grpc_device_address_option(use_grpc_device_option(func))
-
-
-def use_simulation_option(default: bool) -> Callable[[F], F]:
-    """Decorator for --use-simulation command line option."""
-    return click.option(
-        "--use-simulation/--no-use-simulation",
-        default=default,
-        is_flag=True,
-        help="Use simulated instruments.",
-    )
 
 
 def get_grpc_device_channel(

--- a/examples/nidmm_measurement/measurement.py
+++ b/examples/nidmm_measurement/measurement.py
@@ -9,7 +9,6 @@ from typing import Any, Tuple
 
 import click
 import nidmm
-from _constants import USE_SIMULATION
 from _helpers import (
     ServiceOptions,
     configure_logging,
@@ -17,7 +16,6 @@ from _helpers import (
     get_grpc_device_channel,
     get_service_options,
     grpc_device_options,
-    use_simulation_option,
     verbosity_option,
 )
 from _nidmm_helpers import create_session

--- a/examples/nidmm_measurement/measurement.py
+++ b/examples/nidmm_measurement/measurement.py
@@ -121,7 +121,6 @@ def measure(
 @click.command
 @verbosity_option
 @grpc_device_options
-@use_simulation_option(default=USE_SIMULATION)
 def main(verbosity: int, **kwargs: Any) -> None:
     """Perform a measurement using an NI DMM."""
     configure_logging(verbosity)

--- a/examples/nifgen_standard_function/_constants.py
+++ b/examples/nifgen_standard_function/_constants.py
@@ -2,6 +2,5 @@
 
 USE_SIMULATION = True
 """
-To use physical instruments, set this to False or specify
---no-use-simulation on the command line.
+To use physical instruments, set this to False
 """

--- a/examples/nifgen_standard_function/_helpers.py
+++ b/examples/nifgen_standard_function/_helpers.py
@@ -36,15 +36,12 @@ class ServiceOptions(NamedTuple):
     use_grpc_device: bool = False
     grpc_device_address: str = ""
 
-    use_simulation: bool = False
-
 
 def get_service_options(**kwargs: Any) -> ServiceOptions:
     """Get service options from keyword arguments."""
     return ServiceOptions(
         use_grpc_device=kwargs.get("use_grpc_device", False),
         grpc_device_address=kwargs.get("grpc_device_address", ""),
-        use_simulation=kwargs.get("use_simulation", False),
     )
 
 
@@ -220,16 +217,6 @@ def grpc_device_options(func: F) -> F:
         help="NI gRPC Device Server address (e.g. localhost:31763). If unspecified, use the discovery service to resolve the address.",
     )
     return grpc_device_address_option(use_grpc_device_option(func))
-
-
-def use_simulation_option(default: bool) -> Callable[[F], F]:
-    """Decorator for --use-simulation command line option."""
-    return click.option(
-        "--use-simulation/--no-use-simulation",
-        default=default,
-        is_flag=True,
-        help="Use simulated instruments.",
-    )
 
 
 def get_grpc_device_channel(

--- a/examples/nifgen_standard_function/measurement.py
+++ b/examples/nifgen_standard_function/measurement.py
@@ -169,7 +169,6 @@ def measure(
 @click.command
 @verbosity_option
 @grpc_device_options
-@use_simulation_option(default=USE_SIMULATION)
 def main(verbosity: int, **kwargs: Any) -> None:
     """Generate a standard function waveform using an NI waveform generator."""
     configure_logging(verbosity)

--- a/examples/nifgen_standard_function/measurement.py
+++ b/examples/nifgen_standard_function/measurement.py
@@ -13,7 +13,6 @@ import click
 import grpc
 import hightime
 import nifgen
-from _constants import USE_SIMULATION
 from _helpers import (
     ServiceOptions,
     configure_logging,
@@ -21,7 +20,6 @@ from _helpers import (
     get_grpc_device_channel,
     get_service_options,
     grpc_device_options,
-    use_simulation_option,
     verbosity_option,
 )
 from _nifgen_helpers import create_session

--- a/examples/niscope_acquire_waveform/_constants.py
+++ b/examples/niscope_acquire_waveform/_constants.py
@@ -2,6 +2,5 @@
 
 USE_SIMULATION = True
 """
-To use physical instruments, set this to False or specify
---no-use-simulation on the command line.
+To use physical instruments, set this to False
 """

--- a/examples/niscope_acquire_waveform/_helpers.py
+++ b/examples/niscope_acquire_waveform/_helpers.py
@@ -36,15 +36,12 @@ class ServiceOptions(NamedTuple):
     use_grpc_device: bool = False
     grpc_device_address: str = ""
 
-    use_simulation: bool = False
-
 
 def get_service_options(**kwargs: Any) -> ServiceOptions:
     """Get service options from keyword arguments."""
     return ServiceOptions(
         use_grpc_device=kwargs.get("use_grpc_device", False),
         grpc_device_address=kwargs.get("grpc_device_address", ""),
-        use_simulation=kwargs.get("use_simulation", False),
     )
 
 
@@ -220,16 +217,6 @@ def grpc_device_options(func: F) -> F:
         help="NI gRPC Device Server address (e.g. localhost:31763). If unspecified, use the discovery service to resolve the address.",
     )
     return grpc_device_address_option(use_grpc_device_option(func))
-
-
-def use_simulation_option(default: bool) -> Callable[[F], F]:
-    """Decorator for --use-simulation command line option."""
-    return click.option(
-        "--use-simulation/--no-use-simulation",
-        default=default,
-        is_flag=True,
-        help="Use simulated instruments.",
-    )
 
 
 def get_grpc_device_channel(

--- a/examples/niscope_acquire_waveform/measurement.py
+++ b/examples/niscope_acquire_waveform/measurement.py
@@ -182,7 +182,6 @@ def measure(
 @click.command
 @verbosity_option
 @grpc_device_options
-@use_simulation_option(default=USE_SIMULATION)
 def main(verbosity: int, **kwargs: Any) -> None:
     """Acquire a waveform using an NI oscilloscope."""
     configure_logging(verbosity)

--- a/examples/niscope_acquire_waveform/measurement.py
+++ b/examples/niscope_acquire_waveform/measurement.py
@@ -10,7 +10,6 @@ from typing import Any, List, Tuple
 import click
 import grpc
 import niscope
-from _constants import USE_SIMULATION
 from _helpers import (
     ServiceOptions,
     configure_logging,
@@ -18,7 +17,6 @@ from _helpers import (
     get_grpc_device_channel,
     get_service_options,
     grpc_device_options,
-    use_simulation_option,
     verbosity_option,
 )
 from _niscope_helpers import create_session

--- a/examples/niswitch_control_relays/_constants.py
+++ b/examples/niswitch_control_relays/_constants.py
@@ -2,6 +2,5 @@
 
 USE_SIMULATION = True
 """
-To use physical instruments, set this to False or specify
---no-use-simulation on the command line.
+To use physical instruments, set this to False
 """

--- a/examples/niswitch_control_relays/_helpers.py
+++ b/examples/niswitch_control_relays/_helpers.py
@@ -36,15 +36,12 @@ class ServiceOptions(NamedTuple):
     use_grpc_device: bool = False
     grpc_device_address: str = ""
 
-    use_simulation: bool = False
-
 
 def get_service_options(**kwargs: Any) -> ServiceOptions:
     """Get service options from keyword arguments."""
     return ServiceOptions(
         use_grpc_device=kwargs.get("use_grpc_device", False),
         grpc_device_address=kwargs.get("grpc_device_address", ""),
-        use_simulation=kwargs.get("use_simulation", False),
     )
 
 
@@ -220,16 +217,6 @@ def grpc_device_options(func: F) -> F:
         help="NI gRPC Device Server address (e.g. localhost:31763). If unspecified, use the discovery service to resolve the address.",
     )
     return grpc_device_address_option(use_grpc_device_option(func))
-
-
-def use_simulation_option(default: bool) -> Callable[[F], F]:
-    """Decorator for --use-simulation command line option."""
-    return click.option(
-        "--use-simulation/--no-use-simulation",
-        default=default,
-        is_flag=True,
-        help="Use simulated instruments.",
-    )
 
 
 def get_grpc_device_channel(

--- a/examples/niswitch_control_relays/measurement.py
+++ b/examples/niswitch_control_relays/measurement.py
@@ -90,7 +90,6 @@ def measure(
 @click.command
 @verbosity_option
 @grpc_device_options
-@use_simulation_option(default=USE_SIMULATION)
 def main(verbosity: int, **kwargs: Any) -> None:
     """Control relays using an NI relay driver (e.g. PXI-2567)."""
     configure_logging(verbosity)

--- a/examples/niswitch_control_relays/measurement.py
+++ b/examples/niswitch_control_relays/measurement.py
@@ -8,7 +8,6 @@ from typing import Any, Tuple
 
 import click
 import niswitch
-from _constants import USE_SIMULATION
 from _helpers import (
     ServiceOptions,
     configure_logging,
@@ -16,7 +15,6 @@ from _helpers import (
     get_grpc_device_channel,
     get_service_options,
     grpc_device_options,
-    use_simulation_option,
     verbosity_option,
 )
 from _niswitch_helpers import create_session

--- a/examples/nivisa_dmm_measurement/_constants.py
+++ b/examples/nivisa_dmm_measurement/_constants.py
@@ -2,6 +2,5 @@
 
 USE_SIMULATION = True
 """
-To use physical instruments, set this to False or specify
---no-use-simulation on the command line.
+To use physical instruments, set this to False
 """

--- a/examples/nivisa_dmm_measurement/_helpers.py
+++ b/examples/nivisa_dmm_measurement/_helpers.py
@@ -36,15 +36,12 @@ class ServiceOptions(NamedTuple):
     use_grpc_device: bool = False
     grpc_device_address: str = ""
 
-    use_simulation: bool = False
-
 
 def get_service_options(**kwargs: Any) -> ServiceOptions:
     """Get service options from keyword arguments."""
     return ServiceOptions(
         use_grpc_device=kwargs.get("use_grpc_device", False),
         grpc_device_address=kwargs.get("grpc_device_address", ""),
-        use_simulation=kwargs.get("use_simulation", False),
     )
 
 
@@ -220,16 +217,6 @@ def grpc_device_options(func: F) -> F:
         help="NI gRPC Device Server address (e.g. localhost:31763). If unspecified, use the discovery service to resolve the address.",
     )
     return grpc_device_address_option(use_grpc_device_option(func))
-
-
-def use_simulation_option(default: bool) -> Callable[[F], F]:
-    """Decorator for --use-simulation command line option."""
-    return click.option(
-        "--use-simulation/--no-use-simulation",
-        default=default,
-        is_flag=True,
-        help="Use simulated instruments.",
-    )
 
 
 def get_grpc_device_channel(

--- a/examples/nivisa_dmm_measurement/measurement.py
+++ b/examples/nivisa_dmm_measurement/measurement.py
@@ -14,7 +14,6 @@ from _helpers import (
     configure_logging,
     create_session_management_client,
     get_service_options,
-    use_simulation_option,
     verbosity_option,
 )
 from _visa_helpers import (
@@ -93,7 +92,7 @@ def measure(
         instrument_type_id=INSTRUMENT_TYPE_DMM_SIMULATOR,
         timeout=RESERVATION_TIMEOUT_IN_SECONDS,
     ) as reservation:
-        resource_manager = create_visa_resource_manager(service_options.use_simulation)
+        resource_manager = create_visa_resource_manager(USE_SIMULATION)
         with create_visa_session(
             resource_manager, reservation.session_info.resource_name
         ) as session:
@@ -124,7 +123,6 @@ def measure(
 
 @click.command
 @verbosity_option
-@use_simulation_option(default=USE_SIMULATION)
 def main(verbosity: int, **kwargs: Any) -> None:
     """Perform a DMM measurement using NI-VISA and an NI Instrument Simulator v2.0."""
     configure_logging(verbosity)

--- a/examples/output_voltage_measurement/_constants.py
+++ b/examples/output_voltage_measurement/_constants.py
@@ -2,6 +2,5 @@
 
 USE_SIMULATION = True
 """
-To use physical instruments, set this to False or specify
---no-use-simulation on the command line.
+To use physical instruments, set this to False
 """

--- a/examples/output_voltage_measurement/_helpers.py
+++ b/examples/output_voltage_measurement/_helpers.py
@@ -36,15 +36,12 @@ class ServiceOptions(NamedTuple):
     use_grpc_device: bool = False
     grpc_device_address: str = ""
 
-    use_simulation: bool = False
-
 
 def get_service_options(**kwargs: Any) -> ServiceOptions:
     """Get service options from keyword arguments."""
     return ServiceOptions(
         use_grpc_device=kwargs.get("use_grpc_device", False),
         grpc_device_address=kwargs.get("grpc_device_address", ""),
-        use_simulation=kwargs.get("use_simulation", False),
     )
 
 
@@ -220,16 +217,6 @@ def grpc_device_options(func: F) -> F:
         help="NI gRPC Device Server address (e.g. localhost:31763). If unspecified, use the discovery service to resolve the address.",
     )
     return grpc_device_address_option(use_grpc_device_option(func))
-
-
-def use_simulation_option(default: bool) -> Callable[[F], F]:
-    """Decorator for --use-simulation command line option."""
-    return click.option(
-        "--use-simulation/--no-use-simulation",
-        default=default,
-        is_flag=True,
-        help="Use simulated instruments.",
-    )
 
 
 def get_grpc_device_channel(

--- a/examples/output_voltage_measurement/measurement.py
+++ b/examples/output_voltage_measurement/measurement.py
@@ -23,7 +23,6 @@ from _helpers import (
     get_service_options,
     get_session_and_channel_for_pin,
     grpc_device_options,
-    use_simulation_option,
     verbosity_option,
 )
 from _visa_helpers import check_instrument_error, log_instrument_id, reset_instrument
@@ -126,10 +125,10 @@ def measure(
         source_session_info = _get_session_info_for_pin(reservation.session_info, input_pin)
         measure_session_info = _get_session_info_for_pin(reservation.session_info, output_pin)
         with _nidcpower_helpers.create_session(
-            source_session_info, service_options.use_simulation, grpc_device_channel
+            source_session_info, USE_SIMULATION, grpc_device_channel
         ) as source_session, _visa_helpers.create_session(
             measure_session_info.resource_name,
-            use_simulation=service_options.use_simulation,
+            use_simulation=USE_SIMULATION,
         ) as measure_session:
             cancellation_event = threading.Event()
             measurement_service.context.add_cancel_callback(cancellation_event.set)
@@ -218,7 +217,6 @@ def _wait_for_source_complete_event(
 @click.command
 @verbosity_option
 @grpc_device_options
-@use_simulation_option(default=USE_SIMULATION)
 def main(verbosity: int, **kwargs: Any) -> None:
     """Source DC voltage as input with an NI SMU and measure output using NI-VISA DMM."""
     configure_logging(verbosity)

--- a/examples/sample_measurement/_helpers.py
+++ b/examples/sample_measurement/_helpers.py
@@ -36,15 +36,12 @@ class ServiceOptions(NamedTuple):
     use_grpc_device: bool = False
     grpc_device_address: str = ""
 
-    use_simulation: bool = False
-
 
 def get_service_options(**kwargs: Any) -> ServiceOptions:
     """Get service options from keyword arguments."""
     return ServiceOptions(
         use_grpc_device=kwargs.get("use_grpc_device", False),
         grpc_device_address=kwargs.get("grpc_device_address", ""),
-        use_simulation=kwargs.get("use_simulation", False),
     )
 
 
@@ -220,16 +217,6 @@ def grpc_device_options(func: F) -> F:
         help="NI gRPC Device Server address (e.g. localhost:31763). If unspecified, use the discovery service to resolve the address.",
     )
     return grpc_device_address_option(use_grpc_device_option(func))
-
-
-def use_simulation_option(default: bool) -> Callable[[F], F]:
-    """Decorator for --use-simulation command line option."""
-    return click.option(
-        "--use-simulation/--no-use-simulation",
-        default=default,
-        is_flag=True,
-        help="Use simulated instruments.",
-    )
 
 
 def get_grpc_device_channel(

--- a/examples/sample_streaming_measurement/_helpers.py
+++ b/examples/sample_streaming_measurement/_helpers.py
@@ -36,15 +36,12 @@ class ServiceOptions(NamedTuple):
     use_grpc_device: bool = False
     grpc_device_address: str = ""
 
-    use_simulation: bool = False
-
 
 def get_service_options(**kwargs: Any) -> ServiceOptions:
     """Get service options from keyword arguments."""
     return ServiceOptions(
         use_grpc_device=kwargs.get("use_grpc_device", False),
         grpc_device_address=kwargs.get("grpc_device_address", ""),
-        use_simulation=kwargs.get("use_simulation", False),
     )
 
 
@@ -220,16 +217,6 @@ def grpc_device_options(func: F) -> F:
         help="NI gRPC Device Server address (e.g. localhost:31763). If unspecified, use the discovery service to resolve the address.",
     )
     return grpc_device_address_option(use_grpc_device_option(func))
-
-
-def use_simulation_option(default: bool) -> Callable[[F], F]:
-    """Decorator for --use-simulation command line option."""
-    return click.option(
-        "--use-simulation/--no-use-simulation",
-        default=default,
-        is_flag=True,
-        help="Use simulated instruments.",
-    )
 
 
 def get_grpc_device_channel(

--- a/examples/ui_progress_updates/_helpers.py
+++ b/examples/ui_progress_updates/_helpers.py
@@ -36,15 +36,12 @@ class ServiceOptions(NamedTuple):
     use_grpc_device: bool = False
     grpc_device_address: str = ""
 
-    use_simulation: bool = False
-
 
 def get_service_options(**kwargs: Any) -> ServiceOptions:
     """Get service options from keyword arguments."""
     return ServiceOptions(
         use_grpc_device=kwargs.get("use_grpc_device", False),
         grpc_device_address=kwargs.get("grpc_device_address", ""),
-        use_simulation=kwargs.get("use_simulation", False),
     )
 
 
@@ -220,16 +217,6 @@ def grpc_device_options(func: F) -> F:
         help="NI gRPC Device Server address (e.g. localhost:31763). If unspecified, use the discovery service to resolve the address.",
     )
     return grpc_device_address_option(use_grpc_device_option(func))
-
-
-def use_simulation_option(default: bool) -> Callable[[F], F]:
-    """Decorator for --use-simulation command line option."""
-    return click.option(
-        "--use-simulation/--no-use-simulation",
-        default=default,
-        is_flag=True,
-        help="Use simulated instruments.",
-    )
 
 
 def get_grpc_device_channel(

--- a/ni_measurementlink_generator/ni_measurementlink_generator/templates/_helpers.py.mako
+++ b/ni_measurementlink_generator/ni_measurementlink_generator/templates/_helpers.py.mako
@@ -35,15 +35,12 @@ class ServiceOptions(NamedTuple):
     use_grpc_device: bool = False
     grpc_device_address: str = ""
 
-    use_simulation: bool = False
-
 
 def get_service_options(**kwargs: Any) -> ServiceOptions:
     """Get service options from keyword arguments."""
     return ServiceOptions(
         use_grpc_device=kwargs.get("use_grpc_device", False),
         grpc_device_address=kwargs.get("grpc_device_address", ""),
-        use_simulation=kwargs.get("use_simulation", False),
     )
 
 
@@ -219,16 +216,6 @@ def grpc_device_options(func: F) -> F:
         help="NI gRPC Device Server address (e.g. localhost:31763). If unspecified, use the discovery service to resolve the address.",
     )
     return grpc_device_address_option(use_grpc_device_option(func))
-
-
-def use_simulation_option(default: bool) -> Callable[[F], F]:
-    """Decorator for --use-simulation command line option."""
-    return click.option(
-        "--use-simulation/--no-use-simulation",
-        default=default,
-        is_flag=True,
-        help="Use simulated instruments.",
-    )
 
 
 def get_grpc_device_channel(

--- a/ni_measurementlink_generator/tests/test_assets/example_renders/measurement/_helpers.py
+++ b/ni_measurementlink_generator/tests/test_assets/example_renders/measurement/_helpers.py
@@ -35,15 +35,12 @@ class ServiceOptions(NamedTuple):
     use_grpc_device: bool = False
     grpc_device_address: str = ""
 
-    use_simulation: bool = False
-
 
 def get_service_options(**kwargs: Any) -> ServiceOptions:
     """Get service options from keyword arguments."""
     return ServiceOptions(
         use_grpc_device=kwargs.get("use_grpc_device", False),
         grpc_device_address=kwargs.get("grpc_device_address", ""),
-        use_simulation=kwargs.get("use_simulation", False),
     )
 
 
@@ -219,16 +216,6 @@ def grpc_device_options(func: F) -> F:
         help="NI gRPC Device Server address (e.g. localhost:31763). If unspecified, use the discovery service to resolve the address.",
     )
     return grpc_device_address_option(use_grpc_device_option(func))
-
-
-def use_simulation_option(default: bool) -> Callable[[F], F]:
-    """Decorator for --use-simulation command line option."""
-    return click.option(
-        "--use-simulation/--no-use-simulation",
-        default=default,
-        is_flag=True,
-        help="Use simulated instruments.",
-    )
 
 
 def get_grpc_device_channel(

--- a/ni_measurementlink_generator/tests/test_assets/example_renders/measurement_with_annotations/_helpers.py
+++ b/ni_measurementlink_generator/tests/test_assets/example_renders/measurement_with_annotations/_helpers.py
@@ -35,15 +35,12 @@ class ServiceOptions(NamedTuple):
     use_grpc_device: bool = False
     grpc_device_address: str = ""
 
-    use_simulation: bool = False
-
 
 def get_service_options(**kwargs: Any) -> ServiceOptions:
     """Get service options from keyword arguments."""
     return ServiceOptions(
         use_grpc_device=kwargs.get("use_grpc_device", False),
         grpc_device_address=kwargs.get("grpc_device_address", ""),
-        use_simulation=kwargs.get("use_simulation", False),
     )
 
 
@@ -219,16 +216,6 @@ def grpc_device_options(func: F) -> F:
         help="NI gRPC Device Server address (e.g. localhost:31763). If unspecified, use the discovery service to resolve the address.",
     )
     return grpc_device_address_option(use_grpc_device_option(func))
-
-
-def use_simulation_option(default: bool) -> Callable[[F], F]:
-    """Decorator for --use-simulation command line option."""
-    return click.option(
-        "--use-simulation/--no-use-simulation",
-        default=default,
-        is_flag=True,
-        help="Use simulated instruments.",
-    )
 
 
 def get_grpc_device_channel(


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fixes #395. Remove the 'use_simulation' command-line option that wasn't working and replaces all of it with the USE_SIMULATION compile-time constant in _constants.py.

Further refactoring / renaming will be done in #408 

### Why should this Pull Request be merged?

Incorrect command-line option that was never used.

### What testing has been done?

poetry run pytest -v