### PR TITLE
docs: Enable githubpages, intersphinx, and type hints

### DIFF
--- a/.github/workflows/Publish_NIMS.yml
+++ b/.github/workflows/Publish_NIMS.yml
@@ -62,8 +62,7 @@ jobs:
       - name: Update API Reference Documents(Generated using Sphinx)
         run: |
           rm -rf docs
-          mkdir -p docs
-          touch docs/.nojekyll         
+          mkdir -p docs       
           poetry run sphinx-build _docs_source docs -b html
 
       - name: Commit file changes.

--- a/.github/workflows/check_nims.yml
+++ b/.github/workflows/check_nims.yml
@@ -47,8 +47,7 @@ jobs:
       - name: Build docs and check for errors/warnings
         run: |
           rm -rf docs
-          mkdir -p docs
-          touch docs/.nojekyll         
+          mkdir -p docs   
           poetry run sphinx-build _docs_source docs -b html -W --keep-going
       - name: Revert docs
         run:  git clean -dfx docs/ && git restore docs/

--- a/_docs_source/conf.py
+++ b/_docs_source/conf.py
@@ -47,7 +47,7 @@ autoapi_options = list(autoapi.extension._DEFAULT_OPTIONS)
 autoapi_options.remove("private-members")  # note: remove this to include "_" members in docs
 autoapi_dirs = [root_path / "ni_measurementlink_service"]
 autoapi_type = "python"
-autodoc_typehints = "none"
+autodoc_typehints = "description"
 
 
 # WARNING: more than one target found for cross-reference 'MeasurementInfo':

--- a/_docs_source/conf.py
+++ b/_docs_source/conf.py
@@ -84,8 +84,8 @@ intersphinx_mapping = {
     "nidigital": ("https://nidigital.readthedocs.io/en/stable/", None),
     "nidmm": ("https://nidmm.readthedocs.io/en/stable/", None),
     "nifgen": ("https://nifgen.readthedocs.io/en/stable/", None),
-    "niniscope": ("https://niscope.readthedocs.io/en/stable/", None),
-    "niniswitch": ("https://niswitch.readthedocs.io/en/stable/", None),
+    "niscope": ("https://niscope.readthedocs.io/en/stable/", None),
+    "niswitch": ("https://niswitch.readthedocs.io/en/stable/", None),
     "python": ("https://docs.python.org/3", None),
 }
 

--- a/_docs_source/conf.py
+++ b/_docs_source/conf.py
@@ -9,12 +9,14 @@ import toml
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    "sphinx.ext.autodoc",
     "autoapi.extension",
-    "sphinx.ext.viewcode",
-    "sphinx.ext.napoleon",
-    "sphinx_click",
     "m2r2",
+    "sphinx_click",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.githubpages",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
 ]
 
 root_path = pathlib.Path(__file__).parent.parent
@@ -74,6 +76,18 @@ def setup(sphinx):
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+
+intersphinx_mapping = {
+    "nidaqmx": ("https://nidaqmx-python.readthedocs.io/en/stable/", None),
+    "nidcpower": ("https://nidcpower.readthedocs.io/en/stable/", None),
+    "nidigital": ("https://nidigital.readthedocs.io/en/stable/", None),
+    "nidmm": ("https://nidmm.readthedocs.io/en/stable/", None),
+    "nifgen": ("https://nifgen.readthedocs.io/en/stable/", None),
+    "niniscope": ("https://niscope.readthedocs.io/en/stable/", None),
+    "niniswitch": ("https://niswitch.readthedocs.io/en/stable/", None),
+    "python": ("https://docs.python.org/3", None),
+}
 
 
 # -- Options for HTML output ----------------------------------------------


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Enable more Sphinx extensions:
- githubpages: Automatically create `.nojekyll` file
- intersphinx: Allow linking to docs for the Python stdlib and other packages

Remove `touch docs/.nojekyll` from GitHub workflows.

Show type hints in attribute/parameter descriptions.

### Why should this Pull Request be merged?

Enhance documentation by linking to other docs and showing type hints.

Simplify GitHub workflows.

### What testing has been done?

Built docs locally. Verified that the `.nojekyll` file is created and that hyperlinks to stdlib and nidcpower work.