### PR TITLE
examples: Run ni-python-styleguide separately for each example

### DIFF
--- a/.github/workflows/check_examples.yml
+++ b/.github/workflows/check_examples.yml
@@ -38,6 +38,15 @@ jobs:
             popd
             echo "::endgroup::"
           done
+      - name: Lint examples
+        run: |
+          for example in examples/*/; do
+            echo "::group::$example"
+            pushd $example
+            poetry run ni-python-styleguide lint
+            popd
+            echo "::endgroup::"
+          done
       - name: Mypy static analysis (examples, Linux)
         run: |
           for example in examples/*/; do

--- a/examples/game_of_life/_helpers.py
+++ b/examples/game_of_life/_helpers.py
@@ -7,7 +7,6 @@ from typing import Any, Callable, List, NamedTuple, Optional, Tuple, TypeVar, Un
 
 import click
 import grpc
-
 import ni_measurementlink_service as nims
 from ni_measurementlink_service import session_management
 from ni_measurementlink_service._internal.stubs.ni.measurementlink.pinmap.v1 import (

--- a/examples/game_of_life/measurement.py
+++ b/examples/game_of_life/measurement.py
@@ -5,9 +5,8 @@ import time
 from typing import Any, Generator, List, Tuple
 
 import click
-from _helpers import configure_logging, verbosity_option
-
 import ni_measurementlink_service as nims
+from _helpers import configure_logging, verbosity_option
 from ni_measurementlink_service._internal.stubs.ni.protobuf.types import xydata_pb2
 
 service_directory = pathlib.Path(__file__).resolve().parent

--- a/examples/game_of_life/pyproject.toml
+++ b/examples/game_of_life/pyproject.toml
@@ -10,6 +10,7 @@ ni-measurementlink-service = {version = "^1.3.0-dev0", allow-prereleases = true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 
 [tool.poetry.group.dev.dependencies]
+ni-python-styleguide = ">=0.4.1"
 mypy = ">=1.0"
 grpc-stubs = "^1.53"
 types-protobuf = "^4.21"

--- a/examples/nidaqmx_analog_input/_helpers.py
+++ b/examples/nidaqmx_analog_input/_helpers.py
@@ -7,7 +7,6 @@ from typing import Any, Callable, List, NamedTuple, Optional, Tuple, TypeVar, Un
 
 import click
 import grpc
-
 import ni_measurementlink_service as nims
 from ni_measurementlink_service import session_management
 from ni_measurementlink_service._internal.stubs.ni.measurementlink.pinmap.v1 import (

--- a/examples/nidaqmx_analog_input/_nidaqmx_helpers.py
+++ b/examples/nidaqmx_analog_input/_nidaqmx_helpers.py
@@ -3,9 +3,8 @@
 from typing import Optional
 
 import grpc
-import nidaqmx
-
 import ni_measurementlink_service as nims
+import nidaqmx
 
 
 def create_task(

--- a/examples/nidaqmx_analog_input/measurement.py
+++ b/examples/nidaqmx_analog_input/measurement.py
@@ -6,6 +6,7 @@ import sys
 from typing import Any, List, Optional, Tuple
 
 import click
+import ni_measurementlink_service as nims
 import nidaqmx
 from _helpers import (
     ServiceOptions,
@@ -18,8 +19,6 @@ from _helpers import (
 )
 from _nidaqmx_helpers import create_task
 from nidaqmx.constants import TaskMode
-
-import ni_measurementlink_service as nims
 
 script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent

--- a/examples/nidaqmx_analog_input/pyproject.toml
+++ b/examples/nidaqmx_analog_input/pyproject.toml
@@ -11,6 +11,7 @@ ni-measurementlink-service = {version = "^1.3.0-dev0", allow-prereleases = true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 
 [tool.poetry.group.dev.dependencies]
+ni-python-styleguide = ">=0.4.1"
 mypy = ">=1.0"
 grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies.

--- a/examples/nidaqmx_analog_input/teststand_fixture.py
+++ b/examples/nidaqmx_analog_input/teststand_fixture.py
@@ -1,11 +1,10 @@
 """Functions to set up and tear down sessions of NI-Scope devices in NI TestStand."""
 from typing import Any
 
+import ni_measurementlink_service as nims
 import nidaqmx
 from _helpers import GrpcChannelPoolHelper, PinMapClient, TestStandSupport
 from _nidaqmx_helpers import create_task
-
-import ni_measurementlink_service as nims
 
 
 def update_pin_map(pin_map_path: str, sequence_context: Any) -> str:

--- a/examples/nidcpower_source_dc_voltage/_helpers.py
+++ b/examples/nidcpower_source_dc_voltage/_helpers.py
@@ -7,7 +7,6 @@ from typing import Any, Callable, List, NamedTuple, Optional, Tuple, TypeVar, Un
 
 import click
 import grpc
-
 import ni_measurementlink_service as nims
 from ni_measurementlink_service import session_management
 from ni_measurementlink_service._internal.stubs.ni.measurementlink.pinmap.v1 import (

--- a/examples/nidcpower_source_dc_voltage/_nidcpower_helpers.py
+++ b/examples/nidcpower_source_dc_voltage/_nidcpower_helpers.py
@@ -3,10 +3,9 @@
 from typing import Any, Dict, Optional
 
 import grpc
+import ni_measurementlink_service as nims
 import nidcpower
 from _constants import USE_SIMULATION
-
-import ni_measurementlink_service as nims
 
 
 def create_session(

--- a/examples/nidcpower_source_dc_voltage/measurement.py
+++ b/examples/nidcpower_source_dc_voltage/measurement.py
@@ -10,6 +10,7 @@ from typing import Any, Iterable, List, Tuple
 import click
 import grpc
 import hightime
+import ni_measurementlink_service as nims
 import nidcpower
 from _constants import USE_SIMULATION
 from _helpers import (
@@ -23,8 +24,6 @@ from _helpers import (
     verbosity_option,
 )
 from _nidcpower_helpers import create_session
-
-import ni_measurementlink_service as nims
 
 NIDCPOWER_WAIT_FOR_EVENT_TIMEOUT_ERROR_CODE = -1074116059
 NIDCPOWER_TIMEOUT_EXCEEDED_ERROR_CODE = -1074097933

--- a/examples/nidcpower_source_dc_voltage/pyproject.toml
+++ b/examples/nidcpower_source_dc_voltage/pyproject.toml
@@ -12,6 +12,7 @@ click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pal
 grpcio = "*"
 
 [tool.poetry.group.dev.dependencies]
+ni-python-styleguide = ">=0.4.1"
 mypy = ">=1.0"
 grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies.

--- a/examples/nidcpower_source_dc_voltage/teststand_fixture.py
+++ b/examples/nidcpower_source_dc_voltage/teststand_fixture.py
@@ -1,11 +1,10 @@
 """Functions to set up and tear down sessions of NI-DCPower devices in NI TestStand."""
 from typing import Any
 
+import ni_measurementlink_service as nims
 import nidcpower
 from _helpers import GrpcChannelPoolHelper, PinMapClient, TestStandSupport
 from _nidcpower_helpers import create_session
-
-import ni_measurementlink_service as nims
 
 
 def update_pin_map(pin_map_path: str, sequence_context: Any) -> str:

--- a/examples/nidigital_spi/_helpers.py
+++ b/examples/nidigital_spi/_helpers.py
@@ -7,7 +7,6 @@ from typing import Any, Callable, List, NamedTuple, Optional, Tuple, TypeVar, Un
 
 import click
 import grpc
-
 import ni_measurementlink_service as nims
 from ni_measurementlink_service import session_management
 from ni_measurementlink_service._internal.stubs.ni.measurementlink.pinmap.v1 import (

--- a/examples/nidigital_spi/_nidigital_helpers.py
+++ b/examples/nidigital_spi/_nidigital_helpers.py
@@ -3,10 +3,9 @@
 from typing import Any, Dict, Optional
 
 import grpc
+import ni_measurementlink_service as nims
 import nidigital
 from _constants import USE_SIMULATION
-
-import ni_measurementlink_service as nims
 
 
 def create_session(

--- a/examples/nidigital_spi/measurement.py
+++ b/examples/nidigital_spi/measurement.py
@@ -6,6 +6,7 @@ import sys
 from typing import Any, Iterable, Tuple, Union
 
 import click
+import ni_measurementlink_service as nims
 import nidigital
 from _constants import USE_SIMULATION
 from _helpers import (
@@ -19,8 +20,6 @@ from _helpers import (
     verbosity_option,
 )
 from _nidigital_helpers import create_session
-
-import ni_measurementlink_service as nims
 
 script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent

--- a/examples/nidigital_spi/pyproject.toml
+++ b/examples/nidigital_spi/pyproject.toml
@@ -12,6 +12,7 @@ click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pal
 grpcio = "*"
 
 [tool.poetry.group.dev.dependencies]
+ni-python-styleguide = ">=0.4.1"
 mypy = ">=1.0"
 grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies.

--- a/examples/nidigital_spi/teststand_fixture.py
+++ b/examples/nidigital_spi/teststand_fixture.py
@@ -1,11 +1,10 @@
 """Functions to set up and tear down sessions of NI Digital Pattern instruments in NI TestStand."""
 from typing import Any, Iterable
 
+import ni_measurementlink_service as nims
 import nidigital
 from _helpers import GrpcChannelPoolHelper, PinMapClient, TestStandSupport
 from _nidigital_helpers import create_session
-
-import ni_measurementlink_service as nims
 from ni_measurementlink_service.session_management import (
     INSTRUMENT_TYPE_NI_DIGITAL_PATTERN,
 )

--- a/examples/nidmm_measurement/_helpers.py
+++ b/examples/nidmm_measurement/_helpers.py
@@ -7,7 +7,6 @@ from typing import Any, Callable, List, NamedTuple, Optional, Tuple, TypeVar, Un
 
 import click
 import grpc
-
 import ni_measurementlink_service as nims
 from ni_measurementlink_service import session_management
 from ni_measurementlink_service._internal.stubs.ni.measurementlink.pinmap.v1 import (

--- a/examples/nidmm_measurement/_nidmm_helpers.py
+++ b/examples/nidmm_measurement/_nidmm_helpers.py
@@ -3,10 +3,9 @@
 from typing import Any, Dict, Optional
 
 import grpc
+import ni_measurementlink_service as nims
 import nidmm
 from _constants import USE_SIMULATION
-
-import ni_measurementlink_service as nims
 
 
 def create_session(

--- a/examples/nidmm_measurement/measurement.py
+++ b/examples/nidmm_measurement/measurement.py
@@ -8,6 +8,7 @@ from enum import Enum
 from typing import Any, Tuple
 
 import click
+import ni_measurementlink_service as nims
 import nidmm
 from _constants import USE_SIMULATION
 from _helpers import (
@@ -21,8 +22,6 @@ from _helpers import (
     verbosity_option,
 )
 from _nidmm_helpers import create_session
-
-import ni_measurementlink_service as nims
 
 script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent

--- a/examples/nidmm_measurement/pyproject.toml
+++ b/examples/nidmm_measurement/pyproject.toml
@@ -12,6 +12,7 @@ click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pal
 grpcio = "*"
 
 [tool.poetry.group.dev.dependencies]
+ni-python-styleguide = ">=0.4.1"
 mypy = ">=1.0"
 grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies.

--- a/examples/nidmm_measurement/teststand_fixture.py
+++ b/examples/nidmm_measurement/teststand_fixture.py
@@ -1,11 +1,10 @@
 """Functions to set up and tear down sessions of NI-DMM devices in NI TestStand."""
 from typing import Any
 
+import ni_measurementlink_service as nims
 import nidmm
 from _helpers import GrpcChannelPoolHelper, PinMapClient, TestStandSupport
 from _nidmm_helpers import create_session
-
-import ni_measurementlink_service as nims
 
 
 def update_pin_map(pin_map_path: str, sequence_context: Any) -> None:

--- a/examples/nifgen_standard_function/_helpers.py
+++ b/examples/nifgen_standard_function/_helpers.py
@@ -7,7 +7,6 @@ from typing import Any, Callable, List, NamedTuple, Optional, Tuple, TypeVar, Un
 
 import click
 import grpc
-
 import ni_measurementlink_service as nims
 from ni_measurementlink_service import session_management
 from ni_measurementlink_service._internal.stubs.ni.measurementlink.pinmap.v1 import (

--- a/examples/nifgen_standard_function/_nifgen_helpers.py
+++ b/examples/nifgen_standard_function/_nifgen_helpers.py
@@ -3,10 +3,9 @@
 from typing import Any, Dict, Optional
 
 import grpc
+import ni_measurementlink_service as nims
 import nifgen
 from _constants import USE_SIMULATION
-
-import ni_measurementlink_service as nims
 
 
 def create_session(

--- a/examples/nifgen_standard_function/measurement.py
+++ b/examples/nifgen_standard_function/measurement.py
@@ -12,6 +12,7 @@ from typing import Any, Tuple
 import click
 import grpc
 import hightime
+import ni_measurementlink_service as nims
 import nifgen
 from _constants import USE_SIMULATION
 from _helpers import (
@@ -25,8 +26,6 @@ from _helpers import (
     verbosity_option,
 )
 from _nifgen_helpers import create_session
-
-import ni_measurementlink_service as nims
 
 NIFGEN_OPERATION_TIMED_OUT_ERROR_CODE = -1074098044
 NIFGEN_MAX_TIME_EXCEEDED_ERROR_CODE = -1074118637

--- a/examples/nifgen_standard_function/pyproject.toml
+++ b/examples/nifgen_standard_function/pyproject.toml
@@ -12,6 +12,7 @@ click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pal
 grpcio = "*"
 
 [tool.poetry.group.dev.dependencies]
+ni-python-styleguide = ">=0.4.1"
 mypy = ">=1.0"
 grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies.

--- a/examples/nifgen_standard_function/teststand_fixture.py
+++ b/examples/nifgen_standard_function/teststand_fixture.py
@@ -1,11 +1,10 @@
 """Functions to set up and tear down sessions of NI-FGEN devices in NI TestStand."""
 from typing import Any
 
+import ni_measurementlink_service as nims
 import nifgen
 from _helpers import GrpcChannelPoolHelper, PinMapClient, TestStandSupport
 from _nifgen_helpers import create_session
-
-import ni_measurementlink_service as nims
 
 
 def update_pin_map(pin_map_path: str, sequence_context: Any) -> None:

--- a/examples/niscope_acquire_waveform/_helpers.py
+++ b/examples/niscope_acquire_waveform/_helpers.py
@@ -7,7 +7,6 @@ from typing import Any, Callable, List, NamedTuple, Optional, Tuple, TypeVar, Un
 
 import click
 import grpc
-
 import ni_measurementlink_service as nims
 from ni_measurementlink_service import session_management
 from ni_measurementlink_service._internal.stubs.ni.measurementlink.pinmap.v1 import (

--- a/examples/niscope_acquire_waveform/_niscope_helpers.py
+++ b/examples/niscope_acquire_waveform/_niscope_helpers.py
@@ -3,10 +3,9 @@
 from typing import Any, Dict, Optional
 
 import grpc
+import ni_measurementlink_service as nims
 import niscope
 from _constants import USE_SIMULATION
-
-import ni_measurementlink_service as nims
 
 
 def create_session(

--- a/examples/niscope_acquire_waveform/measurement.py
+++ b/examples/niscope_acquire_waveform/measurement.py
@@ -9,6 +9,7 @@ from typing import Any, List, Tuple
 
 import click
 import grpc
+import ni_measurementlink_service as nims
 import niscope
 from _constants import USE_SIMULATION
 from _helpers import (
@@ -22,8 +23,6 @@ from _helpers import (
     verbosity_option,
 )
 from _niscope_helpers import create_session
-
-import ni_measurementlink_service as nims
 
 script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent

--- a/examples/niscope_acquire_waveform/pyproject.toml
+++ b/examples/niscope_acquire_waveform/pyproject.toml
@@ -12,6 +12,7 @@ click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pal
 grpcio = "*"
 
 [tool.poetry.group.dev.dependencies]
+ni-python-styleguide = ">=0.4.1"
 mypy = ">=1.0"
 grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies.

--- a/examples/niscope_acquire_waveform/teststand_fixture.py
+++ b/examples/niscope_acquire_waveform/teststand_fixture.py
@@ -1,11 +1,10 @@
 """Functions to set up and tear down sessions of NI-Scope devices in NI TestStand."""
 from typing import Any
 
+import ni_measurementlink_service as nims
 import niscope
 from _helpers import GrpcChannelPoolHelper, PinMapClient, TestStandSupport
 from _niscope_helpers import create_session
-
-import ni_measurementlink_service as nims
 
 
 def update_pin_map(pin_map_path: str, sequence_context: Any) -> None:

--- a/examples/niswitch_control_relays/_helpers.py
+++ b/examples/niswitch_control_relays/_helpers.py
@@ -7,7 +7,6 @@ from typing import Any, Callable, List, NamedTuple, Optional, Tuple, TypeVar, Un
 
 import click
 import grpc
-
 import ni_measurementlink_service as nims
 from ni_measurementlink_service import session_management
 from ni_measurementlink_service._internal.stubs.ni.measurementlink.pinmap.v1 import (

--- a/examples/niswitch_control_relays/_niswitch_helpers.py
+++ b/examples/niswitch_control_relays/_niswitch_helpers.py
@@ -3,10 +3,9 @@
 from typing import Any, Dict, Optional
 
 import grpc
+import ni_measurementlink_service as nims
 import niswitch
 from _constants import USE_SIMULATION
-
-import ni_measurementlink_service as nims
 
 
 def create_session(

--- a/examples/niswitch_control_relays/measurement.py
+++ b/examples/niswitch_control_relays/measurement.py
@@ -7,6 +7,7 @@ import sys
 from typing import Any, Tuple
 
 import click
+import ni_measurementlink_service as nims
 import niswitch
 from _constants import USE_SIMULATION
 from _helpers import (
@@ -20,8 +21,6 @@ from _helpers import (
     verbosity_option,
 )
 from _niswitch_helpers import create_session
-
-import ni_measurementlink_service as nims
 
 script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent

--- a/examples/niswitch_control_relays/pyproject.toml
+++ b/examples/niswitch_control_relays/pyproject.toml
@@ -12,6 +12,7 @@ click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pal
 grpcio = "*"
 
 [tool.poetry.group.dev.dependencies]
+ni-python-styleguide = ">=0.4.1"
 mypy = ">=1.0"
 grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies.

--- a/examples/niswitch_control_relays/teststand_fixture.py
+++ b/examples/niswitch_control_relays/teststand_fixture.py
@@ -1,11 +1,10 @@
 """Functions to set up and tear down sessions of NI-Switch devices in NI TestStand."""
 from typing import Any
 
+import ni_measurementlink_service as nims
 import niswitch
 from _helpers import GrpcChannelPoolHelper, PinMapClient, TestStandSupport
 from _niswitch_helpers import create_session
-
-import ni_measurementlink_service as nims
 
 
 def update_pin_map(pin_map_path: str, sequence_context: Any) -> None:

--- a/examples/nivisa_dmm_measurement/_helpers.py
+++ b/examples/nivisa_dmm_measurement/_helpers.py
@@ -7,7 +7,6 @@ from typing import Any, Callable, List, NamedTuple, Optional, Tuple, TypeVar, Un
 
 import click
 import grpc
-
 import ni_measurementlink_service as nims
 from ni_measurementlink_service import session_management
 from ni_measurementlink_service._internal.stubs.ni.measurementlink.pinmap.v1 import (

--- a/examples/nivisa_dmm_measurement/measurement.py
+++ b/examples/nivisa_dmm_measurement/measurement.py
@@ -7,6 +7,7 @@ from enum import Enum
 from typing import Any, Tuple
 
 import click
+import ni_measurementlink_service as nims
 import pyvisa.resources
 from _constants import USE_SIMULATION
 from _helpers import (
@@ -25,8 +26,6 @@ from _visa_helpers import (
     log_instrument_id,
     reset_instrument,
 )
-
-import ni_measurementlink_service as nims
 
 script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent

--- a/examples/nivisa_dmm_measurement/pyproject.toml
+++ b/examples/nivisa_dmm_measurement/pyproject.toml
@@ -13,6 +13,7 @@ click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pal
 grpcio = "*"
 
 [tool.poetry.group.dev.dependencies]
+ni-python-styleguide = ">=0.4.1"
 mypy = ">=1.0"
 grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies.

--- a/examples/nivisa_dmm_measurement/teststand_fixture.py
+++ b/examples/nivisa_dmm_measurement/teststand_fixture.py
@@ -1,6 +1,7 @@
 """Functions to set up and tear down NI-VISA DMM sessions in NI TestStand."""
 from typing import Any
 
+import ni_measurementlink_service as nims
 import pyvisa.resources
 from _constants import USE_SIMULATION
 from _helpers import GrpcChannelPoolHelper, PinMapClient, TestStandSupport
@@ -11,8 +12,6 @@ from _visa_helpers import (
     log_instrument_id,
     reset_instrument,
 )
-
-import ni_measurementlink_service as nims
 
 
 def update_pin_map(pin_map_path: str, sequence_context: Any) -> None:

--- a/examples/output_voltage_measurement/_helpers.py
+++ b/examples/output_voltage_measurement/_helpers.py
@@ -7,7 +7,6 @@ from typing import Any, Callable, List, NamedTuple, Optional, Tuple, TypeVar, Un
 
 import click
 import grpc
-
 import ni_measurementlink_service as nims
 from ni_measurementlink_service import session_management
 from ni_measurementlink_service._internal.stubs.ni.measurementlink.pinmap.v1 import (

--- a/examples/output_voltage_measurement/_nidcpower_helpers.py
+++ b/examples/output_voltage_measurement/_nidcpower_helpers.py
@@ -3,9 +3,8 @@
 from typing import Any, Dict, Optional
 
 import grpc
-import nidcpower
-
 import ni_measurementlink_service as nims
+import nidcpower
 
 
 def create_session(

--- a/examples/output_voltage_measurement/measurement.py
+++ b/examples/output_voltage_measurement/measurement.py
@@ -12,6 +12,7 @@ import _visa_helpers
 import click
 import grpc
 import hightime
+import ni_measurementlink_service as nims
 import nidcpower
 import nidcpower.session
 import pyvisa
@@ -28,8 +29,6 @@ from _helpers import (
     verbosity_option,
 )
 from _visa_helpers import check_instrument_error, log_instrument_id, reset_instrument
-
-import ni_measurementlink_service as nims
 from ni_measurementlink_service.session_management import SessionInformation
 
 NIDCPOWER_WAIT_FOR_EVENT_TIMEOUT_ERROR_CODE = -1074116059

--- a/examples/output_voltage_measurement/pyproject.toml
+++ b/examples/output_voltage_measurement/pyproject.toml
@@ -14,6 +14,7 @@ click = ">=7.1.2"
 grpcio = "*"
 
 [tool.poetry.group.dev.dependencies]
+ni-python-styleguide = ">=0.4.1"
 mypy = ">=1.0"
 grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies.

--- a/examples/output_voltage_measurement/teststand_nidcpower.py
+++ b/examples/output_voltage_measurement/teststand_nidcpower.py
@@ -1,12 +1,11 @@
 """Functions to set up and tear down sessions of NI-DCPower devices in NI TestStand."""
 from typing import Any
 
+import ni_measurementlink_service as nims
 import nidcpower
 from _constants import USE_SIMULATION
 from _helpers import GrpcChannelPoolHelper, TestStandSupport
 from _nidcpower_helpers import create_session
-
-import ni_measurementlink_service as nims
 
 
 def create_nidcpower_sessions(sequence_context: Any) -> None:

--- a/examples/output_voltage_measurement/teststand_nivisa_dmm.py
+++ b/examples/output_voltage_measurement/teststand_nivisa_dmm.py
@@ -1,6 +1,7 @@
 """Functions to set up and tear down NI-VISA DMM sessions in NI TestStand."""
 from typing import Any
 
+import ni_measurementlink_service as nims
 import pyvisa.resources
 from _constants import USE_SIMULATION
 from _helpers import GrpcChannelPoolHelper, TestStandSupport
@@ -11,8 +12,6 @@ from _visa_helpers import (
     log_instrument_id,
     reset_instrument,
 )
-
-import ni_measurementlink_service as nims
 
 
 def create_nivisa_dmm_sessions(sequence_context: Any) -> None:

--- a/examples/sample_measurement/_helpers.py
+++ b/examples/sample_measurement/_helpers.py
@@ -7,7 +7,6 @@ from typing import Any, Callable, List, NamedTuple, Optional, Tuple, TypeVar, Un
 
 import click
 import grpc
-
 import ni_measurementlink_service as nims
 from ni_measurementlink_service import session_management
 from ni_measurementlink_service._internal.stubs.ni.measurementlink.pinmap.v1 import (

--- a/examples/sample_measurement/measurement.py
+++ b/examples/sample_measurement/measurement.py
@@ -6,14 +6,13 @@ from enum import Enum
 from typing import Iterable, Tuple
 
 import click
+import ni_measurementlink_service as nims
 from _helpers import configure_logging, verbosity_option
 
 try:
     from _stubs import color_pb2
 except ImportError:
     from examples.sample_measurement._stubs import color_pb2  # type: ignore
-
-import ni_measurementlink_service as nims
 
 script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent

--- a/examples/sample_measurement/pyproject.toml
+++ b/examples/sample_measurement/pyproject.toml
@@ -10,6 +10,7 @@ ni-measurementlink-service = {version = "^1.3.0-dev0", allow-prereleases = true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 
 [tool.poetry.group.dev.dependencies]
+ni-python-styleguide = ">=0.4.1"
 mypy = ">=1.0"
 grpc-stubs = "^1.53"
 types-protobuf = "^4.21"
@@ -22,3 +23,6 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
 disallow_untyped_defs = true
+
+[tool.ni-python-styleguide]
+extend_exclude = '*_pb2_grpc.py,*_pb2_grpc.pyi,*_pb2.py,*_pb2.pyi'

--- a/examples/sample_streaming_measurement/_helpers.py
+++ b/examples/sample_streaming_measurement/_helpers.py
@@ -7,7 +7,6 @@ from typing import Any, Callable, List, NamedTuple, Optional, Tuple, TypeVar, Un
 
 import click
 import grpc
-
 import ni_measurementlink_service as nims
 from ni_measurementlink_service import session_management
 from ni_measurementlink_service._internal.stubs.ni.measurementlink.pinmap.v1 import (

--- a/examples/sample_streaming_measurement/measurement.py
+++ b/examples/sample_streaming_measurement/measurement.py
@@ -8,9 +8,8 @@ from typing import Generator, List, Tuple
 
 import click
 import grpc
-from _helpers import configure_logging, verbosity_option
-
 import ni_measurementlink_service as nims
+from _helpers import configure_logging, verbosity_option
 
 script_or_exe = sys.executable if getattr(sys, "frozen", False) else __file__
 service_directory = pathlib.Path(script_or_exe).resolve().parent

--- a/examples/sample_streaming_measurement/pyproject.toml
+++ b/examples/sample_streaming_measurement/pyproject.toml
@@ -10,6 +10,7 @@ ni-measurementlink-service = {version = "^1.3.0-dev0", allow-prereleases = true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 
 [tool.poetry.group.dev.dependencies]
+ni-python-styleguide = ">=0.4.1"
 mypy = ">=1.0"
 grpc-stubs = "^1.49.1"
 # Uncomment to use prerelease dependencies.

--- a/examples/ui_progress_updates/_helpers.py
+++ b/examples/ui_progress_updates/_helpers.py
@@ -7,7 +7,6 @@ from typing import Any, Callable, List, NamedTuple, Optional, Tuple, TypeVar, Un
 
 import click
 import grpc
-
 import ni_measurementlink_service as nims
 from ni_measurementlink_service import session_management
 from ni_measurementlink_service._internal.stubs.ni.measurementlink.pinmap.v1 import (

--- a/examples/ui_progress_updates/measurement.py
+++ b/examples/ui_progress_updates/measurement.py
@@ -9,9 +9,8 @@ from typing import Generator, List, Tuple
 
 import click
 import grpc
-from _helpers import configure_logging, verbosity_option
-
 import ni_measurementlink_service as nims
+from _helpers import configure_logging, verbosity_option
 
 RANDOM_NUMBERS_PER_SECOND = 100.0
 RANDOM_NUMBER_RANGE = 10.0

--- a/examples/ui_progress_updates/pyproject.toml
+++ b/examples/ui_progress_updates/pyproject.toml
@@ -10,6 +10,7 @@ ni-measurementlink-service = {version = "^1.3.0-dev0", allow-prereleases = true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 
 [tool.poetry.group.dev.dependencies]
+ni-python-styleguide = ">=0.4.1"
 mypy = ">=1.0"
 grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [tool.black]
-extend_exclude = '_pb2(_grpc)?\.(py|pyi)$|ni_measurementlink_generator/'
+extend_exclude = '_pb2(_grpc)?\.(py|pyi)$|ni_measurementlink_generator/|examples/'
 line-length = 100
 
 [tool.ni-python-styleguide]
-extend_exclude = '*_pb2_grpc.py,*_pb2_grpc.pyi,*_pb2.py,*_pb2.pyi,ni_measurementlink_generator/'
+extend_exclude = '*_pb2_grpc.py,*_pb2_grpc.pyi,*_pb2.py,*_pb2.pyi,ni_measurementlink_generator/,examples/'
 
 [tool.poetry]
 name = "ni_measurementlink_service"


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add a dependency on `ni-python-styleguide` to each example. Running `ni-python-styleguide` from the main project treats the examples as part of the main project, which affects sorting of imports.

Update the main project's `ni-python-styleguide` and `black` configurations to exclude the examples.

Update `sample_measurement`'s `ni-python-styleguide` configuration to exclude Protobuf codegen.

Update the `check_examples` workflow to lint the examples separately.

### Why should this Pull Request be merged?

Fixes https://github.com/ni/measurementlink-python/issues/374

### What testing has been done?

PR build