### PR TITLE
service: Update reserve_session to roll back on error

### DIFF
--- a/ni_measurementlink_service/session_management.py
+++ b/ni_measurementlink_service/session_management.py
@@ -361,6 +361,7 @@ class SessionManagementClient(object):
         if len(session_info) == 0:
             raise ValueError("No sessions reserved. Expected single session, got 0 sessions.")
         elif len(session_info) > 1:
+            self._unreserve_sessions(session_info)
             raise ValueError(
                 "Too many sessions reserved. Expected single session, got "
                 f"{len(session_info)} sessions."


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update `SessionManagementClient.reserve_session` to roll back the reservation when raising a "Too many sessions reserved" error.

I don't think it's necessary to roll back the "No sessions reserved" case because the session management server's unreserve method would loop over an empty list.

### Why should this Pull Request be merged?

Fixes #400 

### What testing has been done?

Ran new acceptance test (part of separate PR)