### PR TITLE
service: Add create_nidaqmx_task(s) API

### DIFF
--- a/ni_measurementlink_service/_drivers/_nidaqmx.py
+++ b/ni_measurementlink_service/_drivers/_nidaqmx.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import nidaqmx
+
+from ni_measurementlink_service import session_management  # circular import
+from ni_measurementlink_service._channelpool import GrpcChannelPool
+from ni_measurementlink_service._drivers._grpcdevice import (
+    get_insecure_grpc_device_channel,
+)
+from ni_measurementlink_service._internal.discovery_client import DiscoveryClient
+from ni_measurementlink_service._sessiontypes import SessionInitializationBehavior
+
+_INITIALIZATION_BEHAVIOR = {
+    SessionInitializationBehavior.AUTO: nidaqmx.SessionInitializationBehavior.AUTO,
+    SessionInitializationBehavior.INITIALIZE_SERVER_SESSION: nidaqmx.SessionInitializationBehavior.INITIALIZE_SERVER_SESSION,
+    SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION: nidaqmx.SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION,
+}
+
+
+class SessionConstructor:
+    """Constructs sessions based on SessionInformation."""
+
+    def __init__(
+        self,
+        discovery_client: DiscoveryClient,
+        grpc_channel_pool: GrpcChannelPool,
+        initialization_behavior: SessionInitializationBehavior,
+    ) -> None:
+        """Initialize the session constructor."""
+        self._grpc_channel = get_insecure_grpc_device_channel(
+            discovery_client, grpc_channel_pool, nidaqmx.GRPC_SERVICE_INTERFACE_NAME
+        )
+        self._initialization_behavior = _INITIALIZATION_BEHAVIOR[initialization_behavior]
+
+    def __call__(self, session_info: session_management.SessionInformation) -> nidaqmx.Task:
+        """Construct a session object."""
+        kwargs: Dict[str, Any] = {}
+        if self._grpc_channel:
+            kwargs["grpc_options"] = nidaqmx.GrpcSessionOptions(
+                grpc_channel=self._grpc_channel,
+                session_name=session_info.session_name,
+                initialization_behavior=self._initialization_behavior,
+            )
+
+        return nidaqmx.Task(
+            new_task_name=session_info.session_name,
+            **kwargs,
+        )

--- a/ni_measurementlink_service/session_management.py
+++ b/ni_measurementlink_service/session_management.py
@@ -56,6 +56,7 @@ from ni_measurementlink_service._sessiontypes import (
 if TYPE_CHECKING:
     # Driver API packages are optional dependencies, so only import them lazily
     # at run time or when type-checking.
+    import nidaqmx
     import nidcpower
     import nidigital
     import nidmm
@@ -452,6 +453,61 @@ class BaseReservation(abc.ABC):
                 sessions match the instrument type ID.
         """
         return self._create_sessions_core(session_constructor, instrument_type_id)
+
+    @requires_feature(SESSION_MANAGEMENT_2024Q1)
+    def create_nidaqmx_task(
+        self,
+        initialization_behavior: SessionInitializationBehavior = SessionInitializationBehavior.AUTO,
+    ) -> ContextManager[TypedSessionInformation[nidaqmx.Task]]:
+        """Create a single NI-DAQmx task.
+
+        Args:
+            initialization_behavior: Specifies whether to initialize a new
+                task or attach to an existing task.
+
+        Returns:
+            A context manager that yields a session information object. The
+            created task is available via the ``session`` field.
+
+        Note:
+            If the ``session_exists`` field is ``False``, the returned task is
+            empty and the caller is expected to add channels to it.
+
+        See Also:
+            For more details, see :py:class:`nidaqmx.Task`.
+        """
+        from ni_measurementlink_service._drivers._nidaqmx import SessionConstructor
+
+        session_constructor = SessionConstructor(
+            self._discovery_client, self._grpc_channel_pool, initialization_behavior
+        )
+        return self._create_session_core(session_constructor, INSTRUMENT_TYPE_NI_DAQMX)
+
+    @requires_feature(SESSION_MANAGEMENT_2024Q1)
+    def create_nidaqmx_tasks(
+        self,
+        initialization_behavior: SessionInitializationBehavior = SessionInitializationBehavior.AUTO,
+    ) -> ContextManager[Sequence[TypedSessionInformation[nidcpower.Session]]]:
+        """Create multiple NI-DAQmx tasks.
+
+        Args:
+            initialization_behavior: Specifies whether to initialize a new
+                task or attach to an existing task.
+
+        Returns:
+            A context manager that yields a sequence of session information
+            objects. The created tasks are available via the ``session``
+            field.
+
+        See Also:
+            For more details, see :py:class:`nidaqmx.Task`.
+        """
+        from ni_measurementlink_service._drivers._nidaqmx import SessionConstructor
+
+        session_constructor = SessionConstructor(
+            self._discovery_client, self._grpc_channel_pool, initialization_behavior
+        )
+        return self._create_sessions_core(session_constructor, INSTRUMENT_TYPE_NI_DAQMX)
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
     def create_nidcpower_session(

--- a/ni_measurementlink_service/session_management.py
+++ b/ni_measurementlink_service/session_management.py
@@ -469,6 +469,10 @@ class BaseReservation(abc.ABC):
             A context manager that yields a session information object. The
             created task is available via the ``session`` field.
 
+        Raises:
+            ValueError: If no NI-DAQmx tasks are reserved or too many
+                NI-DAQmx tasks are reserved.
+
         Note:
             If the ``session_exists`` field is ``False``, the returned task is
             empty and the caller is expected to add channels to it.
@@ -498,6 +502,13 @@ class BaseReservation(abc.ABC):
             A context manager that yields a sequence of session information
             objects. The created tasks are available via the ``session``
             field.
+
+        Raises:
+            ValueError: If no NI-DAQmx tasks are reserved.
+
+        Note:
+            If the ``session_exists`` field is ``False``, the returned tasks are
+            empty and the caller is expected to add channels to them.
 
         See Also:
             For more details, see :py:class:`nidaqmx.Task`.

--- a/tests/unit/_drivers/test_nidaqmx.py
+++ b/tests/unit/_drivers/test_nidaqmx.py
@@ -1,0 +1,93 @@
+import functools
+from unittest.mock import ANY, Mock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from ni_measurementlink_service.session_management import (
+    INSTRUMENT_TYPE_NI_DAQMX,
+    MultiSessionReservation,
+    SessionInitializationBehavior,
+)
+from tests.unit._drivers._driver_utils import create_mock_session, create_mock_sessions
+from tests.unit._reservation_utils import create_grpc_session_infos
+
+try:
+    import nidaqmx
+except ImportError:
+    nidaqmx = None
+
+pytestmark = pytest.mark.skipif(nidaqmx is None, reason="Requires 'nidaqmx' package.")
+
+if nidaqmx:
+    # Note: this reads the Task type before it is patched.
+    create_mock_nidaqmx_task = functools.partial(create_mock_session, nidaqmx.Task)
+    create_mock_nidaqmx_tasks = functools.partial(create_mock_sessions, nidaqmx.Task)
+    create_nidaqmx_session_infos = functools.partial(
+        create_grpc_session_infos, INSTRUMENT_TYPE_NI_DAQMX
+    )
+
+
+def test___single_session_info___create_nidaqmx_task___task_created(
+    session_type: Mock,
+    session_management_client: Mock,
+) -> None:
+    reservation = MultiSessionReservation(
+        session_management_client, create_nidaqmx_session_infos(1)
+    )
+    task = create_mock_nidaqmx_task()
+    session_type.side_effect = [task]
+
+    with reservation.create_nidaqmx_task() as session_info:
+        assert session_info.session is task
+
+    session_type.assert_called_once_with(new_task_name="MySession0", grpc_options=ANY)
+
+
+def test___multiple_session_infos___create_nidaqmx_tasks___sessions_created(
+    session_type: Mock,
+    session_management_client: Mock,
+) -> None:
+    reservation = MultiSessionReservation(
+        session_management_client, create_nidaqmx_session_infos(2)
+    )
+    tasks = create_mock_nidaqmx_tasks(3)
+    session_type.side_effect = tasks
+
+    with reservation.create_nidaqmx_tasks() as session_info:
+        assert session_info[0].session == tasks[0]
+        assert session_info[1].session == tasks[1]
+
+    session_type.assert_any_call(new_task_name="MySession0", grpc_options=ANY)
+    session_type.assert_any_call(new_task_name="MySession1", grpc_options=ANY)
+
+
+def test___optional_args___create_nidaqmx_task___optional_args_passed(
+    session_type: Mock,
+    session_management_client: Mock,
+) -> None:
+    reservation = MultiSessionReservation(
+        session_management_client, create_nidaqmx_session_infos(1)
+    )
+    task = create_mock_nidaqmx_task()
+    session_type.side_effect = [task]
+
+    with reservation.create_nidaqmx_task(
+        initialization_behavior=SessionInitializationBehavior.INITIALIZE_SERVER_SESSION,
+    ):
+        pass
+
+    session_type.assert_called_once_with(
+        new_task_name="MySession0",
+        grpc_options=ANY,
+    )
+    assert (
+        session_type.call_args.kwargs["grpc_options"].initialization_behavior
+        == nidaqmx.SessionInitializationBehavior.INITIALIZE_SERVER_SESSION
+    )
+
+
+@pytest.fixture
+def session_type(mocker: MockerFixture) -> Mock:
+    """A test fixture that replaces the Session class with a mock."""
+    return mocker.patch("nidaqmx.Task", autospec=True)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add `reservation.create_nidaqmx_task(s)`.

### Why should this Pull Request be merged?

Part of new session management API.

### What testing has been done?

Ran new unit tests. 
Updated DAQmx example to use new API (not part of this PR).