### PR TITLE
[RFC] examples: Update one of the TestStand code module to use the new session management API

### DIFF
--- a/examples/nidcpower_source_dc_voltage/teststand_fixture.py
+++ b/examples/nidcpower_source_dc_voltage/teststand_fixture.py
@@ -2,9 +2,14 @@
 from typing import Any
 
 import ni_measurementlink_service as nims
-import nidcpower
 from _helpers import GrpcChannelPoolHelper, PinMapClient, TestStandSupport
-from _nidcpower_helpers import create_session
+from ni_measurementlink_service.discovery import DiscoveryClient
+from ni_measurementlink_service.session_management import (
+    INSTRUMENT_TYPE_NI_DCPOWER,
+    PinMapContext,
+    SessionInitializationBehavior,
+    SessionManagementClient,
+)
 
 
 def update_pin_map(pin_map_path: str, sequence_context: Any) -> str:
@@ -39,48 +44,47 @@ def create_nidcpower_sessions(sequence_context: Any) -> None:
             (Dynamically typed.)
     """
     with GrpcChannelPoolHelper() as grpc_channel_pool:
-        session_management_client = nims.session_management.Client(
-            grpc_channel=grpc_channel_pool.session_management_channel
-        )
-
         teststand_support = TestStandSupport(sequence_context)
         pin_map_id = teststand_support.get_active_pin_map_id()
-        pin_map_context = nims.session_management.PinMapContext(pin_map_id=pin_map_id, sites=None)
-        grpc_device_channel = grpc_channel_pool.get_grpc_device_channel(
-            nidcpower.GRPC_SERVICE_INTERFACE_NAME
+        pin_map_context = PinMapContext(pin_map_id=pin_map_id, sites=None)
+
+        discovery_client = DiscoveryClient(grpc_channel_pool=grpc_channel_pool)
+        session_management_client = SessionManagementClient(
+            discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool
         )
         with session_management_client.reserve_sessions(
-            context=pin_map_context,
-            instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_DCPOWER,
+            pin_map_context, instrument_type_id=INSTRUMENT_TYPE_NI_DCPOWER
         ) as reservation:
-            for session_info in reservation.session_info:
-                # Leave session open
-                _ = create_session(
-                    session_info,
-                    grpc_device_channel,
-                    initialization_behavior=nidcpower.SessionInitializationBehavior.INITIALIZE_SERVER_SESSION,
-                )
+            # Initialize new sessions on the server, but do not close them.
+            # (Deliberately leak them.)
+            context_manager = reservation.create_nidcpower_sessions(
+                initialization_behavior=SessionInitializationBehavior.INITIALIZE_SERVER_SESSION
+            )
+            _ = context_manager.__enter__()
+
             session_management_client.register_sessions(reservation.session_info)
 
 
 def destroy_nidcpower_sessions() -> None:
     """Destroy and unregister all NI-DCPower sessions."""
     with GrpcChannelPoolHelper() as grpc_channel_pool:
-        session_management_client = nims.session_management.Client(
-            grpc_channel=grpc_channel_pool.session_management_channel
-        )
-        grpc_device_channel = grpc_channel_pool.get_grpc_device_channel(
-            nidcpower.GRPC_SERVICE_INTERFACE_NAME
+        discovery_client = DiscoveryClient(grpc_channel_pool=grpc_channel_pool)
+        session_management_client = SessionManagementClient(
+            discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool
         )
         with session_management_client.reserve_all_registered_sessions(
-            instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_DCPOWER,
+            instrument_type_id=INSTRUMENT_TYPE_NI_DCPOWER
         ) as reservation:
+            # If there are no registered sessions, there is nothing to clean up.
+            if not reservation.session_info:
+                return
+            
             session_management_client.unregister_sessions(reservation.session_info)
 
-            for session_info in reservation.session_info:
-                session = create_session(
-                    session_info,
-                    grpc_device_channel,
-                    initialization_behavior=nidcpower.SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION,
-                )
-                session.close()
+            # Attach to the sessions on the server and explicitly close them.
+            with reservation.create_nidcpower_sessions(
+                initialization_behavior=SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION
+            ) as session_infos:
+                for session_info in session_infos:
+                    session_info.session.close()
+                


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update one of the TestStand code modules to use the new session management API.

### Why should this Pull Request be merged?

Uses same session creation code as for measurements, with simulation via `.env` file.

Allows deleting more example-specific "helpers" code.

### What testing has been done?

Manually tested with TestStand 2021 SP1.