### PR TITLE
service: Fix session type checks

### DIFF
--- a/ni_measurementlink_service/session_management/_reservation.py
+++ b/ni_measurementlink_service/session_management/_reservation.py
@@ -136,7 +136,6 @@ class BaseReservation(abc.ABC):
         self,
         session_constructor: Callable[[SessionInformation], TSession],
         instrument_type_id: str,
-        session_type: Optional[Type[TSession]] = None,
     ) -> Generator[TypedSessionInformation[TSession], None, None]:
         if not instrument_type_id:
             raise ValueError("This method requires an instrument type ID.")
@@ -156,8 +155,6 @@ class BaseReservation(abc.ABC):
         with closing_session(session_constructor(session_info)) as session:
             with self._cache_session(session_info.session_name, session):
                 new_session_info = session_info._with_session(session)
-                if session_type:
-                    new_session_info._check_runtime_type(session_type)
                 yield cast(TypedSessionInformation[TSession], new_session_info)
 
     @contextlib.contextmanager
@@ -165,7 +162,6 @@ class BaseReservation(abc.ABC):
         self,
         session_constructor: Callable[[SessionInformation], TSession],
         instrument_type_id: str,
-        session_type: Optional[Type[TSession]] = None,
     ) -> Generator[Sequence[TypedSessionInformation[TSession]], None, None]:
         if not instrument_type_id:
             raise ValueError("This method requires an instrument type ID.")
@@ -182,8 +178,6 @@ class BaseReservation(abc.ABC):
                 session = stack.enter_context(closing_session(session_constructor(session_info)))
                 stack.enter_context(self._cache_session(session_info.session_name, session))
                 new_session_info = session_info._with_session(session)
-                if session_type:
-                    new_session_info._check_runtime_type(session_type)
                 typed_session_infos.append(
                     cast(TypedSessionInformation[TSession], new_session_info)
                 )
@@ -275,16 +269,12 @@ class BaseReservation(abc.ABC):
         See Also:
             For more details, see :py:class:`nidaqmx.Task`.
         """
-        import nidaqmx
-
         from ni_measurementlink_service._drivers._nidaqmx import SessionConstructor
 
         session_constructor = SessionConstructor(
             self._discovery_client, self._grpc_channel_pool, initialization_behavior
         )
-        return self._create_session_core(
-            session_constructor, INSTRUMENT_TYPE_NI_DAQMX, nidaqmx.Task
-        )
+        return self._create_session_core(session_constructor, INSTRUMENT_TYPE_NI_DAQMX)
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
     def create_nidaqmx_tasks(
@@ -312,16 +302,12 @@ class BaseReservation(abc.ABC):
         See Also:
             For more details, see :py:class:`nidaqmx.Task`.
         """
-        import nidaqmx
-
         from ni_measurementlink_service._drivers._nidaqmx import SessionConstructor
 
         session_constructor = SessionConstructor(
             self._discovery_client, self._grpc_channel_pool, initialization_behavior
         )
-        return self._create_sessions_core(
-            session_constructor, INSTRUMENT_TYPE_NI_DAQMX, nidaqmx.Task
-        )
+        return self._create_sessions_core(session_constructor, INSTRUMENT_TYPE_NI_DAQMX)
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
     def create_nidcpower_session(
@@ -356,16 +342,12 @@ class BaseReservation(abc.ABC):
         See Also:
             For more details, see :py:class:`nidcpower.Session`.
         """
-        import nidcpower
-
         from ni_measurementlink_service._drivers._nidcpower import SessionConstructor
 
         session_constructor = SessionConstructor(
             self._discovery_client, self._grpc_channel_pool, reset, options, initialization_behavior
         )
-        return self._create_session_core(
-            session_constructor, INSTRUMENT_TYPE_NI_DCPOWER, nidcpower.Session
-        )
+        return self._create_session_core(session_constructor, INSTRUMENT_TYPE_NI_DCPOWER)
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
     def create_nidcpower_sessions(
@@ -400,16 +382,12 @@ class BaseReservation(abc.ABC):
         See Also:
             For more details, see :py:class:`nidcpower.Session`.
         """
-        import nidcpower
-
         from ni_measurementlink_service._drivers._nidcpower import SessionConstructor
 
         session_constructor = SessionConstructor(
             self._discovery_client, self._grpc_channel_pool, reset, options, initialization_behavior
         )
-        return self._create_sessions_core(
-            session_constructor, INSTRUMENT_TYPE_NI_DCPOWER, nidcpower.Session
-        )
+        return self._create_sessions_core(session_constructor, INSTRUMENT_TYPE_NI_DCPOWER)
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
     def create_nidigital_session(
@@ -444,8 +422,6 @@ class BaseReservation(abc.ABC):
         See Also:
             For more details, see :py:class:`nidigital.Session`.
         """
-        import nidigital
-
         from ni_measurementlink_service._drivers._nidigital import SessionConstructor
 
         session_constructor = SessionConstructor(
@@ -455,9 +431,7 @@ class BaseReservation(abc.ABC):
             options,
             initialization_behavior,
         )
-        return self._create_session_core(
-            session_constructor, INSTRUMENT_TYPE_NI_DIGITAL_PATTERN, nidigital.Session
-        )
+        return self._create_session_core(session_constructor, INSTRUMENT_TYPE_NI_DIGITAL_PATTERN)
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
     def create_nidigital_sessions(
@@ -492,8 +466,6 @@ class BaseReservation(abc.ABC):
         See Also:
             For more details, see :py:class:`nidigital.Session`.
         """
-        import nidigital
-
         from ni_measurementlink_service._drivers._nidigital import SessionConstructor
 
         session_constructor = SessionConstructor(
@@ -503,9 +475,7 @@ class BaseReservation(abc.ABC):
             options,
             initialization_behavior,
         )
-        return self._create_sessions_core(
-            session_constructor, INSTRUMENT_TYPE_NI_DIGITAL_PATTERN, nidigital.Session
-        )
+        return self._create_sessions_core(session_constructor, INSTRUMENT_TYPE_NI_DIGITAL_PATTERN)
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
     def create_nidmm_session(
@@ -540,8 +510,6 @@ class BaseReservation(abc.ABC):
         See Also:
             For more details, see :py:class:`nidmm.Session`.
         """
-        import nidmm
-
         from ni_measurementlink_service._drivers._nidmm import SessionConstructor
 
         session_constructor = SessionConstructor(
@@ -551,7 +519,7 @@ class BaseReservation(abc.ABC):
             options,
             initialization_behavior,
         )
-        return self._create_session_core(session_constructor, INSTRUMENT_TYPE_NI_DMM, nidmm.Session)
+        return self._create_session_core(session_constructor, INSTRUMENT_TYPE_NI_DMM)
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
     def create_nidmm_sessions(
@@ -586,8 +554,6 @@ class BaseReservation(abc.ABC):
         See Also:
             For more details, see :py:class:`nidmm.Session`.
         """
-        import nidmm
-
         from ni_measurementlink_service._drivers._nidmm import SessionConstructor
 
         session_constructor = SessionConstructor(
@@ -597,9 +563,7 @@ class BaseReservation(abc.ABC):
             options,
             initialization_behavior,
         )
-        return self._create_sessions_core(
-            session_constructor, INSTRUMENT_TYPE_NI_DMM, nidmm.Session
-        )
+        return self._create_sessions_core(session_constructor, INSTRUMENT_TYPE_NI_DMM)
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
     def create_nifgen_session(
@@ -634,8 +598,6 @@ class BaseReservation(abc.ABC):
         See Also:
             For more details, see :py:class:`nifgen.Session`.
         """
-        import nifgen
-
         from ni_measurementlink_service._drivers._nifgen import SessionConstructor
 
         session_constructor = SessionConstructor(
@@ -645,9 +607,7 @@ class BaseReservation(abc.ABC):
             options,
             initialization_behavior,
         )
-        return self._create_session_core(
-            session_constructor, INSTRUMENT_TYPE_NI_FGEN, nifgen.Session
-        )
+        return self._create_session_core(session_constructor, INSTRUMENT_TYPE_NI_FGEN)
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
     def create_nifgen_sessions(
@@ -682,8 +642,6 @@ class BaseReservation(abc.ABC):
         See Also:
             For more details, see :py:class:`nifgen.Session`.
         """
-        import nifgen
-
         from ni_measurementlink_service._drivers._nifgen import SessionConstructor
 
         session_constructor = SessionConstructor(
@@ -693,9 +651,7 @@ class BaseReservation(abc.ABC):
             options,
             initialization_behavior,
         )
-        return self._create_sessions_core(
-            session_constructor, INSTRUMENT_TYPE_NI_FGEN, nifgen.Session
-        )
+        return self._create_sessions_core(session_constructor, INSTRUMENT_TYPE_NI_FGEN)
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
     def create_niscope_session(
@@ -730,8 +686,6 @@ class BaseReservation(abc.ABC):
         See Also:
             For more details, see :py:class:`niscope.Session`.
         """
-        import niscope
-
         from ni_measurementlink_service._drivers._niscope import SessionConstructor
 
         session_constructor = SessionConstructor(
@@ -741,9 +695,7 @@ class BaseReservation(abc.ABC):
             options,
             initialization_behavior,
         )
-        return self._create_session_core(
-            session_constructor, INSTRUMENT_TYPE_NI_SCOPE, niscope.Session
-        )
+        return self._create_session_core(session_constructor, INSTRUMENT_TYPE_NI_SCOPE)
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
     def create_niscope_sessions(
@@ -778,8 +730,6 @@ class BaseReservation(abc.ABC):
         See Also:
             For more details, see :py:class:`niscope.Session`.
         """
-        import niscope
-
         from ni_measurementlink_service._drivers._niscope import SessionConstructor
 
         session_constructor = SessionConstructor(
@@ -789,9 +739,7 @@ class BaseReservation(abc.ABC):
             options,
             initialization_behavior,
         )
-        return self._create_sessions_core(
-            session_constructor, INSTRUMENT_TYPE_NI_SCOPE, niscope.Session
-        )
+        return self._create_sessions_core(session_constructor, INSTRUMENT_TYPE_NI_SCOPE)
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
     def create_niswitch_session(
@@ -831,8 +779,6 @@ class BaseReservation(abc.ABC):
         See Also:
             For more details, see :py:class:`niswitch.Session`.
         """
-        import niswitch
-
         from ni_measurementlink_service._drivers._niswitch import SessionConstructor
 
         session_constructor = SessionConstructor(
@@ -843,9 +789,7 @@ class BaseReservation(abc.ABC):
             reset_device,
             initialization_behavior,
         )
-        return self._create_session_core(
-            session_constructor, INSTRUMENT_TYPE_NI_RELAY_DRIVER, niswitch.Session
-        )
+        return self._create_session_core(session_constructor, INSTRUMENT_TYPE_NI_RELAY_DRIVER)
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
     def create_niswitch_sessions(
@@ -885,8 +829,6 @@ class BaseReservation(abc.ABC):
         See Also:
             For more details, see :py:class:`niswitch.Session`.
         """
-        import niswitch
-
         from ni_measurementlink_service._drivers._niswitch import SessionConstructor
 
         session_constructor = SessionConstructor(
@@ -897,9 +839,7 @@ class BaseReservation(abc.ABC):
             reset_device,
             initialization_behavior,
         )
-        return self._create_sessions_core(
-            session_constructor, INSTRUMENT_TYPE_NI_RELAY_DRIVER, niswitch.Session
-        )
+        return self._create_sessions_core(session_constructor, INSTRUMENT_TYPE_NI_RELAY_DRIVER)
 
 
 class SingleSessionReservation(BaseReservation):

--- a/ni_measurementlink_service/session_management/_types.py
+++ b/ni_measurementlink_service/session_management/_types.py
@@ -9,9 +9,7 @@ from typing import (
     NamedTuple,
     Optional,
     Protocol,
-    Type,
     TypeVar,
-    cast,
 )
 
 from ni_measurementlink_service._internal.stubs import session_pb2
@@ -136,15 +134,15 @@ class SessionInformation(NamedTuple):
     This field is None until the appropriate create_session(s) method is called.
     """
 
-    def _as_typed(self, session_type: Type[TSession]) -> TypedSessionInformation[TSession]:
-        assert isinstance(self.session, session_type)
-        return cast(TypedSessionInformation[TSession], self)
+    def _check_runtime_type(self, session_type: type) -> None:
+        if not isinstance(self.session, session_type):
+            raise TypeError(
+                f"Incorrect type for session '{self.session_name}'. "
+                f"Expected '{session_type}', got '{type(self.session)}'"
+            )
 
     def _with_session(self, session: object) -> SessionInformation:
         return self._replace(session=session)
-
-    def _with_typed_session(self, session: TSession) -> TypedSessionInformation[TSession]:
-        return self._with_session(session)._as_typed(type(session))
 
     @classmethod
     def _from_grpc_v1(

--- a/tests/unit/_drivers/test_nidaqmx.py
+++ b/tests/unit/_drivers/test_nidaqmx.py
@@ -20,7 +20,6 @@ except ImportError:
 pytestmark = pytest.mark.skipif(nidaqmx is None, reason="Requires 'nidaqmx' package.")
 
 if nidaqmx:
-    # Note: this reads the Task type before it is patched.
     create_mock_nidaqmx_task = functools.partial(create_mock_session, nidaqmx.Task)
     create_mock_nidaqmx_tasks = functools.partial(create_mock_sessions, nidaqmx.Task)
     create_nidaqmx_session_infos = functools.partial(
@@ -29,65 +28,66 @@ if nidaqmx:
 
 
 def test___single_session_info___create_nidaqmx_task___task_created(
-    session_type: Mock,
+    task_new: Mock,
     session_management_client: Mock,
 ) -> None:
     reservation = MultiSessionReservation(
         session_management_client, create_nidaqmx_session_infos(1)
     )
     task = create_mock_nidaqmx_task()
-    session_type.side_effect = [task]
+    task_new.side_effect = [task]
 
     with reservation.create_nidaqmx_task() as session_info:
         assert session_info.session is task
 
-    session_type.assert_called_once_with(new_task_name="MySession0", grpc_options=ANY)
+    task_new.assert_called_once_with(nidaqmx.Task, new_task_name="MySession0", grpc_options=ANY)
 
 
 def test___multiple_session_infos___create_nidaqmx_tasks___sessions_created(
-    session_type: Mock,
+    task_new: Mock,
     session_management_client: Mock,
 ) -> None:
     reservation = MultiSessionReservation(
         session_management_client, create_nidaqmx_session_infos(2)
     )
-    tasks = create_mock_nidaqmx_tasks(3)
-    session_type.side_effect = tasks
+    tasks = create_mock_nidaqmx_tasks(2)
+    task_new.side_effect = tasks
 
     with reservation.create_nidaqmx_tasks() as session_info:
         assert session_info[0].session == tasks[0]
         assert session_info[1].session == tasks[1]
 
-    session_type.assert_any_call(new_task_name="MySession0", grpc_options=ANY)
-    session_type.assert_any_call(new_task_name="MySession1", grpc_options=ANY)
+    task_new.assert_any_call(nidaqmx.Task, new_task_name="MySession0", grpc_options=ANY)
+    task_new.assert_any_call(nidaqmx.Task, new_task_name="MySession1", grpc_options=ANY)
 
 
 def test___optional_args___create_nidaqmx_task___optional_args_passed(
-    session_type: Mock,
+    task_new: Mock,
     session_management_client: Mock,
 ) -> None:
     reservation = MultiSessionReservation(
         session_management_client, create_nidaqmx_session_infos(1)
     )
     task = create_mock_nidaqmx_task()
-    session_type.side_effect = [task]
+    task_new.side_effect = [task]
 
     with reservation.create_nidaqmx_task(
         initialization_behavior=SessionInitializationBehavior.INITIALIZE_SERVER_SESSION,
     ):
         pass
 
-    session_type.assert_called_once_with(
+    task_new.assert_called_once_with(
+        nidaqmx.Task,
         new_task_name="MySession0",
         grpc_options=ANY,
     )
     assert (
-        session_type.call_args.kwargs["grpc_options"].initialization_behavior
+        task_new.call_args.kwargs["grpc_options"].initialization_behavior
         == nidaqmx.SessionInitializationBehavior.INITIALIZE_SERVER_SESSION
     )
 
 
 @pytest.fixture
-def session_type(mocker: MockerFixture) -> Mock:
-    """A test fixture that replaces the Session class with a mock."""
-    return mocker.patch("nidaqmx.Task", autospec=True)
+def task_new(mocker: MockerFixture) -> Mock:
+    """A test fixture that patches the Task class's __new__ method."""
+    return mocker.patch("nidaqmx.Task.__new__", autospec=True)

--- a/tests/unit/_drivers/test_nidcpower.py
+++ b/tests/unit/_drivers/test_nidcpower.py
@@ -24,7 +24,6 @@ except ImportError:
 pytestmark = pytest.mark.skipif(nidcpower is None, reason="Requires 'nidcpower' package.")
 
 if nidcpower:
-    # Note: this reads the Session type before it is patched.
     create_mock_nidcpower_session = functools.partial(create_mock_session, nidcpower.Session)
     create_mock_nidcpower_sessions = functools.partial(create_mock_sessions, nidcpower.Session)
     create_nidcpower_session_infos = functools.partial(
@@ -34,50 +33,54 @@ if nidcpower:
 
 
 def test___single_session_info___create_nidcpower_session___session_created(
-    session_type: Mock,
+    session_new: Mock,
     session_management_client: Mock,
 ) -> None:
     reservation = MultiSessionReservation(
         session_management_client, create_nidcpower_session_infos(1)
     )
     session = create_mock_nidcpower_session()
-    session_type.side_effect = [session]
+    session_new.side_effect = [session]
 
     with reservation.create_nidcpower_session() as session_info:
         assert session_info.session is session
 
-    session_type.assert_called_once_with(
-        resource_name="Dev0", reset=False, options={}, grpc_options=ANY
+    session_new.assert_called_once_with(
+        nidcpower.Session, resource_name="Dev0", reset=False, options={}, grpc_options=ANY
     )
 
 
 def test___multiple_session_infos___create_nidcpower_sessions___sessions_created(
-    session_type: Mock,
+    session_new: Mock,
     session_management_client: Mock,
 ) -> None:
     reservation = MultiSessionReservation(
         session_management_client, create_nidcpower_session_infos(2)
     )
     sessions = create_mock_nidcpower_sessions(3)
-    session_type.side_effect = sessions
+    session_new.side_effect = sessions
 
     with reservation.create_nidcpower_sessions() as session_info:
         assert session_info[0].session == sessions[0]
         assert session_info[1].session == sessions[1]
 
-    session_type.assert_any_call(resource_name="Dev0", reset=False, options={}, grpc_options=ANY)
-    session_type.assert_any_call(resource_name="Dev1", reset=False, options={}, grpc_options=ANY)
+    session_new.assert_any_call(
+        nidcpower.Session, resource_name="Dev0", reset=False, options={}, grpc_options=ANY
+    )
+    session_new.assert_any_call(
+        nidcpower.Session, resource_name="Dev1", reset=False, options={}, grpc_options=ANY
+    )
 
 
 def test___optional_args___create_nidcpower_session___optional_args_passed(
-    session_type: Mock,
+    session_new: Mock,
     session_management_client: Mock,
 ) -> None:
     reservation = MultiSessionReservation(
         session_management_client, create_nidcpower_session_infos(1)
     )
     session = create_mock_nidcpower_session()
-    session_type.side_effect = [session]
+    session_new.side_effect = [session]
 
     with reservation.create_nidcpower_session(
         reset=True,
@@ -86,18 +89,22 @@ def test___optional_args___create_nidcpower_session___optional_args_passed(
     ):
         pass
 
-    session_type.assert_called_once_with(
-        resource_name="Dev0", reset=True, options={"simulate": False}, grpc_options=ANY
+    session_new.assert_called_once_with(
+        nidcpower.Session,
+        resource_name="Dev0",
+        reset=True,
+        options={"simulate": False},
+        grpc_options=ANY,
     )
     assert (
-        session_type.call_args.kwargs["grpc_options"].initialization_behavior
+        session_new.call_args.kwargs["grpc_options"].initialization_behavior
         == nidcpower.SessionInitializationBehavior.INITIALIZE_SERVER_SESSION
     )
 
 
 def test___simulation_configured___create_nidcpower_session___simulation_options_passed(
     mocker: MockerFixture,
-    session_type: Mock,
+    session_new: Mock,
     session_management_client: Mock,
 ) -> None:
     set_nidcpower_simulation_options(mocker, True, "PXIe", "4147")
@@ -105,20 +112,24 @@ def test___simulation_configured___create_nidcpower_session___simulation_options
         session_management_client, create_nidcpower_session_infos(1)
     )
     session = create_mock_nidcpower_session()
-    session_type.side_effect = [session]
+    session_new.side_effect = [session]
 
     with reservation.create_nidcpower_session():
         pass
 
     expected_options = {"simulate": True, "driver_setup": {"BoardType": "PXIe", "Model": "4147"}}
-    session_type.assert_called_once_with(
-        resource_name="Dev0", reset=False, options=expected_options, grpc_options=ANY
+    session_new.assert_called_once_with(
+        nidcpower.Session,
+        resource_name="Dev0",
+        reset=False,
+        options=expected_options,
+        grpc_options=ANY,
     )
 
 
 def test___optional_args_and_simulation_configured___create_nidcpower_session___optional_args_passed(
     mocker: MockerFixture,
-    session_type: Mock,
+    session_new: Mock,
     session_management_client: Mock,
 ) -> None:
     set_nidcpower_simulation_options(mocker, True, "PXIe", "4147")
@@ -126,18 +137,22 @@ def test___optional_args_and_simulation_configured___create_nidcpower_session___
         session_management_client, create_nidcpower_session_infos(1)
     )
     session = create_mock_nidcpower_session()
-    session_type.side_effect = [session]
+    session_new.side_effect = [session]
 
     with reservation.create_nidcpower_session(reset=True, options={"simulate": False}):
         pass
 
     expected_options = {"simulate": False}
-    session_type.assert_called_once_with(
-        resource_name="Dev0", reset=True, options=expected_options, grpc_options=ANY
+    session_new.assert_called_once_with(
+        nidcpower.Session,
+        resource_name="Dev0",
+        reset=True,
+        options=expected_options,
+        grpc_options=ANY,
     )
 
 
 @pytest.fixture
-def session_type(mocker: MockerFixture) -> Mock:
-    """A test fixture that replaces the Session class with a mock."""
-    return mocker.patch("nidcpower.Session", autospec=True)
+def session_new(mocker: MockerFixture) -> Mock:
+    """A test fixture that patches the Session class's __new__ method."""
+    return mocker.patch("nidcpower.Session.__new__", autospec=True)

--- a/tests/unit/_drivers/test_nidigital.py
+++ b/tests/unit/_drivers/test_nidigital.py
@@ -24,7 +24,6 @@ except ImportError:
 pytestmark = pytest.mark.skipif(nidigital is None, reason="Requires 'nidigital' package.")
 
 if nidigital:
-    # Note: this reads the Session type before it is patched.
     create_mock_nidigital_session = functools.partial(create_mock_session, nidigital.Session)
     create_mock_nidigital_sessions = functools.partial(create_mock_sessions, nidigital.Session)
     create_nidigital_session_infos = functools.partial(
@@ -34,54 +33,54 @@ if nidigital:
 
 
 def test___single_session_info___create_nidigital_session___session_created(
-    session_type: Mock,
+    session_new: Mock,
     session_management_client: Mock,
 ) -> None:
     reservation = MultiSessionReservation(
         session_management_client, create_nidigital_session_infos(1)
     )
     session = create_mock_nidigital_session()
-    session_type.side_effect = [session]
+    session_new.side_effect = [session]
 
     with reservation.create_nidigital_session() as session_info:
         assert session_info.session is session
 
-    session_type.assert_called_once_with(
-        resource_name="Dev0", reset_device=False, options={}, grpc_options=ANY
+    session_new.assert_called_once_with(
+        nidigital.Session, resource_name="Dev0", reset_device=False, options={}, grpc_options=ANY
     )
 
 
 def test___multiple_session_infos___create_nidigital_sessions___sessions_created(
-    session_type: Mock,
+    session_new: Mock,
     session_management_client: Mock,
 ) -> None:
     reservation = MultiSessionReservation(
         session_management_client, create_nidigital_session_infos(2)
     )
     sessions = create_mock_nidigital_sessions(3)
-    session_type.side_effect = sessions
+    session_new.side_effect = sessions
 
     with reservation.create_nidigital_sessions() as session_info:
         assert session_info[0].session == sessions[0]
         assert session_info[1].session == sessions[1]
 
-    session_type.assert_any_call(
-        resource_name="Dev0", reset_device=False, options={}, grpc_options=ANY
+    session_new.assert_any_call(
+        nidigital.Session, resource_name="Dev0", reset_device=False, options={}, grpc_options=ANY
     )
-    session_type.assert_any_call(
-        resource_name="Dev1", reset_device=False, options={}, grpc_options=ANY
+    session_new.assert_any_call(
+        nidigital.Session, resource_name="Dev1", reset_device=False, options={}, grpc_options=ANY
     )
 
 
 def test___optional_args___create_nidigital_session___optional_args_passed(
-    session_type: Mock,
+    session_new: Mock,
     session_management_client: Mock,
 ) -> None:
     reservation = MultiSessionReservation(
         session_management_client, create_nidigital_session_infos(1)
     )
     session = create_mock_nidigital_session()
-    session_type.side_effect = [session]
+    session_new.side_effect = [session]
 
     with reservation.create_nidigital_session(
         reset_device=True,
@@ -90,21 +89,22 @@ def test___optional_args___create_nidigital_session___optional_args_passed(
     ):
         pass
 
-    session_type.assert_called_once_with(
+    session_new.assert_called_once_with(
+        nidigital.Session,
         resource_name="Dev0",
         reset_device=True,
         options={"simulate": False},
         grpc_options=ANY,
     )
     assert (
-        session_type.call_args.kwargs["grpc_options"].initialization_behavior
+        session_new.call_args.kwargs["grpc_options"].initialization_behavior
         == nidigital.SessionInitializationBehavior.INITIALIZE_SERVER_SESSION
     )
 
 
 def test___simulation_configured___create_nidigital_session___simulation_options_passed(
     mocker: MockerFixture,
-    session_type: Mock,
+    session_new: Mock,
     session_management_client: Mock,
 ) -> None:
     set_nidigital_simulation_options(mocker, True, "PXIe", "6570")
@@ -112,7 +112,7 @@ def test___simulation_configured___create_nidigital_session___simulation_options
         session_management_client, create_nidigital_session_infos(1)
     )
     session = create_mock_nidigital_session()
-    session_type.side_effect = [session]
+    session_new.side_effect = [session]
 
     with reservation.create_nidigital_session():
         pass
@@ -121,7 +121,8 @@ def test___simulation_configured___create_nidigital_session___simulation_options
         "simulate": True,
         "driver_setup": {"BoardType": "PXIe", "Model": "6570"},
     }
-    session_type.assert_called_once_with(
+    session_new.assert_called_once_with(
+        nidigital.Session,
         resource_name="Dev0",
         reset_device=False,
         options=expected_options,
@@ -131,7 +132,7 @@ def test___simulation_configured___create_nidigital_session___simulation_options
 
 def test___optional_args_and_simulation_configured___create_nidigital_session___optional_args_passed(
     mocker: MockerFixture,
-    session_type: Mock,
+    session_new: Mock,
     session_management_client: Mock,
 ) -> None:
     set_nidigital_simulation_options(mocker, True, "PXIe", "6570")
@@ -139,13 +140,14 @@ def test___optional_args_and_simulation_configured___create_nidigital_session___
         session_management_client, create_nidigital_session_infos(1)
     )
     session = create_mock_nidigital_session()
-    session_type.side_effect = [session]
+    session_new.side_effect = [session]
 
     with reservation.create_nidigital_session(reset_device=True, options={"simulate": False}):
         pass
 
     expected_options = {"simulate": False}
-    session_type.assert_called_once_with(
+    session_new.assert_called_once_with(
+        nidigital.Session,
         resource_name="Dev0",
         reset_device=True,
         options=expected_options,
@@ -154,6 +156,6 @@ def test___optional_args_and_simulation_configured___create_nidigital_session___
 
 
 @pytest.fixture
-def session_type(mocker: MockerFixture) -> Mock:
-    """A test fixture that replaces the Session class with a mock."""
-    return mocker.patch("nidigital.Session", autospec=True)
+def session_new(mocker: MockerFixture) -> Mock:
+    """A test fixture that patches the Session class's __new__ method."""
+    return mocker.patch("nidigital.Session.__new__", autospec=True)

--- a/tests/unit/_drivers/test_nifgen.py
+++ b/tests/unit/_drivers/test_nifgen.py
@@ -24,7 +24,6 @@ except ImportError:
 pytestmark = pytest.mark.skipif(nifgen is None, reason="Requires 'nifgen' package.")
 
 if nifgen:
-    # Note: this reads the Session type before it is patched.
     create_mock_nifgen_session = functools.partial(create_mock_session, nifgen.Session)
     create_mock_nifgen_sessions = functools.partial(create_mock_sessions, nifgen.Session)
     create_nifgen_session_infos = functools.partial(
@@ -34,48 +33,48 @@ if nifgen:
 
 
 def test___single_session_info___create_nifgen_session___session_created(
-    session_type: Mock,
+    session_new: Mock,
     session_management_client: Mock,
 ) -> None:
     reservation = MultiSessionReservation(session_management_client, create_nifgen_session_infos(1))
     session = create_mock_nifgen_session()
-    session_type.side_effect = [session]
+    session_new.side_effect = [session]
 
     with reservation.create_nifgen_session() as session_info:
         assert session_info.session is session
 
-    session_type.assert_called_once_with(
-        resource_name="Dev0", reset_device=False, options={}, grpc_options=ANY
+    session_new.assert_called_once_with(
+        nifgen.Session, resource_name="Dev0", reset_device=False, options={}, grpc_options=ANY
     )
 
 
 def test___multiple_session_infos___create_nifgen_sessions___sessions_created(
-    session_type: Mock,
+    session_new: Mock,
     session_management_client: Mock,
 ) -> None:
     reservation = MultiSessionReservation(session_management_client, create_nifgen_session_infos(2))
     sessions = create_mock_nifgen_sessions(3)
-    session_type.side_effect = sessions
+    session_new.side_effect = sessions
 
     with reservation.create_nifgen_sessions() as session_info:
         assert session_info[0].session == sessions[0]
         assert session_info[1].session == sessions[1]
 
-    session_type.assert_any_call(
-        resource_name="Dev0", reset_device=False, options={}, grpc_options=ANY
+    session_new.assert_any_call(
+        nifgen.Session, resource_name="Dev0", reset_device=False, options={}, grpc_options=ANY
     )
-    session_type.assert_any_call(
-        resource_name="Dev1", reset_device=False, options={}, grpc_options=ANY
+    session_new.assert_any_call(
+        nifgen.Session, resource_name="Dev1", reset_device=False, options={}, grpc_options=ANY
     )
 
 
 def test___optional_args___create_nifgen_session___optional_args_passed(
-    session_type: Mock,
+    session_new: Mock,
     session_management_client: Mock,
 ) -> None:
     reservation = MultiSessionReservation(session_management_client, create_nifgen_session_infos(1))
     session = create_mock_nifgen_session()
-    session_type.side_effect = [session]
+    session_new.side_effect = [session]
 
     with reservation.create_nifgen_session(
         reset_device=True,
@@ -84,24 +83,28 @@ def test___optional_args___create_nifgen_session___optional_args_passed(
     ):
         pass
 
-    session_type.assert_called_once_with(
-        resource_name="Dev0", reset_device=True, options={"simulate": False}, grpc_options=ANY
+    session_new.assert_called_once_with(
+        nifgen.Session,
+        resource_name="Dev0",
+        reset_device=True,
+        options={"simulate": False},
+        grpc_options=ANY,
     )
     assert (
-        session_type.call_args.kwargs["grpc_options"].initialization_behavior
+        session_new.call_args.kwargs["grpc_options"].initialization_behavior
         == nifgen.SessionInitializationBehavior.INITIALIZE_SERVER_SESSION
     )
 
 
 def test___simulation_configured___create_nifgen_session___simulation_options_passed(
     mocker: MockerFixture,
-    session_type: Mock,
+    session_new: Mock,
     session_management_client: Mock,
 ) -> None:
     set_nifgen_simulation_options(mocker, True, "PXIe", "5423 (2CH)")
     reservation = MultiSessionReservation(session_management_client, create_nifgen_session_infos(1))
     session = create_mock_nifgen_session()
-    session_type.side_effect = [session]
+    session_new.side_effect = [session]
 
     with reservation.create_nifgen_session():
         pass
@@ -110,31 +113,39 @@ def test___simulation_configured___create_nifgen_session___simulation_options_pa
         "simulate": True,
         "driver_setup": {"BoardType": "PXIe", "Model": "5423 (2CH)"},
     }
-    session_type.assert_called_once_with(
-        resource_name="Dev0", reset_device=False, options=expected_options, grpc_options=ANY
+    session_new.assert_called_once_with(
+        nifgen.Session,
+        resource_name="Dev0",
+        reset_device=False,
+        options=expected_options,
+        grpc_options=ANY,
     )
 
 
 def test___optional_args_and_simulation_configured___create_nifgen_session___optional_args_passed(
     mocker: MockerFixture,
-    session_type: Mock,
+    session_new: Mock,
     session_management_client: Mock,
 ) -> None:
     set_nifgen_simulation_options(mocker, True, "PXIe", "5423 (2CH)")
     reservation = MultiSessionReservation(session_management_client, create_nifgen_session_infos(1))
     session = create_mock_nifgen_session()
-    session_type.side_effect = [session]
+    session_new.side_effect = [session]
 
     with reservation.create_nifgen_session(reset_device=True, options={"simulate": False}):
         pass
 
     expected_options = {"simulate": False}
-    session_type.assert_called_once_with(
-        resource_name="Dev0", reset_device=True, options=expected_options, grpc_options=ANY
+    session_new.assert_called_once_with(
+        nifgen.Session,
+        resource_name="Dev0",
+        reset_device=True,
+        options=expected_options,
+        grpc_options=ANY,
     )
 
 
 @pytest.fixture
-def session_type(mocker: MockerFixture) -> Mock:
-    """A test fixture that replaces the Session class with a mock."""
-    return mocker.patch("nifgen.Session", autospec=True)
+def session_new(mocker: MockerFixture) -> Mock:
+    """A test fixture that patches the Session class's __new__ method."""
+    return mocker.patch("nifgen.Session.__new__", autospec=True)

--- a/tests/unit/_drivers/test_niscope.py
+++ b/tests/unit/_drivers/test_niscope.py
@@ -24,7 +24,6 @@ except ImportError:
 pytestmark = pytest.mark.skipif(niscope is None, reason="Requires 'niscope' package.")
 
 if niscope:
-    # Note: this reads the Session type before it is patched.
     create_mock_niscope_session = functools.partial(create_mock_session, niscope.Session)
     create_mock_niscope_sessions = functools.partial(create_mock_sessions, niscope.Session)
     create_niscope_session_infos = functools.partial(
@@ -34,54 +33,54 @@ if niscope:
 
 
 def test___single_session_info___create_niscope_session___session_created(
-    session_type: Mock,
+    session_new: Mock,
     session_management_client: Mock,
 ) -> None:
     reservation = MultiSessionReservation(
         session_management_client, create_niscope_session_infos(1)
     )
     session = create_mock_niscope_session()
-    session_type.side_effect = [session]
+    session_new.side_effect = [session]
 
     with reservation.create_niscope_session() as session_info:
         assert session_info.session is session
 
-    session_type.assert_called_once_with(
-        resource_name="Dev0", reset_device=False, options={}, grpc_options=ANY
+    session_new.assert_called_once_with(
+        niscope.Session, resource_name="Dev0", reset_device=False, options={}, grpc_options=ANY
     )
 
 
 def test___multiple_session_infos___create_niscope_sessions___sessions_created(
-    session_type: Mock,
+    session_new: Mock,
     session_management_client: Mock,
 ) -> None:
     reservation = MultiSessionReservation(
         session_management_client, create_niscope_session_infos(2)
     )
     sessions = create_mock_niscope_sessions(3)
-    session_type.side_effect = sessions
+    session_new.side_effect = sessions
 
     with reservation.create_niscope_sessions() as session_info:
         assert session_info[0].session == sessions[0]
         assert session_info[1].session == sessions[1]
 
-    session_type.assert_any_call(
-        resource_name="Dev0", reset_device=False, options={}, grpc_options=ANY
+    session_new.assert_any_call(
+        niscope.Session, resource_name="Dev0", reset_device=False, options={}, grpc_options=ANY
     )
-    session_type.assert_any_call(
-        resource_name="Dev1", reset_device=False, options={}, grpc_options=ANY
+    session_new.assert_any_call(
+        niscope.Session, resource_name="Dev1", reset_device=False, options={}, grpc_options=ANY
     )
 
 
 def test___optional_args___create_niscope_session___optional_args_passed(
-    session_type: Mock,
+    session_new: Mock,
     session_management_client: Mock,
 ) -> None:
     reservation = MultiSessionReservation(
         session_management_client, create_niscope_session_infos(1)
     )
     session = create_mock_niscope_session()
-    session_type.side_effect = [session]
+    session_new.side_effect = [session]
 
     with reservation.create_niscope_session(
         reset_device=True,
@@ -90,21 +89,22 @@ def test___optional_args___create_niscope_session___optional_args_passed(
     ):
         pass
 
-    session_type.assert_called_once_with(
+    session_new.assert_called_once_with(
+        niscope.Session,
         resource_name="Dev0",
         reset_device=True,
         options={"simulate": False},
         grpc_options=ANY,
     )
     assert (
-        session_type.call_args.kwargs["grpc_options"].initialization_behavior
+        session_new.call_args.kwargs["grpc_options"].initialization_behavior
         == niscope.SessionInitializationBehavior.INITIALIZE_SERVER_SESSION
     )
 
 
 def test___simulation_configured___create_niscope_session___simulation_options_passed(
     mocker: MockerFixture,
-    session_type: Mock,
+    session_new: Mock,
     session_management_client: Mock,
 ) -> None:
     set_niscope_simulation_options(mocker, True, "PXIe", "5162 (4CH)")
@@ -112,7 +112,7 @@ def test___simulation_configured___create_niscope_session___simulation_options_p
         session_management_client, create_niscope_session_infos(1)
     )
     session = create_mock_niscope_session()
-    session_type.side_effect = [session]
+    session_new.side_effect = [session]
 
     with reservation.create_niscope_session():
         pass
@@ -121,7 +121,8 @@ def test___simulation_configured___create_niscope_session___simulation_options_p
         "simulate": True,
         "driver_setup": {"BoardType": "PXIe", "Model": "5162 (4CH)"},
     }
-    session_type.assert_called_once_with(
+    session_new.assert_called_once_with(
+        niscope.Session,
         resource_name="Dev0",
         reset_device=False,
         options=expected_options,
@@ -131,7 +132,7 @@ def test___simulation_configured___create_niscope_session___simulation_options_p
 
 def test___optional_args_and_simulation_configured___create_niscope_session___optional_args_passed(
     mocker: MockerFixture,
-    session_type: Mock,
+    session_new: Mock,
     session_management_client: Mock,
 ) -> None:
     set_niscope_simulation_options(mocker, True, "PXIe", "5162 (4CH)")
@@ -139,13 +140,14 @@ def test___optional_args_and_simulation_configured___create_niscope_session___op
         session_management_client, create_niscope_session_infos(1)
     )
     session = create_mock_niscope_session()
-    session_type.side_effect = [session]
+    session_new.side_effect = [session]
 
     with reservation.create_niscope_session(reset_device=True, options={"simulate": False}):
         pass
 
     expected_options = {"simulate": False}
-    session_type.assert_called_once_with(
+    session_new.assert_called_once_with(
+        niscope.Session,
         resource_name="Dev0",
         reset_device=True,
         options=expected_options,
@@ -154,6 +156,6 @@ def test___optional_args_and_simulation_configured___create_niscope_session___op
 
 
 @pytest.fixture
-def session_type(mocker: MockerFixture) -> Mock:
-    """A test fixture that replaces the Session class with a mock."""
-    return mocker.patch("niscope.Session", autospec=True)
+def session_new(mocker: MockerFixture) -> Mock:
+    """A test fixture that patches the Session class's __new__ method."""
+    return mocker.patch("niscope.Session.__new__", autospec=True)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

`_with_typed_session()` was incorrectly assuming that the runtime type matches the static type. Also, it was trying to infer the static type variable `TSession` based on the runtime type expression `type(session)`.

Fixing this revealed a problem with the tests: patching `driver.Session` and replacing it with a mock causes `isinstance` checks to fail. The 2nd argument to `isinstance` must be a type, so it raises an error if `driver.Session` is a `Mock` instance rather than a type. Patching `driver.Session.__new__` instead of `driver.Session` avoids this problem because it ensures that `driver.Session` is still a type. (Patching `driver.Session` to replace it with a subclass that overrides `__new__` would also work.)

### Why should this Pull Request be merged?

These type checks are needed for `get_connection(s)`

### What testing has been done?

Ran updated unit tests.