### PR TITLE
renovate: Minimize config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,26 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
   "branchPrefix": "users/renovate/",
-  "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
-  "onboarding": true,
-  "platform": "github",
-  "forkProcessing": "disabled",
-  "repositories": ["ni/measurementlink-python"],
-  "packageRules": [
-    {
-      "description": "lockFileMaintenance",
-      "matchUpdateTypes": [
-        "pin",
-        "digest",
-        "patch",
-        "minor",
-        "major",
-        "lockFileMaintenance"
-      ],
-      "dependencyDashboardApproval": false,
-      "minimumReleaseAge": null
-    }
-  ],
-  "lockFileMaintenance": { "enabled": true }
+  "extends": ["config:recommended", ":maintainLockFilesWeekly"]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
   "branchPrefix": "users/renovate/",
   "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
   "onboarding": true,


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Use `config:recommended` preset. This should enable the "dependency dashboard", which is a special GitHub issue that shows the Renovate status and allows us to control it. In particular, this allows us to bypass the schedule and request that Renovate post PRs immediately, which I cannot seem to do with the mend.io developer dashboard.
- Replace `lockFileMaintenance` setting with the `:maintainLockFilesWeekly` preset. (We can change to `:maintainLockFilesMonthly` or `:maintainLockFilesDisabled` if weekly doesn't work out.)
- Remove `onboarding`, `platform`, and `repositories` because these settings are for self-hosted Renovate.
- Remove `forkProcessing` because the default behavior sounds appropriate.
- Remove `dependencyDashboardApproval`, `minimumReleaseAge`, and `gitAuthor` because I think these match the defaults.

### Why should this Pull Request be merged?

Enable "dependency dashboard".

Further clean up Renovate config.

### What testing has been done?

None (hence the additional PR)