### PR TITLE
Add GitHub workflow to run RenovateBot

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "branchPrefix": "users/renovate/",
+  "username": "renovate-release",
+  "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
+  "onboarding": true,
+  "platform": "github",
+  "forkProcessing": "disabled",
+  "repositories": ["ni/measurementlink-python"],
+  "packageRules": [
+    {
+      "description": "lockFileMaintenance",
+      "matchUpdateTypes": [
+        "pin",
+        "digest",
+        "patch",
+        "minor",
+        "major",
+        "lockFileMaintenance"
+      ],
+      "dependencyDashboardApproval": false,
+      "minimumReleaseAge": null
+    }
+  ]
+}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,22 @@
+name: Renovate
+
+on:
+  schedule:
+    # Run hourly
+    - cron: '0 * * * *'
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  renovate:
+    name: Renovate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.6.0
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v39.0.5
+        with:
+          configurationFile: .github/renovate.json
+          renovate-version: 37.18.4
+          token: ${{ secrets.RENOVATE_TOKEN }}


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add a GitHub workflow that runs RenovateBot, which is an application that updates dependency lock files for NPM, Poetry, and other development tools.

The docs recommend running it hourly when using the GitHub action: https://docs.renovatebot.com/getting-started/running/#hosting-renovate

There are other ways to host RenovateBot (AzDO pipelines, mend.io hosted application, etc.), and we may switch later if it makes sense.

### Why should this Pull Request be merged?

Fixes https://github.com/ni/measurementlink-python/issues/337

Dependabot keeps complaining about one of our dependencies, but using Dependabot to update `poetry.lock` would upgrade the lock file format, which we don't want to do yet.

### What testing has been done?

Manually tested an earlier version of this config by adding `on: pull_request:`. (This seems to be the easiest way to run a new GitHub workflow before it's merged into main.)