### PR TITLE
scripts: Don't install dev-dependencies into C:\ProgramData

### DIFF
--- a/scripts/install_examples.py
+++ b/scripts/install_examples.py
@@ -57,7 +57,12 @@ def main():
             pyproject_path.write_text(new_pyproject_data)
 
         print(f"Installing dependencies")
-        subprocess.run(["poetry", "-v", "install", "--only", "main"], check=True, cwd=install_path, env=clean_env)
+        subprocess.run(
+            ["poetry", "-v", "install", "--only", "main"],
+            check=True,
+            cwd=install_path,
+            env=clean_env,
+        )
 
         print("")
 

--- a/scripts/install_examples.py
+++ b/scripts/install_examples.py
@@ -57,7 +57,7 @@ def main():
             pyproject_path.write_text(new_pyproject_data)
 
         print(f"Installing dependencies")
-        subprocess.run(["poetry", "-v", "install"], check=True, cwd=install_path, env=clean_env)
+        subprocess.run(["poetry", "-v", "install", "--only", "main"], check=True, cwd=install_path, env=clean_env)
 
         print("")
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update `install_examples.py` to skip dev-dependencies by specifying `--only main`.

### Why should this Pull Request be merged?

Deployed measurement services don't need mypy, etc.

### What testing has been done?

Based on stdout timestamps, the install time for `game_of_life` went from about 20 seconds to about 15 seconds.
Did a full run of `install_examples.py` and tested all examples in InstrumentStudio and (where applicable) TestStand, with fixes from another PR.