### PR TITLE
[releases/1.2] examples: Update start.bat to use virtualenv (#416)

### DIFF
--- a/examples/game_of_life/start.bat
+++ b/examples/game_of_life/start.bat
@@ -3,4 +3,4 @@ REM The discovery service uses this script to start the measurement service.
 REM You can customize this script for your Python setup. The -v option logs
 REM messages with level INFO and above.
 
-call python "%~dp0measurement.py" -v
+.venv\Scripts\python.exe measurement.py -v

--- a/examples/nivisa_dmm_measurement/start.bat
+++ b/examples/nivisa_dmm_measurement/start.bat
@@ -3,6 +3,4 @@ REM The discovery service uses this script to start the measurement service.
 REM You can customize this script for your Python setup. The -v option logs
 REM messages with level INFO and above.
 
-REM If you don't have NI Instrument Simulator v2.0 hardware, you can simulate 
-REM it in software by adding the --use-simulation option to this command.
 .venv\Scripts\python.exe measurement.py -v

--- a/examples/output_voltage_measurement/start.bat
+++ b/examples/output_voltage_measurement/start.bat
@@ -3,4 +3,4 @@ REM The discovery service uses this script to start the measurement service.
 REM You can customize this script for your Python setup. The -v option logs
 REM messages with level INFO and above.
 
-call python "%~dp0measurement.py" -v
+.venv\Scripts\python.exe measurement.py -v


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Cherry-pick #416 into releases/1.2.

> game_of_life and output_voltage_measurement:
> - Update start.bat to use a virtualenv.
>
> nivisa_dmm_measurement:
> - Remove outdated comments from start.bat

### Why should this Pull Request be merged?

Make new examples work when statically registered.

### What testing has been done?

Used `install_examples.py` and ran all affected examples.