### PR TITLE
GitHub workflow: Stop using deprecated set-output command

### DIFF
--- a/.github/workflows/Publish_NIMS.yml
+++ b/.github/workflows/Publish_NIMS.yml
@@ -3,6 +3,7 @@ name:  Update docs and Publish NIMS
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 concurrency: publish_to_pypi
 

--- a/.github/workflows/Publish_NIMS.yml
+++ b/.github/workflows/Publish_NIMS.yml
@@ -43,7 +43,7 @@ jobs:
       # If the tag is 0.1.0, this will set the version of NIMS package to 0.1.0
       - name: Store version from Tag
         id: vars
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+        run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
       - name: Update NIMS package version based on tag name.
         run: |


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

`Publish_NIMS.yml`:
- Append variables to `$GITHUB_OUTPUT` instead of using the deprecated `set-output` command.
- Add a `workflow_dispatch` trigger for testing.

### Why should this Pull Request be merged?

Fix this warning:

> Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

### What testing has been done?

None. (The `workflow_dispatch` trigger doesn't work until it's committed to main.)