### PR TITLE
[releases/1.2] Importing nidcpower.session into output voltage measurement (#399)

### DIFF
--- a/examples/output_voltage_measurement/measurement.py
+++ b/examples/output_voltage_measurement/measurement.py
@@ -13,6 +13,7 @@ import click
 import grpc
 import hightime
 import nidcpower
+import nidcpower.session
 import pyvisa
 from _constants import USE_SIMULATION
 from _helpers import (
@@ -182,7 +183,7 @@ def _get_session_info_for_pin(
 
 def _wait_for_source_complete_event(
     measurement_service: nims.MeasurementService,
-    channels: nidcpower._SessionBase,
+    channels: nidcpower.session._SessionBase,
     cancellation_event: threading.Event,
 ) -> None:
     deadline = time.time() + measurement_service.context.time_remaining


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).


### What does this Pull Request accomplish?

Cherry-pick fix for output voltage measurement.

Original PR: (#399)

### Why should this Pull Request be merged?

Output voltage measurement will not run successfully in 1.2 release if we do not submit this fix.

### What testing has been done?

None