### PR TITLE
[releases/1.2] service: Update reserve_session to roll back on error (#401)

### DIFF
--- a/ni_measurementlink_service/session_management.py
+++ b/ni_measurementlink_service/session_management.py
@@ -309,6 +309,7 @@ class SessionManagementClient(object):
         if len(session_info) == 0:
             raise ValueError("No sessions reserved. Expected single session, got 0 sessions.")
         elif len(session_info) > 1:
+            self._unreserve_sessions(session_info)
             raise ValueError(
                 "Too many sessions reserved. Expected single session, got "
                 f"{len(session_info)} sessions."


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Cherry-pick https://github.com/ni/measurementlink-python/pull/401:

> Update SessionManagementClient.reserve_session to roll back the reservation when raising a "Too many sessions reserved" error.

(cherry picked from commit 761140f06ce60cc5d1edfc83e85aea6a0e1724df)

### Why should this Pull Request be merged?

Fixes #400 

### What testing has been done?

Ran new acceptance test (part of separate PR) in main branch