### PR TITLE
service: Update session info property to return created session(s)

### DIFF
--- a/examples/nidaqmx_analog_input/measurement.py
+++ b/examples/nidaqmx_analog_input/measurement.py
@@ -52,8 +52,8 @@ def measure(pin_name: str, sample_rate: float, number_of_samples: int) -> Tuple[
             measurement_service.context.add_cancel_callback(cancel_callback)
 
             # If we created a new DAQmx task, we must also add channels to it.
-            if not reservation.session_info.session_exists:
-                task.ai_channels.add_ai_voltage_chan(reservation.session_info.channel_list)
+            if not session_info.session_exists:
+                task.ai_channels.add_ai_voltage_chan(session_info.channel_list)
 
             task.timing.cfg_samp_clk_timing(
                 rate=sample_rate,

--- a/examples/nidigital_spi/measurement.py
+++ b/examples/nidigital_spi/measurement.py
@@ -55,7 +55,7 @@ def measure(
             selected_sites_string = ",".join(f"site{i}" for i in pin_map_context.sites or [])
             selected_sites = session.sites[selected_sites_string]
 
-            if not reservation.session_info.session_exists:
+            if not session_info.session_exists:
                 # When running the measurement from TestStand, teststand_fixture.py should have
                 # already loaded the pin map, specifications, levels, timing, and patterns.
                 session.load_pin_map(pin_map_context.pin_map_id)

--- a/ni_measurementlink_service/session_management/_types.py
+++ b/ni_measurementlink_service/session_management/_types.py
@@ -143,6 +143,8 @@ class SessionInformation(NamedTuple):
             )
 
     def _with_session(self, session: object) -> SessionInformation:
+        if self.session is session:
+            return self
         return self._replace(session=session)
 
     @classmethod
@@ -247,6 +249,8 @@ class Connection(NamedTuple):
         self.session_info._check_runtime_type(session_type)
 
     def _with_session(self, session: object) -> Connection:
+        if self.session is session:
+            return self
         return self._replace(session_info=self.session_info._with_session(session))
 
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update the `reservation.session_info` property to include the created session object(s).

In the `SessionInformation._with_session()` and `Connection._with_session()` methods, return the existing instance if the session didn't change. Named tuples are immutable, so there is no benefit in always creating a new instance.

Remove unnecessary calls to `reservation.session_info` from a couple of examples.

### Why should this Pull Request be merged?

Principle of least surprise: `SessionInformation`'s `session` field should reflect session creation.

### What testing has been done?

Ran all tests.
Manually tested updated examples.