### PR TITLE
Importing nidcpower.session into output voltage measurement

### DIFF
--- a/examples/output_voltage_measurement/measurement.py
+++ b/examples/output_voltage_measurement/measurement.py
@@ -182,7 +182,7 @@ def _get_session_info_for_pin(
 
 def _wait_for_source_complete_event(
     measurement_service: nims.MeasurementService,
-    channels: nidcpower._SessionBase,
+    channels: nidcpower.Session,
     cancellation_event: threading.Event,
 ) -> None:
     deadline = time.time() + measurement_service.context.time_remaining

--- a/examples/output_voltage_measurement/measurement.py
+++ b/examples/output_voltage_measurement/measurement.py
@@ -1,7 +1,5 @@
 """ Source DC voltage as input with an NI SMU and measure output using NI-VISA DMM."""
 
-from __future__ import annotations
-
 import logging
 import pathlib
 import threading
@@ -15,6 +13,7 @@ import click
 import grpc
 import hightime
 import nidcpower
+import nidcpower.session
 import pyvisa
 from _constants import USE_SIMULATION
 from _helpers import (
@@ -184,7 +183,7 @@ def _get_session_info_for_pin(
 
 def _wait_for_source_complete_event(
     measurement_service: nims.MeasurementService,
-    channels: nidcpower._SessionBase,
+    channels: nidcpower.session._SessionBase,
     cancellation_event: threading.Event,
 ) -> None:
     deadline = time.time() + measurement_service.context.time_remaining

--- a/examples/output_voltage_measurement/measurement.py
+++ b/examples/output_voltage_measurement/measurement.py
@@ -1,5 +1,7 @@
 """ Source DC voltage as input with an NI SMU and measure output using NI-VISA DMM."""
 
+from __future__ import annotations
+
 import logging
 import pathlib
 import threading
@@ -182,7 +184,7 @@ def _get_session_info_for_pin(
 
 def _wait_for_source_complete_event(
     measurement_service: nims.MeasurementService,
-    channels: nidcpower.Session,
+    channels: nidcpower._SessionBase,
     cancellation_event: threading.Event,
 ) -> None:
     deadline = time.time() + measurement_service.context.time_remaining


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

When running the OutputVoltageMeasurement I got the following error:

> Traceback (most recent call last):
  File "C:\Users\DelpireTest1\Desktop\measurementlink-python\measurementlink-python\examples\output_voltage_measurement\measurement.py", line 177, in <module>
    channels: nidcpower._SessionBase,
AttributeError: module 'nidcpower' has no attribute '_SessionBase'

~I am not sure what has happened with `nidcpower._SessionBase`. A search in the ni/nimi-python repo shows this class for our other drivers, DMM, Scope, Switch, etc., but I do not see it for nidcpower.~

Importing nidcpower.session and fixing type hint.

### Why should this Pull Request be merged?

Currently it seems the measurement cannot be run out of the box. This should fix it.

### What testing has been done?

Was able to run the measurement successfully and it worked with both InstrumentStudio and TestStand.