### PR TITLE
[releases/1.2] Fix pywintypes error during the launch of the discovery service after a fresh install of MeasurementLink

### DIFF
--- a/ni_measurementlink_service/_internal/discovery_client.py
+++ b/ni_measurementlink_service/_internal/discovery_client.py
@@ -20,12 +20,10 @@ from ni_measurementlink_service._loggers import ClientLogger
 from ni_measurementlink_service.measurement.info import MeasurementInfo, ServiceInfo
 
 if sys.platform == "win32":
-    import errno
     import msvcrt
 
     import win32con
     import win32file
-    import winerror
 
 _logger = logging.getLogger(__name__)
 # Save Popen object to avoid "ResourceWarning: subprocess N is still running"
@@ -283,7 +281,7 @@ def _start_service(
         try:
             with _open_key_file(str(key_file_path)) as _:
                 return discovery_service_subprocess
-        except IOError:
+        except OSError:
             pass
         if time.time() >= timeout_time:
             raise TimeoutError("Timed out waiting for discovery service to start")
@@ -293,7 +291,7 @@ def _start_service(
 def _service_already_running(key_file_path: pathlib.Path) -> bool:
     try:
         _delete_existing_key_file(key_file_path)
-    except IOError:
+    except OSError:
         return True
     return False
 
@@ -344,14 +342,7 @@ def _open_key_file(path: str) -> typing.TextIO:
                 None,
             )
         except win32file.error as e:
-            if e.winerror == winerror.ERROR_FILE_NOT_FOUND:
-                raise FileNotFoundError(errno.ENOENT, e.strerror, path) from e
-            elif (
-                e.winerror == winerror.ERROR_ACCESS_DENIED
-                or e.winerror == winerror.ERROR_SHARING_VIOLATION
-            ):
-                raise PermissionError(errno.EACCES, e.strerror, path) from e
-            raise
+            raise OSError(None, e.strerror, path, e.winerror) from e
 
         # The CRT file descriptor takes ownership of the Win32 file handle.
         # os.O_TEXT is unnecessary because Python handles newline conversion.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Cherry-pick change on fixing the pywintypes error during the launch of the discovery service after a fresh install of MeasurementLink: #397

### Why should this Pull Request be merged?

Fixes [Bug 2514643](https://dev.azure.com/ni/DevCentral/_workitems/edit/2514643): Auto-launching discovery service fails after clean install (GitHub Issue https://github.com/ni/measurementlink-python/issues/369)

### What testing has been done?
None