### PR TITLE
examples: Depend on released version

### DIFF
--- a/examples/game_of_life/pyproject.toml
+++ b/examples/game_of_life/pyproject.toml
@@ -14,7 +14,7 @@ mypy = ">=1.0"
 grpc-stubs = "^1.53"
 types-protobuf = "^4.21"
 # Uncomment to use prerelease dependencies.
-ni-measurementlink-service = {path = "../..", develop = true}
+# ni-measurementlink-service = {path = "../..", develop = true}
 
 [tool.mypy]
 disallow_untyped_defs = true

--- a/examples/game_of_life/pyproject.toml
+++ b/examples/game_of_life/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-ni-measurementlink-service = {version = "^1.2.0-dev0", allow-prereleases = true}
+ni-measurementlink-service = {version = "^1.2.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/sample_measurement/pyproject.toml
+++ b/examples/sample_measurement/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-ni-measurementlink-service = {version = "^1.2.0-dev0", allow-prereleases = true}
+ni-measurementlink-service = {version = "^1.2.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/sample_measurement/pyproject.toml
+++ b/examples/sample_measurement/pyproject.toml
@@ -14,7 +14,7 @@ mypy = ">=1.0"
 grpc-stubs = "^1.53"
 types-protobuf = "^4.21"
 # Uncomment to use prerelease dependencies.
-ni-measurementlink-service = {path = "../..", develop = true}
+# ni-measurementlink-service = {path = "../..", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.2.0"]


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update examples that depend on 1.2 to use the released version.

> **Note** This will not pass the check-examples PR workflow until 1.2 is released.

### Why should this Pull Request be merged?

Use correct versions

### What testing has been done?

None