### PR TITLE
tests: Fix mypy errors

### DIFF
--- a/tests/unit/test_discovery_client.py
+++ b/tests/unit/test_discovery_client.py
@@ -264,7 +264,7 @@ def test___key_file_not_exist___open_key_file___raises_file_not_found_error(
     else:
         mocker.patch(
             "win32file.CreateFile",
-            side_effect=win32file.error(windows_error_code, None, None),
+            side_effect=win32file.error(windows_error_code, "CreateFileA", "File not found"),
         )
 
         with pytest.raises(FileNotFoundError):


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fix mypy errors:
```
tests\unit\test_discovery_client.py:267: error: Argument 2 to "error" has incompatible type "None"; expected "str"  [arg-type]
tests\unit\test_discovery_client.py:267: error: Argument 3 to "error" has incompatible type "None"; expected "str"  [arg-type]
```
### Why should this Pull Request be merged?

Main branch should not have mypy errors.

### What testing has been done?

Ran `poetry run mypy tests`