### PR TITLE
[releases/1.2] Prepare to release 1.2.0

### DIFF
--- a/examples/game_of_life/pyproject.toml
+++ b/examples/game_of_life/pyproject.toml
@@ -14,7 +14,7 @@ mypy = ">=1.0"
 grpc-stubs = "^1.53"
 types-protobuf = "^4.21"
 # Uncomment to use prerelease dependencies.
-ni-measurementlink-service = {path = "../..", develop = true}
+# ni-measurementlink-service = {path = "../..", develop = true}
 
 [tool.mypy]
 disallow_untyped_defs = true

--- a/examples/game_of_life/pyproject.toml
+++ b/examples/game_of_life/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-ni-measurementlink-service = {version = "^1.2.0-dev0", allow-prereleases = true}
+ni-measurementlink-service = {version = "^1.2.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/sample_measurement/pyproject.toml
+++ b/examples/sample_measurement/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-ni-measurementlink-service = {version = "^1.2.0-dev0", allow-prereleases = true}
+ni-measurementlink-service = {version = "^1.2.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/sample_measurement/pyproject.toml
+++ b/examples/sample_measurement/pyproject.toml
@@ -14,7 +14,7 @@ mypy = ">=1.0"
 grpc-stubs = "^1.53"
 types-protobuf = "^4.21"
 # Uncomment to use prerelease dependencies.
-ni-measurementlink-service = {path = "../..", develop = true}
+# ni-measurementlink-service = {path = "../..", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.2.0"]

--- a/ni_measurementlink_generator/pyproject.toml
+++ b/ni_measurementlink_generator/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ni_measurementlink_generator"
-version = "1.2.0-dev3"
+version = "1.2.0"
 description = "MeasurementLink Code Generator for Python"
 authors = ["NI <opensource@ni.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ extend_exclude = '*_pb2_grpc.py,*_pb2_grpc.pyi,*_pb2.py,*_pb2.pyi,ni_measurement
 
 [tool.poetry]
 name = "ni_measurementlink_service"
-version = "1.2.0-dev3"
+version = "1.2.0"
 description = "MeasurementLink Support for Python"
 authors = ["NI <opensource@ni.com>"]
 readme = "README.md" # apply the repo readme to the package as well


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update `ni-measurementlink-service` and `ni-measurementlink-generator` versions to 1.2.0 to work around https://github.com/ni/measurementlink-python/issues/162

Update examples that depend on 1.2 to use the released version.

### Why should this Pull Request be merged?

Use correct version numbers for 1.2.0 build.

### What testing has been done?

None