### PR TITLE
service: Fix NI-SWITCH simulation errors

### DIFF
--- a/ni_measurementlink_service/_drivers/_niswitch.py
+++ b/ni_measurementlink_service/_drivers/_niswitch.py
@@ -53,8 +53,12 @@ class SessionConstructor:
                 initialization_behavior=self._initialization_behavior,
             )
 
+        # Initializing a nonexistent switch module returns
+        # NISWITCH_ERROR_INVALID_RESOURCE_DESCRIPTOR, even if simulate=True.
+        resource_name = "" if self._simulate else session_info.resource_name
+
         return niswitch.Session(
-            resource_name=session_info.resource_name,
+            resource_name=resource_name,
             topology=self._topology,
             simulate=self._simulate,
             reset_device=self._reset_device,

--- a/ni_measurementlink_service/session_management/_reservation.py
+++ b/ni_measurementlink_service/session_management/_reservation.py
@@ -1421,13 +1421,14 @@ class BaseReservation(abc.ABC):
         Args:
             topology: Specifies the switch topology. If this argument is not
                 specified, the default value is "Configured Topology", which you
-                may override by setting ``NISWITCH_TOPOLOGY`` in the
-                configuration file (``.env``).
+                may override by setting ``MEASUREMENTLINK_NISWITCH_TOPOLOGY`` in
+                the configuration file (``.env``).
 
             simulate: Enables or disables simulation of the switch module. If
                 this argument is not specified, the default value is ``False``,
-                which you may override by setting ``NISWITCH_SIMULATE`` in the
-                configuration file (``.env``).
+                which you may override by setting
+                ``MEASUREMENTLINK_NISWITCH_SIMULATE`` in the configuration file
+                (``.env``).
 
             reset_device: Specifies whether to reset the switch module during
                 the initialization procedure.
@@ -1471,13 +1472,14 @@ class BaseReservation(abc.ABC):
         Args:
             topology: Specifies the switch topology. If this argument is not
                 specified, the default value is "Configured Topology", which you
-                may override by setting ``NISWITCH_TOPOLOGY`` in the
-                configuration file (``.env``).
+                may override by setting ``MEASUREMENTLINK_NISWITCH_TOPOLOGY`` in
+                the configuration file (``.env``).
 
             simulate: Enables or disables simulation of the switch module. If
                 this argument is not specified, the default value is ``False``,
-                which you may override by setting ``NISWITCH_SIMULATE`` in the
-                configuration file (``.env``).
+                which you may override by setting
+                ``MEASUREMENTLINK_NISWITCH_SIMULATE`` in the configuration file
+                (``.env``).
 
             reset_device: Specifies whether to reset the switch module during
                 the initialization procedure.

--- a/tests/unit/_drivers/test_niswitch.py
+++ b/tests/unit/_drivers/test_niswitch.py
@@ -85,7 +85,11 @@ def test___multiple_session_infos___create_niswitch_sessions___sessions_created(
     )
 
 
+# For NI-SWITCH, we set resource_name to "" when simulate is True.
+@pytest.mark.parametrize("simulate,expected_resource_name", [(False, "Dev0"), (True, "")])
 def test___optional_args___create_niswitch_session___optional_args_passed(
+    simulate: bool,
+    expected_resource_name: str,
     session_new: Mock,
     session_management_client: Mock,
 ) -> None:
@@ -97,7 +101,7 @@ def test___optional_args___create_niswitch_session___optional_args_passed(
 
     with reservation.create_niswitch_session(
         topology="2567/Independent",
-        simulate=True,
+        simulate=simulate,
         reset_device=True,
         initialization_behavior=SessionInitializationBehavior.INITIALIZE_SERVER_SESSION,
     ):
@@ -105,9 +109,9 @@ def test___optional_args___create_niswitch_session___optional_args_passed(
 
     session_new.assert_called_once_with(
         niswitch.Session,
-        resource_name="Dev0",
+        resource_name=expected_resource_name,
         topology="2567/Independent",
-        simulate=True,
+        simulate=simulate,
         reset_device=True,
         grpc_options=ANY,
     )
@@ -134,7 +138,7 @@ def test___simulation_configured___create_niswitch_session___simulation_options_
 
     session_new.assert_called_once_with(
         niswitch.Session,
-        resource_name="Dev0",
+        resource_name="",
         topology="2567/Independent",
         simulate=True,
         reset_device=False,


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Avoid `NISWITCH_ERROR_INVALID_RESOURCE_DESCRIPTOR` when setting `simulate=True` for `create_niswitch_session(s)`.

### Why should this Pull Request be merged?

Fixes a bug found while updating examples.

### What testing has been done?

Ran updated unit tests.
Manually tested with updated examples.