### PR TITLE
service: Rename create_session(s) to initialize_session(s)

### DIFF
--- a/examples/nidcpower_source_dc_voltage/measurement.py
+++ b/examples/nidcpower_source_dc_voltage/measurement.py
@@ -78,7 +78,7 @@ def measure(
     measurement_service.context.add_cancel_callback(cancellation_event.set)
 
     with measurement_service.context.reserve_session(pin_names) as reservation:
-        with reservation.create_nidcpower_session() as session_info:
+        with reservation.initialize_nidcpower_session() as session_info:
             # Use connections to map pin names to channel names. This sets the
             # channel order based on the pin order and allows mapping the
             # resulting measurements back to the corresponding pins and sites.

--- a/examples/nidigital_spi/measurement.py
+++ b/examples/nidigital_spi/measurement.py
@@ -49,7 +49,7 @@ def measure(
     logging.info("Starting test: pin_names=%s", pin_names)
 
     with measurement_service.context.reserve_session(pin_names) as reservation:
-        with reservation.create_nidigital_session() as session_info:
+        with reservation.initialize_nidigital_session() as session_info:
             session = session_info.session
             pin_map_context = measurement_service.context.pin_map_context
             selected_sites_string = ",".join(f"site{i}" for i in pin_map_context.sites or [])

--- a/examples/nidmm_measurement/measurement.py
+++ b/examples/nidmm_measurement/measurement.py
@@ -76,7 +76,7 @@ def measure(
     nidmm_function = nidmm.Function(measurement_type.value or Function.DC_VOLTS.value)
 
     with measurement_service.context.reserve_session(pin_name) as reservation:
-        with reservation.create_nidmm_session() as session_info:
+        with reservation.initialize_nidmm_session() as session_info:
             session = session_info.session
             session.configure_measurement_digits(nidmm_function, range, resolution_digits)
             measured_value = session.read()

--- a/examples/nifgen_standard_function/measurement.py
+++ b/examples/nifgen_standard_function/measurement.py
@@ -83,7 +83,7 @@ def measure(
     nifgen_waveform = nifgen.Waveform(waveform_type.value or Waveform.SINE.value)
 
     with measurement_service.context.reserve_sessions(pin_name) as reservation:
-        with reservation.create_nifgen_sessions() as session_infos:
+        with reservation.initialize_nifgen_sessions() as session_infos:
             for session_info in session_infos:
                 # Output mode must be the same for all channels in the session.
                 session_info.session.output_mode = nifgen.OutputMode.FUNC

--- a/examples/niscope_acquire_waveform/measurement.py
+++ b/examples/niscope_acquire_waveform/measurement.py
@@ -91,7 +91,7 @@ def measure(
     measurement_service.context.add_cancel_callback(cancellation_event.set)
 
     with measurement_service.context.reserve_session(pin_names) as reservation:
-        with reservation.create_niscope_session() as session_info:
+        with reservation.initialize_niscope_session() as session_info:
             # Use connections to map pin names to channel names. This sets the
             # channel order based on the pin order and allows mapping the
             # resulting measurements back to the corresponding pins and sites.

--- a/examples/niswitch_control_relays/measurement.py
+++ b/examples/niswitch_control_relays/measurement.py
@@ -34,7 +34,7 @@ def measure(
     )
 
     with measurement_service.context.reserve_sessions(relay_names) as reservation:
-        with reservation.create_niswitch_sessions() as session_infos:
+        with reservation.initialize_niswitch_sessions() as session_infos:
             # Open or close all relays corresponding to the selected pins and
             # sites.
             for session_info in session_infos:

--- a/examples/nivisa_dmm_measurement/measurement.py
+++ b/examples/nivisa_dmm_measurement/measurement.py
@@ -51,7 +51,9 @@ def measure(
     )
 
     with measurement_service.context.reserve_session(pin_name) as reservation:
-        with reservation.create_session(_create_session, INSTRUMENT_TYPE_VISA_DMM) as session_info:
+        with reservation.initialize_session(
+            _construct_visa_dmm_session, INSTRUMENT_TYPE_VISA_DMM
+        ) as session_info:
             session = session_info.session
             session.configure_measurement_digits(measurement_type, range, resolution_digits)
             measured_value = session.read()
@@ -60,7 +62,7 @@ def measure(
     return (measured_value,)
 
 
-def _create_session(session_info: SessionInformation) -> Session:
+def _construct_visa_dmm_session(session_info: SessionInformation) -> Session:
     # When this measurement is called from outside of TestStand (session_exists
     # == False), reset the instrument to a known state. In TestStand,
     # ProcessSetup resets the instrument.

--- a/examples/output_voltage_measurement/measurement.py
+++ b/examples/output_voltage_measurement/measurement.py
@@ -91,8 +91,8 @@ def measure(
     measurement_service.context.add_cancel_callback(cancellation_event.set)
 
     with measurement_service.context.reserve_sessions([input_pin, output_pin]) as reservation:
-        with reservation.create_nidcpower_session(), reservation.create_session(
-            _create_visa_dmm_session, _visa_dmm.INSTRUMENT_TYPE_VISA_DMM
+        with reservation.initialize_nidcpower_session(), reservation.initialize_session(
+            _construct_visa_dmm_session, _visa_dmm.INSTRUMENT_TYPE_VISA_DMM
         ):
             # Configure the SMU channel connected to the input pin.
             source_connection = reservation.get_nidcpower_connection(input_pin)
@@ -130,7 +130,7 @@ def measure(
     return (measured_value,)
 
 
-def _create_visa_dmm_session(session_info: SessionInformation) -> _visa_dmm.Session:
+def _construct_visa_dmm_session(session_info: SessionInformation) -> _visa_dmm.Session:
     # When this measurement is called from outside of TestStand (session_exists
     # == False), reset the instrument to a known state. In TestStand,
     # ProcessSetup resets the instrument.

--- a/ni_measurementlink_service/session_management/_reservation.py
+++ b/ni_measurementlink_service/session_management/_reservation.py
@@ -280,7 +280,7 @@ class BaseReservation(abc.ABC):
         ]
 
     @contextlib.contextmanager
-    def _create_session_core(
+    def _initialize_session_core(
         self,
         session_constructor: Callable[[SessionInformation], TSession],
         instrument_type_id: str,
@@ -306,7 +306,7 @@ class BaseReservation(abc.ABC):
                 yield cast(TypedSessionInformation[TSession], new_session_info)
 
     @contextlib.contextmanager
-    def _create_sessions_core(
+    def _initialize_sessions_core(
         self,
         session_constructor: Callable[[SessionInformation], TSession],
         instrument_type_id: str,
@@ -434,12 +434,12 @@ class BaseReservation(abc.ABC):
         return results
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
-    def create_session(
+    def initialize_session(
         self,
         session_constructor: Callable[[SessionInformation], TSession],
         instrument_type_id: str,
     ) -> ContextManager[TypedSessionInformation[TSession]]:
-        """Create a single instrument session.
+        """Initialize a single instrument session.
 
         This is a generic method that supports any instrument driver.
 
@@ -454,22 +454,22 @@ class BaseReservation(abc.ABC):
 
         Returns:
             A context manager that yields a session information object. The
-            created session is available via the ``session`` field.
+            session object is available via the ``session`` field.
 
         Raises:
             ValueError: If the instrument type ID is empty, no reserved sessions
                 match the instrument type ID, or too many reserved sessions
                 match the instrument type ID.
         """
-        return self._create_session_core(session_constructor, instrument_type_id)
+        return self._initialize_session_core(session_constructor, instrument_type_id)
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
-    def create_sessions(
+    def initialize_sessions(
         self,
         session_constructor: Callable[[SessionInformation], TSession],
         instrument_type_id: str,
     ) -> ContextManager[Sequence[TypedSessionInformation[TSession]]]:
-        """Create multiple instrument sessions.
+        """Initialize multiple instrument sessions.
 
         This is a generic method that supports any instrument driver.
 
@@ -484,14 +484,14 @@ class BaseReservation(abc.ABC):
 
         Returns:
             A context manager that yields a sequence of session information
-            objects. The created sessions are available via the ``session``
+            objects. The session objects are available via the ``session``
             field.
 
         Raises:
             ValueError: If the instrument type ID is empty or no reserved
                 sessions matched the instrument type ID.
         """
-        return self._create_sessions_core(session_constructor, instrument_type_id)
+        return self._initialize_sessions_core(session_constructor, instrument_type_id)
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
     def get_connection(
@@ -576,12 +576,12 @@ class BaseReservation(abc.ABC):
         """Create a single NI-DAQmx task.
 
         Args:
-            initialization_behavior: Specifies whether to initialize a new
-                task or attach to an existing task.
+            initialization_behavior: Specifies whether the NI gRPC Device Server
+                will create a new task or attach to an existing task.
 
         Returns:
-            A context manager that yields a session information object. The
-            created task is available via the ``session`` field.
+            A context manager that yields a session information object. The task
+            object is available via the ``session`` field.
 
         Raises:
             ValueError: If no NI-DAQmx tasks are reserved or too many
@@ -599,7 +599,7 @@ class BaseReservation(abc.ABC):
         session_constructor = SessionConstructor(
             self._discovery_client, self._grpc_channel_pool, initialization_behavior
         )
-        return self._create_session_core(session_constructor, INSTRUMENT_TYPE_NI_DAQMX)
+        return self._initialize_session_core(session_constructor, INSTRUMENT_TYPE_NI_DAQMX)
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
     def create_nidaqmx_tasks(
@@ -609,13 +609,12 @@ class BaseReservation(abc.ABC):
         """Create multiple NI-DAQmx tasks.
 
         Args:
-            initialization_behavior: Specifies whether to initialize a new
-                task or attach to an existing task.
+            initialization_behavior: Specifies whether the NI gRPC Device Server
+                will create a new task or attach to an existing task.
 
         Returns:
             A context manager that yields a sequence of session information
-            objects. The created tasks are available via the ``session``
-            field.
+            objects. The task objects are available via the ``session`` field.
 
         Raises:
             ValueError: If no NI-DAQmx tasks are reserved.
@@ -632,7 +631,7 @@ class BaseReservation(abc.ABC):
         session_constructor = SessionConstructor(
             self._discovery_client, self._grpc_channel_pool, initialization_behavior
         )
-        return self._create_sessions_core(session_constructor, INSTRUMENT_TYPE_NI_DAQMX)
+        return self._initialize_sessions_core(session_constructor, INSTRUMENT_TYPE_NI_DAQMX)
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
     def get_nidaqmx_connection(
@@ -690,13 +689,13 @@ class BaseReservation(abc.ABC):
         return self._get_connections_core(nidaqmx.Task, pin_names, sites, INSTRUMENT_TYPE_NI_DAQMX)
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
-    def create_nidcpower_session(
+    def initialize_nidcpower_session(
         self,
         reset: bool = False,
         options: Optional[Dict[str, Any]] = None,
         initialization_behavior: SessionInitializationBehavior = SessionInitializationBehavior.AUTO,
     ) -> ContextManager[TypedSessionInformation[nidcpower.Session]]:
-        """Create a single NI-DCPower instrument session.
+        """Initialize a single NI-DCPower instrument session.
 
         Args:
             reset: Specifies whether to reset channel(s) during the
@@ -708,12 +707,12 @@ class BaseReservation(abc.ABC):
                 ``NIDCPOWER_SIMULATE``, ``NIDCPOWER_BOARD_TYPE``, and
                 ``NIDCPOWER_MODEL`` in the configuration file (``.env``).
 
-            initialization_behavior: Specifies whether to initialize a new
-                session or attach to an existing session.
+            initialization_behavior: Specifies whether the NI gRPC Device Server
+                will initialize a new session or attach to an existing session.
 
         Returns:
             A context manager that yields a session information object. The
-            created session is available via the ``session`` field.
+            session object is available via the ``session`` field.
 
         Raises:
             ValueError: If no NI-DCPower sessions are reserved or too many
@@ -727,7 +726,7 @@ class BaseReservation(abc.ABC):
         session_constructor = SessionConstructor(
             self._discovery_client, self._grpc_channel_pool, reset, options, initialization_behavior
         )
-        return self._create_session_core(session_constructor, INSTRUMENT_TYPE_NI_DCPOWER)
+        return self._initialize_session_core(session_constructor, INSTRUMENT_TYPE_NI_DCPOWER)
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
     def create_nidcpower_sessions(
@@ -736,7 +735,7 @@ class BaseReservation(abc.ABC):
         options: Optional[Dict[str, Any]] = None,
         initialization_behavior: SessionInitializationBehavior = SessionInitializationBehavior.AUTO,
     ) -> ContextManager[Sequence[TypedSessionInformation[nidcpower.Session]]]:
-        """Create multiple NI-DCPower instrument sessions.
+        """Initialize multiple NI-DCPower instrument sessions.
 
         Args:
             reset: Specifies whether to reset channel(s) during the
@@ -748,12 +747,12 @@ class BaseReservation(abc.ABC):
                 ``NIDCPOWER_SIMULATE``, ``NIDCPOWER_BOARD_TYPE``, and
                 ``NIDCPOWER_MODEL`` in the configuration file (``.env``).
 
-            initialization_behavior: Specifies whether to initialize a new
-                session or attach to an existing session.
+            initialization_behavior: Specifies whether the NI gRPC Device Server
+                will initialize a new session or attach to an existing session.
 
         Returns:
             A context manager that yields a sequence of session information
-            objects. The created sessions are available via the ``session``
+            objects. The session objects are available via the ``session``
             field.
 
         Raises:
@@ -767,7 +766,7 @@ class BaseReservation(abc.ABC):
         session_constructor = SessionConstructor(
             self._discovery_client, self._grpc_channel_pool, reset, options, initialization_behavior
         )
-        return self._create_sessions_core(session_constructor, INSTRUMENT_TYPE_NI_DCPOWER)
+        return self._initialize_sessions_core(session_constructor, INSTRUMENT_TYPE_NI_DCPOWER)
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
     def get_nidcpower_connection(
@@ -829,13 +828,13 @@ class BaseReservation(abc.ABC):
         )
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
-    def create_nidigital_session(
+    def initialize_nidigital_session(
         self,
         reset_device: bool = False,
         options: Optional[Dict[str, Any]] = None,
         initialization_behavior: SessionInitializationBehavior = SessionInitializationBehavior.AUTO,
     ) -> ContextManager[TypedSessionInformation[nidigital.Session]]:
-        """Create a single NI-Digital Pattern instrument session.
+        """Initialize a single NI-Digital Pattern instrument session.
 
         Args:
             reset_device: Specifies whether to reset the instrument during the
@@ -847,12 +846,12 @@ class BaseReservation(abc.ABC):
                 ``NIDIGITAL_SIMULATE``, ``NIDIGITAL_BOARD_TYPE``, and
                 ``NIDIGITAL_MODEL`` in the configuration file (``.env``).
 
-            initialization_behavior: Specifies whether to initialize a new
-                session or attach to an existing session.
+            initialization_behavior: Specifies whether the NI gRPC Device Server
+                will initialize a new session or attach to an existing session.
 
         Returns:
             A context manager that yields a session information object. The
-            created session is available via the ``session`` field.
+            session object is available via the ``session`` field.
 
         Raises:
             ValueError: If no NI-Digital sessions are reserved or too many
@@ -870,16 +869,18 @@ class BaseReservation(abc.ABC):
             options,
             initialization_behavior,
         )
-        return self._create_session_core(session_constructor, INSTRUMENT_TYPE_NI_DIGITAL_PATTERN)
+        return self._initialize_session_core(
+            session_constructor, INSTRUMENT_TYPE_NI_DIGITAL_PATTERN
+        )
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
-    def create_nidigital_sessions(
+    def initialize_nidigital_sessions(
         self,
         reset_device: bool = False,
         options: Optional[Dict[str, Any]] = None,
         initialization_behavior: SessionInitializationBehavior = SessionInitializationBehavior.AUTO,
     ) -> ContextManager[Sequence[TypedSessionInformation[nidigital.Session]]]:
-        """Create multiple NI-Digital Pattern instrument sessions.
+        """Initialize multiple NI-Digital Pattern instrument sessions.
 
         Args:
             reset_device: Specifies whether to reset the instrument during the
@@ -891,12 +892,12 @@ class BaseReservation(abc.ABC):
                 ``NIDIGITAL_SIMULATE``, ``NIDIGITAL_BOARD_TYPE``, and
                 ``NIDIGITAL_MODEL`` in the configuration file (``.env``).
 
-            initialization_behavior: Specifies whether to initialize a new
-                session or attach to an existing session.
+            initialization_behavior: Specifies whether the NI gRPC Device Server
+                will initialize a new session or attach to an existing session.
 
         Returns:
             A context manager that yields a sequence of session information
-            objects. The created sessions are available via the ``session``
+            objects. The session objects are available via the ``session``
             field.
 
         Raises:
@@ -914,7 +915,9 @@ class BaseReservation(abc.ABC):
             options,
             initialization_behavior,
         )
-        return self._create_sessions_core(session_constructor, INSTRUMENT_TYPE_NI_DIGITAL_PATTERN)
+        return self._initialize_sessions_core(
+            session_constructor, INSTRUMENT_TYPE_NI_DIGITAL_PATTERN
+        )
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
     def get_nidigital_connection(
@@ -976,13 +979,13 @@ class BaseReservation(abc.ABC):
         )
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
-    def create_nidmm_session(
+    def initialize_nidmm_session(
         self,
         reset_device: bool = False,
         options: Optional[Dict[str, Any]] = None,
         initialization_behavior: SessionInitializationBehavior = SessionInitializationBehavior.AUTO,
     ) -> ContextManager[TypedSessionInformation[nidmm.Session]]:
-        """Create a single NI-DMM instrument session.
+        """Initialize a single NI-DMM instrument session.
 
         Args:
             reset_device: Specifies whether to reset the instrument during the
@@ -991,15 +994,15 @@ class BaseReservation(abc.ABC):
             options: Specifies the initial value of certain properties for the
                 session. If this argument is not specified, the default value is
                 an empty dict, which you may override by specifying
-                ``NIDMM_SIMULATE``, ``NIDMM_BOARD_TYPE``, and
-                ``NIDMM_MODEL`` in the configuration file (``.env``).
+                ``NIDMM_SIMULATE``, ``NIDMM_BOARD_TYPE``, and ``NIDMM_MODEL`` in
+                the configuration file (``.env``).
 
-            initialization_behavior: Specifies whether to initialize a new
-                session or attach to an existing session.
+            initialization_behavior: Specifies whether the NI gRPC Device Server
+                will initialize a new session or attach to an existing session.
 
         Returns:
             A context manager that yields a session information object. The
-            created session is available via the ``session`` field.
+            session object is available via the ``session`` field.
 
         Raises:
             ValueError: If no NI-DMM sessions are reserved or too many
@@ -1017,16 +1020,16 @@ class BaseReservation(abc.ABC):
             options,
             initialization_behavior,
         )
-        return self._create_session_core(session_constructor, INSTRUMENT_TYPE_NI_DMM)
+        return self._initialize_session_core(session_constructor, INSTRUMENT_TYPE_NI_DMM)
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
-    def create_nidmm_sessions(
+    def initialize_nidmm_sessions(
         self,
         reset_device: bool = False,
         options: Optional[Dict[str, Any]] = None,
         initialization_behavior: SessionInitializationBehavior = SessionInitializationBehavior.AUTO,
     ) -> ContextManager[Sequence[TypedSessionInformation[nidmm.Session]]]:
-        """Create multiple NI-DMM instrument sessions.
+        """Initialize multiple NI-DMM instrument sessions.
 
         Args:
             reset_device: Specifies whether to reset the instrument during the
@@ -1035,15 +1038,15 @@ class BaseReservation(abc.ABC):
             options: Specifies the initial value of certain properties for the
                 session. If this argument is not specified, the default value is
                 an empty dict, which you may override by specifying
-                ``NIDMM_SIMULATE``, ``NIDMM_BOARD_TYPE``, and
-                ``NIDMM_MODEL`` in the configuration file (``.env``).
+                ``NIDMM_SIMULATE``, ``NIDMM_BOARD_TYPE``, and ``NIDMM_MODEL`` in
+                the configuration file (``.env``).
 
-            initialization_behavior: Specifies whether to initialize a new
-                session or attach to an existing session.
+            initialization_behavior: Specifies whether the NI gRPC Device Server
+                will initialize a new session or attach to an existing session.
 
         Returns:
             A context manager that yields a sequence of session information
-            objects. The created sessions are available via the ``session``
+            objects. The session objects are available via the ``session``
             field.
 
         Raises:
@@ -1061,7 +1064,7 @@ class BaseReservation(abc.ABC):
             options,
             initialization_behavior,
         )
-        return self._create_sessions_core(session_constructor, INSTRUMENT_TYPE_NI_DMM)
+        return self._initialize_sessions_core(session_constructor, INSTRUMENT_TYPE_NI_DMM)
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
     def get_nidmm_connection(
@@ -1119,13 +1122,13 @@ class BaseReservation(abc.ABC):
         return self._get_connections_core(nidmm.Session, pin_names, sites, INSTRUMENT_TYPE_NI_DMM)
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
-    def create_nifgen_session(
+    def initialize_nifgen_session(
         self,
         reset_device: bool = False,
         options: Optional[Dict[str, Any]] = None,
         initialization_behavior: SessionInitializationBehavior = SessionInitializationBehavior.AUTO,
     ) -> ContextManager[TypedSessionInformation[nifgen.Session]]:
-        """Create a single NI-FGEN instrument session.
+        """Initialize a single NI-FGEN instrument session.
 
         Args:
             reset_device: Specifies whether to reset the instrument during the
@@ -1137,12 +1140,12 @@ class BaseReservation(abc.ABC):
                 ``NIFGEN_SIMULATE``, ``NIFGEN_BOARD_TYPE``, and ``NIFGEN_MODEL``
                 in the configuration file (``.env``).
 
-            initialization_behavior: Specifies whether to initialize a new
-                session or attach to an existing session.
+            initialization_behavior: Specifies whether the NI gRPC Device Server
+                will initialize a new session or attach to an existing session.
 
         Returns:
             A context manager that yields a session information object. The
-            created session is available via the ``session`` field.
+            session object is available via the ``session`` field.
 
         Raises:
             ValueError: If no NI-FGEN sessions are reserved or too many NI-FGEN
@@ -1160,16 +1163,16 @@ class BaseReservation(abc.ABC):
             options,
             initialization_behavior,
         )
-        return self._create_session_core(session_constructor, INSTRUMENT_TYPE_NI_FGEN)
+        return self._initialize_session_core(session_constructor, INSTRUMENT_TYPE_NI_FGEN)
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
-    def create_nifgen_sessions(
+    def initialize_nifgen_sessions(
         self,
         reset_device: bool = False,
         options: Optional[Dict[str, Any]] = None,
         initialization_behavior: SessionInitializationBehavior = SessionInitializationBehavior.AUTO,
     ) -> ContextManager[Sequence[TypedSessionInformation[nifgen.Session]]]:
-        """Create multiple NI-FGEN instrument sessions.
+        """Initialize multiple NI-FGEN instrument sessions.
 
         Args:
             reset_device: Specifies whether to reset the instrument during the
@@ -1181,12 +1184,12 @@ class BaseReservation(abc.ABC):
                 ``NIFGEN_SIMULATE``, ``NIFGEN_BOARD_TYPE``, and ``NIFGEN_MODEL``
                 in the configuration file (``.env``).
 
-            initialization_behavior: Specifies whether to initialize a new
-                session or attach to an existing session.
+            initialization_behavior: Specifies whether the NI gRPC Device Server
+                will initialize a new session or attach to an existing session.
 
         Returns:
             A context manager that yields a sequence of session information
-            objects. The created sessions are available via the ``session``
+            objects. The session objects are available via the ``session``
             field.
 
         Raises:
@@ -1204,7 +1207,7 @@ class BaseReservation(abc.ABC):
             options,
             initialization_behavior,
         )
-        return self._create_sessions_core(session_constructor, INSTRUMENT_TYPE_NI_FGEN)
+        return self._initialize_sessions_core(session_constructor, INSTRUMENT_TYPE_NI_FGEN)
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
     def get_nifgen_connection(
@@ -1262,13 +1265,13 @@ class BaseReservation(abc.ABC):
         return self._get_connections_core(nifgen.Session, pin_names, sites, INSTRUMENT_TYPE_NI_FGEN)
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
-    def create_niscope_session(
+    def initialize_niscope_session(
         self,
         reset_device: bool = False,
         options: Optional[Dict[str, Any]] = None,
         initialization_behavior: SessionInitializationBehavior = SessionInitializationBehavior.AUTO,
     ) -> ContextManager[TypedSessionInformation[niscope.Session]]:
-        """Create a single NI-SCOPE instrument session.
+        """Initialize a single NI-SCOPE instrument session.
 
         Args:
             reset_device: Specifies whether to reset the instrument during the
@@ -1280,12 +1283,12 @@ class BaseReservation(abc.ABC):
                 ``NISCOPE_SIMULATE``, ``NISCOPE_BOARD_TYPE``, and
                 ``NISCOPE_MODEL`` in the configuration file (``.env``).
 
-            initialization_behavior: Specifies whether to initialize a new
-                session or attach to an existing session.
+            initialization_behavior: Specifies whether the NI gRPC Device Server
+                will initialize a new session or attach to an existing session.
 
         Returns:
             A context manager that yields a session information object. The
-            created session is available via the ``session`` field.
+            session object is available via the ``session`` field.
 
         Raises:
             ValueError: If no NI-SCOPE sessions are reserved or too many
@@ -1303,16 +1306,16 @@ class BaseReservation(abc.ABC):
             options,
             initialization_behavior,
         )
-        return self._create_session_core(session_constructor, INSTRUMENT_TYPE_NI_SCOPE)
+        return self._initialize_session_core(session_constructor, INSTRUMENT_TYPE_NI_SCOPE)
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
-    def create_niscope_sessions(
+    def initialize_niscope_sessions(
         self,
         reset_device: bool = False,
         options: Optional[Dict[str, Any]] = None,
         initialization_behavior: SessionInitializationBehavior = SessionInitializationBehavior.AUTO,
     ) -> ContextManager[Sequence[TypedSessionInformation[niscope.Session]]]:
-        """Create multiple NI-SCOPE instrument sessions.
+        """Initialize multiple NI-SCOPE instrument sessions.
 
         Args:
             reset_device: Specifies whether to reset the instrument during the
@@ -1324,12 +1327,12 @@ class BaseReservation(abc.ABC):
                 ``NISCOPE_SIMULATE``, ``NISCOPE_BOARD_TYPE``, and
                 ``NISCOPE_MODEL`` in the configuration file (``.env``).
 
-            initialization_behavior: Specifies whether to initialize a new
-                session or attach to an existing session.
+            initialization_behavior: Specifies whether the NI gRPC Device Server
+                will initialize a new session or attach to an existing session.
 
         Returns:
             A context manager that yields a sequence of session information
-            objects. The created sessions are available via the ``session``
+            objects. The session objects are available via the ``session``
             field.
 
         Raises:
@@ -1347,7 +1350,7 @@ class BaseReservation(abc.ABC):
             options,
             initialization_behavior,
         )
-        return self._create_sessions_core(session_constructor, INSTRUMENT_TYPE_NI_SCOPE)
+        return self._initialize_sessions_core(session_constructor, INSTRUMENT_TYPE_NI_SCOPE)
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
     def get_niscope_connection(
@@ -1407,14 +1410,14 @@ class BaseReservation(abc.ABC):
         )
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
-    def create_niswitch_session(
+    def initialize_niswitch_session(
         self,
         topology: Optional[str] = None,
         simulate: Optional[bool] = None,
         reset_device: bool = False,
         initialization_behavior: SessionInitializationBehavior = SessionInitializationBehavior.AUTO,
     ) -> ContextManager[TypedSessionInformation[niswitch.Session]]:
-        """Create a single NI-SWITCH relay driver instrument session.
+        """Initialize a single NI-SWITCH relay driver instrument session.
 
         Args:
             topology: Specifies the switch topology. If this argument is not
@@ -1431,12 +1434,12 @@ class BaseReservation(abc.ABC):
             reset_device: Specifies whether to reset the switch module during
                 the initialization procedure.
 
-            initialization_behavior: Specifies whether to initialize a new
-                session or attach to an existing session.
+            initialization_behavior: Specifies whether the NI gRPC Device Server
+                will initialize a new session or attach to an existing session.
 
         Returns:
             A context manager that yields a session information object. The
-            created session is available via the ``session`` field.
+            session object is available via the ``session`` field.
 
         Raises:
             ValueError: If no relay driver sessions are reserved or
@@ -1455,17 +1458,17 @@ class BaseReservation(abc.ABC):
             reset_device,
             initialization_behavior,
         )
-        return self._create_session_core(session_constructor, INSTRUMENT_TYPE_NI_RELAY_DRIVER)
+        return self._initialize_session_core(session_constructor, INSTRUMENT_TYPE_NI_RELAY_DRIVER)
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
-    def create_niswitch_sessions(
+    def initialize_niswitch_sessions(
         self,
         topology: Optional[str] = None,
         simulate: Optional[bool] = None,
         reset_device: bool = False,
         initialization_behavior: SessionInitializationBehavior = SessionInitializationBehavior.AUTO,
     ) -> ContextManager[Sequence[TypedSessionInformation[niswitch.Session]]]:
-        """Create multiple NI-SWITCH relay driver instrument sessions.
+        """Initialize multiple NI-SWITCH relay driver instrument sessions.
 
         Args:
             topology: Specifies the switch topology. If this argument is not
@@ -1482,12 +1485,12 @@ class BaseReservation(abc.ABC):
             reset_device: Specifies whether to reset the switch module during
                 the initialization procedure.
 
-            initialization_behavior: Specifies whether to initialize a new
-                session or attach to an existing session.
+            initialization_behavior: Specifies whether the NI gRPC Device Server
+                will initialize a new session or attach to an existing session.
 
         Returns:
             A context manager that yields a sequence of session information
-            objects. The created sessions are available via the ``session``
+            objects. The session objects are available via the ``session``
             field.
 
         Raises:
@@ -1506,7 +1509,7 @@ class BaseReservation(abc.ABC):
             reset_device,
             initialization_behavior,
         )
-        return self._create_sessions_core(session_constructor, INSTRUMENT_TYPE_NI_RELAY_DRIVER)
+        return self._initialize_sessions_core(session_constructor, INSTRUMENT_TYPE_NI_RELAY_DRIVER)
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
     def get_niswitch_connection(

--- a/tests/unit/_drivers/test_nidcpower.py
+++ b/tests/unit/_drivers/test_nidcpower.py
@@ -34,7 +34,7 @@ if nidcpower:
     set_nidcpower_simulation_options = functools.partial(set_simulation_options, "nidcpower")
 
 
-def test___single_session_info___create_nidcpower_session___session_created(
+def test___single_session_info___initialize_nidcpower_session___session_created(
     session_new: Mock,
     session_management_client: Mock,
 ) -> None:
@@ -44,7 +44,7 @@ def test___single_session_info___create_nidcpower_session___session_created(
     session = create_mock_nidcpower_session()
     session_new.side_effect = [session]
 
-    with reservation.create_nidcpower_session() as session_info:
+    with reservation.initialize_nidcpower_session() as session_info:
         assert session_info.session is session
 
     session_new.assert_called_once_with(
@@ -52,7 +52,7 @@ def test___single_session_info___create_nidcpower_session___session_created(
     )
 
 
-def test___multiple_session_infos___create_nidcpower_sessions___sessions_created(
+def test___multiple_session_infos___initialize_nidcpower_sessions___sessions_created(
     session_new: Mock,
     session_management_client: Mock,
 ) -> None:
@@ -74,7 +74,7 @@ def test___multiple_session_infos___create_nidcpower_sessions___sessions_created
     )
 
 
-def test___optional_args___create_nidcpower_session___optional_args_passed(
+def test___optional_args___initialize_nidcpower_session___optional_args_passed(
     session_new: Mock,
     session_management_client: Mock,
 ) -> None:
@@ -84,7 +84,7 @@ def test___optional_args___create_nidcpower_session___optional_args_passed(
     session = create_mock_nidcpower_session()
     session_new.side_effect = [session]
 
-    with reservation.create_nidcpower_session(
+    with reservation.initialize_nidcpower_session(
         reset=True,
         options={"simulate": False},
         initialization_behavior=SessionInitializationBehavior.INITIALIZE_SERVER_SESSION,
@@ -104,7 +104,7 @@ def test___optional_args___create_nidcpower_session___optional_args_passed(
     )
 
 
-def test___simulation_configured___create_nidcpower_session___simulation_options_passed(
+def test___simulation_configured___initialize_nidcpower_session___simulation_options_passed(
     mocker: MockerFixture,
     session_new: Mock,
     session_management_client: Mock,
@@ -116,7 +116,7 @@ def test___simulation_configured___create_nidcpower_session___simulation_options
     session = create_mock_nidcpower_session()
     session_new.side_effect = [session]
 
-    with reservation.create_nidcpower_session():
+    with reservation.initialize_nidcpower_session():
         pass
 
     expected_options = {"simulate": True, "driver_setup": {"BoardType": "PXIe", "Model": "4147"}}
@@ -129,7 +129,7 @@ def test___simulation_configured___create_nidcpower_session___simulation_options
     )
 
 
-def test___optional_args_and_simulation_configured___create_nidcpower_session___optional_args_passed(
+def test___optional_args_and_simulation_configured___initialize_nidcpower_session___optional_args_passed(
     mocker: MockerFixture,
     session_new: Mock,
     session_management_client: Mock,
@@ -141,7 +141,7 @@ def test___optional_args_and_simulation_configured___create_nidcpower_session___
     session = create_mock_nidcpower_session()
     session_new.side_effect = [session]
 
-    with reservation.create_nidcpower_session(reset=True, options={"simulate": False}):
+    with reservation.initialize_nidcpower_session(reset=True, options={"simulate": False}):
         pass
 
     expected_options = {"simulate": False}

--- a/tests/unit/_drivers/test_nidigital.py
+++ b/tests/unit/_drivers/test_nidigital.py
@@ -34,7 +34,7 @@ if nidigital:
     set_nidigital_simulation_options = functools.partial(set_simulation_options, "nidigital")
 
 
-def test___single_session_info___create_nidigital_session___session_created(
+def test___single_session_info___initialize_nidigital_session___session_created(
     session_new: Mock,
     session_management_client: Mock,
 ) -> None:
@@ -44,7 +44,7 @@ def test___single_session_info___create_nidigital_session___session_created(
     session = create_mock_nidigital_session()
     session_new.side_effect = [session]
 
-    with reservation.create_nidigital_session() as session_info:
+    with reservation.initialize_nidigital_session() as session_info:
         assert session_info.session is session
 
     session_new.assert_called_once_with(
@@ -52,7 +52,7 @@ def test___single_session_info___create_nidigital_session___session_created(
     )
 
 
-def test___multiple_session_infos___create_nidigital_sessions___sessions_created(
+def test___multiple_session_infos___initialize_nidigital_sessions___sessions_created(
     session_new: Mock,
     session_management_client: Mock,
 ) -> None:
@@ -62,7 +62,7 @@ def test___multiple_session_infos___create_nidigital_sessions___sessions_created
     sessions = create_mock_nidigital_sessions(3)
     session_new.side_effect = sessions
 
-    with reservation.create_nidigital_sessions() as session_info:
+    with reservation.initialize_nidigital_sessions() as session_info:
         assert session_info[0].session == sessions[0]
         assert session_info[1].session == sessions[1]
 
@@ -74,7 +74,7 @@ def test___multiple_session_infos___create_nidigital_sessions___sessions_created
     )
 
 
-def test___optional_args___create_nidigital_session___optional_args_passed(
+def test___optional_args___initialize_nidigital_session___optional_args_passed(
     session_new: Mock,
     session_management_client: Mock,
 ) -> None:
@@ -84,7 +84,7 @@ def test___optional_args___create_nidigital_session___optional_args_passed(
     session = create_mock_nidigital_session()
     session_new.side_effect = [session]
 
-    with reservation.create_nidigital_session(
+    with reservation.initialize_nidigital_session(
         reset_device=True,
         options={"simulate": False},
         initialization_behavior=SessionInitializationBehavior.INITIALIZE_SERVER_SESSION,
@@ -104,7 +104,7 @@ def test___optional_args___create_nidigital_session___optional_args_passed(
     )
 
 
-def test___simulation_configured___create_nidigital_session___simulation_options_passed(
+def test___simulation_configured___initialize_nidigital_session___simulation_options_passed(
     mocker: MockerFixture,
     session_new: Mock,
     session_management_client: Mock,
@@ -116,7 +116,7 @@ def test___simulation_configured___create_nidigital_session___simulation_options
     session = create_mock_nidigital_session()
     session_new.side_effect = [session]
 
-    with reservation.create_nidigital_session():
+    with reservation.initialize_nidigital_session():
         pass
 
     expected_options = {
@@ -132,7 +132,7 @@ def test___simulation_configured___create_nidigital_session___simulation_options
     )
 
 
-def test___optional_args_and_simulation_configured___create_nidigital_session___optional_args_passed(
+def test___optional_args_and_simulation_configured___initialize_nidigital_session___optional_args_passed(
     mocker: MockerFixture,
     session_new: Mock,
     session_management_client: Mock,
@@ -144,7 +144,7 @@ def test___optional_args_and_simulation_configured___create_nidigital_session___
     session = create_mock_nidigital_session()
     session_new.side_effect = [session]
 
-    with reservation.create_nidigital_session(reset_device=True, options={"simulate": False}):
+    with reservation.initialize_nidigital_session(reset_device=True, options={"simulate": False}):
         pass
 
     expected_options = {"simulate": False}
@@ -182,7 +182,7 @@ def test___session_created___get_nidigital_connection___connection_returned(
         reservation = MultiSessionReservation(session_management_client, grpc_session_infos)
         sessions = create_mock_nidigital_sessions(2)
         session_new.side_effect = sessions
-        session_infos = stack.enter_context(reservation.create_nidigital_sessions())
+        session_infos = stack.enter_context(reservation.initialize_nidigital_sessions())
 
         connection = reservation.get_nidigital_connection(**kwargs)
 
@@ -217,7 +217,7 @@ def test___session_created___get_nidigital_connections___connections_returned(
         reservation = MultiSessionReservation(session_management_client, grpc_session_infos)
         sessions = create_mock_nidigital_sessions(2)
         session_new.side_effect = sessions
-        session_infos = stack.enter_context(reservation.create_nidigital_sessions())
+        session_infos = stack.enter_context(reservation.initialize_nidigital_sessions())
 
         connections = reservation.get_nidigital_connections(**kwargs)
 

--- a/tests/unit/_drivers/test_nidmm.py
+++ b/tests/unit/_drivers/test_nidmm.py
@@ -34,7 +34,7 @@ if nidmm:
     set_nidmm_simulation_options = functools.partial(set_simulation_options, "nidmm")
 
 
-def test___single_session_info___create_nidmm_session___session_created(
+def test___single_session_info___initialize_nidmm_session___session_created(
     session_new: Mock,
     session_management_client: Mock,
 ) -> None:
@@ -42,7 +42,7 @@ def test___single_session_info___create_nidmm_session___session_created(
     session = create_mock_nidmm_session()
     session_new.side_effect = [session]
 
-    with reservation.create_nidmm_session() as session_info:
+    with reservation.initialize_nidmm_session() as session_info:
         assert session_info.session is session
 
     session_new.assert_called_once_with(
@@ -50,7 +50,7 @@ def test___single_session_info___create_nidmm_session___session_created(
     )
 
 
-def test___multiple_session_infos___create_nidmm_sessions___sessions_created(
+def test___multiple_session_infos___initialize_nidmm_sessions___sessions_created(
     session_new: Mock,
     session_management_client: Mock,
 ) -> None:
@@ -58,7 +58,7 @@ def test___multiple_session_infos___create_nidmm_sessions___sessions_created(
     sessions = create_mock_nidmm_sessions(3)
     session_new.side_effect = sessions
 
-    with reservation.create_nidmm_sessions() as session_info:
+    with reservation.initialize_nidmm_sessions() as session_info:
         assert session_info[0].session == sessions[0]
         assert session_info[1].session == sessions[1]
 
@@ -70,7 +70,7 @@ def test___multiple_session_infos___create_nidmm_sessions___sessions_created(
     )
 
 
-def test___optional_args___create_nidmm_session___optional_args_passed(
+def test___optional_args___initialize_nidmm_session___optional_args_passed(
     session_new: Mock,
     session_management_client: Mock,
 ) -> None:
@@ -78,7 +78,7 @@ def test___optional_args___create_nidmm_session___optional_args_passed(
     session = create_mock_nidmm_session()
     session_new.side_effect = [session]
 
-    with reservation.create_nidmm_session(
+    with reservation.initialize_nidmm_session(
         reset_device=True,
         options={"simulate": False},
         initialization_behavior=SessionInitializationBehavior.INITIALIZE_SERVER_SESSION,
@@ -98,7 +98,7 @@ def test___optional_args___create_nidmm_session___optional_args_passed(
     )
 
 
-def test___simulation_configured___create_nidmm_session___simulation_options_passed(
+def test___simulation_configured___initialize_nidmm_session___simulation_options_passed(
     mocker: MockerFixture,
     session_new: Mock,
     session_management_client: Mock,
@@ -108,7 +108,7 @@ def test___simulation_configured___create_nidmm_session___simulation_options_pas
     session = create_mock_nidmm_session()
     session_new.side_effect = [session]
 
-    with reservation.create_nidmm_session():
+    with reservation.initialize_nidmm_session():
         pass
 
     expected_options = {
@@ -124,7 +124,7 @@ def test___simulation_configured___create_nidmm_session___simulation_options_pas
     )
 
 
-def test___optional_args_and_simulation_configured___create_nidmm_session___optional_args_passed(
+def test___optional_args_and_simulation_configured___initialize_nidmm_session___optional_args_passed(
     mocker: MockerFixture,
     session_new: Mock,
     session_management_client: Mock,
@@ -134,7 +134,7 @@ def test___optional_args_and_simulation_configured___create_nidmm_session___opti
     session = create_mock_nidmm_session()
     session_new.side_effect = [session]
 
-    with reservation.create_nidmm_session(reset_device=True, options={"simulate": False}):
+    with reservation.initialize_nidmm_session(reset_device=True, options={"simulate": False}):
         pass
 
     expected_options = {"simulate": False}
@@ -174,7 +174,7 @@ def test___session_created___get_nidmm_connection___connection_returned(
         reservation = MultiSessionReservation(session_management_client, grpc_session_infos)
         sessions = create_mock_nidmm_sessions(4)
         session_new.side_effect = sessions
-        session_infos = stack.enter_context(reservation.create_nidmm_sessions())
+        session_infos = stack.enter_context(reservation.initialize_nidmm_sessions())
 
         connection = reservation.get_nidmm_connection(**kwargs)
 
@@ -209,7 +209,7 @@ def test___session_created___get_nidmm_connections___connections_returned(
         reservation = MultiSessionReservation(session_management_client, grpc_session_infos)
         sessions = create_mock_nidmm_sessions(4)
         session_new.side_effect = sessions
-        session_infos = stack.enter_context(reservation.create_nidmm_sessions())
+        session_infos = stack.enter_context(reservation.initialize_nidmm_sessions())
 
         connections = reservation.get_nidmm_connections(**kwargs)
 

--- a/tests/unit/_drivers/test_nifgen.py
+++ b/tests/unit/_drivers/test_nifgen.py
@@ -34,7 +34,7 @@ if nifgen:
     set_nifgen_simulation_options = functools.partial(set_simulation_options, "nifgen")
 
 
-def test___single_session_info___create_nifgen_session___session_created(
+def test___single_session_info___initialize_nifgen_session___session_created(
     session_new: Mock,
     session_management_client: Mock,
 ) -> None:
@@ -42,7 +42,7 @@ def test___single_session_info___create_nifgen_session___session_created(
     session = create_mock_nifgen_session()
     session_new.side_effect = [session]
 
-    with reservation.create_nifgen_session() as session_info:
+    with reservation.initialize_nifgen_session() as session_info:
         assert session_info.session is session
 
     session_new.assert_called_once_with(
@@ -50,7 +50,7 @@ def test___single_session_info___create_nifgen_session___session_created(
     )
 
 
-def test___multiple_session_infos___create_nifgen_sessions___sessions_created(
+def test___multiple_session_infos___initialize_nifgen_sessions___sessions_created(
     session_new: Mock,
     session_management_client: Mock,
 ) -> None:
@@ -58,7 +58,7 @@ def test___multiple_session_infos___create_nifgen_sessions___sessions_created(
     sessions = create_mock_nifgen_sessions(3)
     session_new.side_effect = sessions
 
-    with reservation.create_nifgen_sessions() as session_info:
+    with reservation.initialize_nifgen_sessions() as session_info:
         assert session_info[0].session == sessions[0]
         assert session_info[1].session == sessions[1]
 
@@ -70,7 +70,7 @@ def test___multiple_session_infos___create_nifgen_sessions___sessions_created(
     )
 
 
-def test___optional_args___create_nifgen_session___optional_args_passed(
+def test___optional_args___initialize_nifgen_session___optional_args_passed(
     session_new: Mock,
     session_management_client: Mock,
 ) -> None:
@@ -78,7 +78,7 @@ def test___optional_args___create_nifgen_session___optional_args_passed(
     session = create_mock_nifgen_session()
     session_new.side_effect = [session]
 
-    with reservation.create_nifgen_session(
+    with reservation.initialize_nifgen_session(
         reset_device=True,
         options={"simulate": False},
         initialization_behavior=SessionInitializationBehavior.INITIALIZE_SERVER_SESSION,
@@ -98,7 +98,7 @@ def test___optional_args___create_nifgen_session___optional_args_passed(
     )
 
 
-def test___simulation_configured___create_nifgen_session___simulation_options_passed(
+def test___simulation_configured___initialize_nifgen_session___simulation_options_passed(
     mocker: MockerFixture,
     session_new: Mock,
     session_management_client: Mock,
@@ -108,7 +108,7 @@ def test___simulation_configured___create_nifgen_session___simulation_options_pa
     session = create_mock_nifgen_session()
     session_new.side_effect = [session]
 
-    with reservation.create_nifgen_session():
+    with reservation.initialize_nifgen_session():
         pass
 
     expected_options = {
@@ -124,7 +124,7 @@ def test___simulation_configured___create_nifgen_session___simulation_options_pa
     )
 
 
-def test___optional_args_and_simulation_configured___create_nifgen_session___optional_args_passed(
+def test___optional_args_and_simulation_configured___initialize_nifgen_session___optional_args_passed(
     mocker: MockerFixture,
     session_new: Mock,
     session_management_client: Mock,
@@ -134,7 +134,7 @@ def test___optional_args_and_simulation_configured___create_nifgen_session___opt
     session = create_mock_nifgen_session()
     session_new.side_effect = [session]
 
-    with reservation.create_nifgen_session(reset_device=True, options={"simulate": False}):
+    with reservation.initialize_nifgen_session(reset_device=True, options={"simulate": False}):
         pass
 
     expected_options = {"simulate": False}
@@ -174,7 +174,7 @@ def test___session_created___get_nifgen_connection___connection_returned(
         reservation = MultiSessionReservation(session_management_client, grpc_session_infos)
         sessions = create_mock_nifgen_sessions(2)
         session_new.side_effect = sessions
-        session_infos = stack.enter_context(reservation.create_nifgen_sessions())
+        session_infos = stack.enter_context(reservation.initialize_nifgen_sessions())
 
         connection = reservation.get_nifgen_connection(**kwargs)
 
@@ -209,7 +209,7 @@ def test___session_created___get_nifgen_connections___connections_returned(
         reservation = MultiSessionReservation(session_management_client, grpc_session_infos)
         sessions = create_mock_nifgen_sessions(2)
         session_new.side_effect = sessions
-        session_infos = stack.enter_context(reservation.create_nifgen_sessions())
+        session_infos = stack.enter_context(reservation.initialize_nifgen_sessions())
 
         connections = reservation.get_nifgen_connections(**kwargs)
 

--- a/tests/unit/_drivers/test_niscope.py
+++ b/tests/unit/_drivers/test_niscope.py
@@ -34,7 +34,7 @@ if niscope:
     set_niscope_simulation_options = functools.partial(set_simulation_options, "niscope")
 
 
-def test___single_session_info___create_niscope_session___session_created(
+def test___single_session_info___initialize_niscope_session___session_created(
     session_new: Mock,
     session_management_client: Mock,
 ) -> None:
@@ -44,7 +44,7 @@ def test___single_session_info___create_niscope_session___session_created(
     session = create_mock_niscope_session()
     session_new.side_effect = [session]
 
-    with reservation.create_niscope_session() as session_info:
+    with reservation.initialize_niscope_session() as session_info:
         assert session_info.session is session
 
     session_new.assert_called_once_with(
@@ -52,7 +52,7 @@ def test___single_session_info___create_niscope_session___session_created(
     )
 
 
-def test___multiple_session_infos___create_niscope_sessions___sessions_created(
+def test___multiple_session_infos___initialize_niscope_sessions___sessions_created(
     session_new: Mock,
     session_management_client: Mock,
 ) -> None:
@@ -62,7 +62,7 @@ def test___multiple_session_infos___create_niscope_sessions___sessions_created(
     sessions = create_mock_niscope_sessions(3)
     session_new.side_effect = sessions
 
-    with reservation.create_niscope_sessions() as session_info:
+    with reservation.initialize_niscope_sessions() as session_info:
         assert session_info[0].session == sessions[0]
         assert session_info[1].session == sessions[1]
 
@@ -74,7 +74,7 @@ def test___multiple_session_infos___create_niscope_sessions___sessions_created(
     )
 
 
-def test___optional_args___create_niscope_session___optional_args_passed(
+def test___optional_args___initialize_niscope_session___optional_args_passed(
     session_new: Mock,
     session_management_client: Mock,
 ) -> None:
@@ -84,7 +84,7 @@ def test___optional_args___create_niscope_session___optional_args_passed(
     session = create_mock_niscope_session()
     session_new.side_effect = [session]
 
-    with reservation.create_niscope_session(
+    with reservation.initialize_niscope_session(
         reset_device=True,
         options={"simulate": False},
         initialization_behavior=SessionInitializationBehavior.INITIALIZE_SERVER_SESSION,
@@ -104,7 +104,7 @@ def test___optional_args___create_niscope_session___optional_args_passed(
     )
 
 
-def test___simulation_configured___create_niscope_session___simulation_options_passed(
+def test___simulation_configured___initialize_niscope_session___simulation_options_passed(
     mocker: MockerFixture,
     session_new: Mock,
     session_management_client: Mock,
@@ -116,7 +116,7 @@ def test___simulation_configured___create_niscope_session___simulation_options_p
     session = create_mock_niscope_session()
     session_new.side_effect = [session]
 
-    with reservation.create_niscope_session():
+    with reservation.initialize_niscope_session():
         pass
 
     expected_options = {
@@ -132,7 +132,7 @@ def test___simulation_configured___create_niscope_session___simulation_options_p
     )
 
 
-def test___optional_args_and_simulation_configured___create_niscope_session___optional_args_passed(
+def test___optional_args_and_simulation_configured___initialize_niscope_session___optional_args_passed(
     mocker: MockerFixture,
     session_new: Mock,
     session_management_client: Mock,
@@ -144,7 +144,7 @@ def test___optional_args_and_simulation_configured___create_niscope_session___op
     session = create_mock_niscope_session()
     session_new.side_effect = [session]
 
-    with reservation.create_niscope_session(reset_device=True, options={"simulate": False}):
+    with reservation.initialize_niscope_session(reset_device=True, options={"simulate": False}):
         pass
 
     expected_options = {"simulate": False}
@@ -182,7 +182,7 @@ def test___session_created___get_niscope_connection___connection_returned(
         reservation = MultiSessionReservation(session_management_client, grpc_session_infos)
         sessions = create_mock_niscope_sessions(2)
         session_new.side_effect = sessions
-        session_infos = stack.enter_context(reservation.create_niscope_sessions())
+        session_infos = stack.enter_context(reservation.initialize_niscope_sessions())
 
         connection = reservation.get_niscope_connection(**kwargs)
 
@@ -217,7 +217,7 @@ def test___session_created___get_niscope_connections___connections_returned(
         reservation = MultiSessionReservation(session_management_client, grpc_session_infos)
         sessions = create_mock_niscope_sessions(2)
         session_new.side_effect = sessions
-        session_infos = stack.enter_context(reservation.create_niscope_sessions())
+        session_infos = stack.enter_context(reservation.initialize_niscope_sessions())
 
         connections = reservation.get_niscope_connections(**kwargs)
 

--- a/tests/unit/_drivers/test_niswitch.py
+++ b/tests/unit/_drivers/test_niswitch.py
@@ -30,7 +30,7 @@ if niswitch:
     )
 
 
-def test___single_session_info___create_niswitch_session___session_created(
+def test___single_session_info___initialize_niswitch_session___session_created(
     session_new: Mock,
     session_management_client: Mock,
 ) -> None:
@@ -40,7 +40,7 @@ def test___single_session_info___create_niswitch_session___session_created(
     session = create_mock_niswitch_session()
     session_new.side_effect = [session]
 
-    with reservation.create_niswitch_session() as session_info:
+    with reservation.initialize_niswitch_session() as session_info:
         assert session_info.session is session
 
     session_new.assert_called_once_with(
@@ -53,7 +53,7 @@ def test___single_session_info___create_niswitch_session___session_created(
     )
 
 
-def test___multiple_session_infos___create_niswitch_sessions___sessions_created(
+def test___multiple_session_infos___initialize_niswitch_sessions___sessions_created(
     session_new: Mock,
     session_management_client: Mock,
 ) -> None:
@@ -63,7 +63,7 @@ def test___multiple_session_infos___create_niswitch_sessions___sessions_created(
     sessions = create_mock_niswitch_sessions(3)
     session_new.side_effect = sessions
 
-    with reservation.create_niswitch_sessions() as session_info:
+    with reservation.initialize_niswitch_sessions() as session_info:
         assert session_info[0].session == sessions[0]
         assert session_info[1].session == sessions[1]
 
@@ -87,7 +87,7 @@ def test___multiple_session_infos___create_niswitch_sessions___sessions_created(
 
 # For NI-SWITCH, we set resource_name to "" when simulate is True.
 @pytest.mark.parametrize("simulate,expected_resource_name", [(False, "Dev0"), (True, "")])
-def test___optional_args___create_niswitch_session___optional_args_passed(
+def test___optional_args___initialize_niswitch_session___optional_args_passed(
     simulate: bool,
     expected_resource_name: str,
     session_new: Mock,
@@ -99,7 +99,7 @@ def test___optional_args___create_niswitch_session___optional_args_passed(
     session = create_mock_niswitch_session()
     session_new.side_effect = [session]
 
-    with reservation.create_niswitch_session(
+    with reservation.initialize_niswitch_session(
         topology="2567/Independent",
         simulate=simulate,
         reset_device=True,
@@ -121,7 +121,7 @@ def test___optional_args___create_niswitch_session___optional_args_passed(
     )
 
 
-def test___simulation_configured___create_niswitch_session___simulation_options_passed(
+def test___simulation_configured___initialize_niswitch_session___simulation_options_passed(
     mocker: MockerFixture,
     session_new: Mock,
     session_management_client: Mock,
@@ -133,7 +133,7 @@ def test___simulation_configured___create_niswitch_session___simulation_options_
     session = create_mock_niswitch_session()
     session_new.side_effect = [session]
 
-    with reservation.create_niswitch_session():
+    with reservation.initialize_niswitch_session():
         pass
 
     session_new.assert_called_once_with(
@@ -146,7 +146,7 @@ def test___simulation_configured___create_niswitch_session___simulation_options_
     )
 
 
-def test___optional_args_and_simulation_configured___create_niswitch_session___optional_args_passed(
+def test___optional_args_and_simulation_configured___initialize_niswitch_session___optional_args_passed(
     mocker: MockerFixture,
     session_new: Mock,
     session_management_client: Mock,
@@ -158,7 +158,7 @@ def test___optional_args_and_simulation_configured___create_niswitch_session___o
     session = create_mock_niswitch_session()
     session_new.side_effect = [session]
 
-    with reservation.create_niswitch_session(
+    with reservation.initialize_niswitch_session(
         topology="2529/2-Wire 4x32 Matrix", simulate=False, reset_device=True
     ):
         pass
@@ -199,7 +199,7 @@ def test___session_created___get_niswitch_connection___connection_returned(
         reservation = MultiSessionReservation(session_management_client, grpc_session_infos)
         sessions = create_mock_niswitch_sessions(2)
         session_new.side_effect = sessions
-        session_infos = stack.enter_context(reservation.create_niswitch_sessions())
+        session_infos = stack.enter_context(reservation.initialize_niswitch_sessions())
 
         connection = reservation.get_niswitch_connection(**kwargs)
 
@@ -238,7 +238,7 @@ def test___session_created___get_niswitch_connections___connections_returned(
         reservation = MultiSessionReservation(session_management_client, grpc_session_infos)
         sessions = create_mock_niswitch_sessions(2)
         session_new.side_effect = sessions
-        session_infos = stack.enter_context(reservation.create_niswitch_sessions())
+        session_infos = stack.enter_context(reservation.initialize_niswitch_sessions())
 
         connections = reservation.get_niswitch_connections(**kwargs)
 

--- a/tests/unit/test_reservation.py
+++ b/tests/unit/test_reservation.py
@@ -23,33 +23,33 @@ create_nifake_session_infos = functools.partial(create_grpc_session_infos, "nifa
 create_nifoo_session_infos = functools.partial(create_grpc_session_infos, "nifoo")
 
 
-def test___single_session_info___create_session___session_info_yielded(
+def test___single_session_info___initialize_session___session_info_yielded(
     session_management_client: Mock,
 ) -> None:
     reservation = MultiSessionReservation(session_management_client, create_nifake_session_infos(1))
 
-    with reservation.create_session(_construct_session, "nifake") as session_info:
+    with reservation.initialize_session(_construct_session, "nifake") as session_info:
         assert session_info.session_name == "MySession0"
         assert session_info.resource_name == "Dev0"
         assert session_info.instrument_type_id == "nifake"
 
 
-def test___single_session_info___create_session___session_created(
+def test___single_session_info___initialize_session___session_created(
     session_management_client: Mock,
 ) -> None:
     reservation = MultiSessionReservation(session_management_client, create_nifake_session_infos(1))
 
-    with reservation.create_session(_construct_session, "nifake") as session_info:
+    with reservation.initialize_session(_construct_session, "nifake") as session_info:
         assert isinstance(session_info.session, fake_driver.Session)
         assert session_info.session.resource_name == "Dev0"
 
 
-def test___single_session_info___create_session___session_lifetime_tracked(
+def test___single_session_info___initialize_session___session_lifetime_tracked(
     session_management_client: Mock,
 ) -> None:
     reservation = MultiSessionReservation(session_management_client, create_nifake_session_infos(1))
 
-    with reservation.create_session(_construct_session, "nifake") as session_info:
+    with reservation.initialize_session(_construct_session, "nifake") as session_info:
         assert reservation._session_cache["MySession0"] is session_info.session
         assert not session_info.session.is_closed
 
@@ -57,37 +57,37 @@ def test___single_session_info___create_session___session_lifetime_tracked(
     assert session_info.session.is_closed
 
 
-def test___empty_instrument_type_id___create_session___value_error_raised(
+def test___empty_instrument_type_id___initialize_session___value_error_raised(
     session_management_client: Mock,
 ) -> None:
     reservation = MultiSessionReservation(session_management_client, create_nifake_session_infos(1))
 
     with pytest.raises(ValueError) as exc_info:
-        with reservation.create_session(_construct_session, ""):
+        with reservation.initialize_session(_construct_session, ""):
             pass
 
     assert "This method requires an instrument type ID." in exc_info.value.args[0]
 
 
-def test___no_session_infos___create_session___value_error_raised(
+def test___no_session_infos___initialize_session___value_error_raised(
     session_management_client: Mock,
 ) -> None:
     reservation = MultiSessionReservation(session_management_client, create_nifake_session_infos(0))
 
     with pytest.raises(ValueError) as exc_info:
-        with reservation.create_session(_construct_session, "nifake"):
+        with reservation.initialize_session(_construct_session, "nifake"):
             pass
 
     assert "No reserved sessions matched instrument type ID 'nifake'." in exc_info.value.args[0]
 
 
-def test___multiple_session_infos___create_session___value_error_raised(
+def test___multiple_session_infos___initialize_session___value_error_raised(
     session_management_client: Mock,
 ) -> None:
     reservation = MultiSessionReservation(session_management_client, create_nifake_session_infos(2))
 
     with pytest.raises(ValueError) as exc_info:
-        with reservation.create_session(_construct_session, "nifake"):
+        with reservation.initialize_session(_construct_session, "nifake"):
             pass
 
     assert (
@@ -95,41 +95,41 @@ def test___multiple_session_infos___create_session___value_error_raised(
     )
 
 
-def test___session_already_exists___create_session___runtime_error_raised(
+def test___session_already_exists___initialize_session___runtime_error_raised(
     session_management_client: Mock,
 ) -> None:
     reservation = MultiSessionReservation(session_management_client, create_nifake_session_infos(1))
 
-    with reservation.create_session(_construct_session, "nifake"):
+    with reservation.initialize_session(_construct_session, "nifake"):
         with pytest.raises(RuntimeError) as exc_info:
-            with reservation.create_session(_construct_session, "nifake"):
+            with reservation.initialize_session(_construct_session, "nifake"):
                 pass
 
     assert "Session 'MySession0' already exists." in exc_info.value.args[0]
 
 
-def test___heterogenous_session_infos___create_session___grouped_by_instrument_type(
+def test___heterogenous_session_infos___initialize_session___grouped_by_instrument_type(
     session_management_client: Mock,
 ) -> None:
     grpc_session_infos = create_nifoo_session_infos(2)
     grpc_session_infos[1].instrument_type_id = "nibar"
     reservation = MultiSessionReservation(session_management_client, grpc_session_infos)
 
-    with reservation.create_session(
+    with reservation.initialize_session(
         _construct_session, "nifoo"
-    ) as nifoo_info, reservation.create_session(_construct_session, "nibar") as nibar_info:
+    ) as nifoo_info, reservation.initialize_session(_construct_session, "nibar") as nibar_info:
         assert nifoo_info.session_name == "MySession0"
         assert nifoo_info.instrument_type_id == "nifoo"
         assert nibar_info.session_name == "MySession1"
         assert nibar_info.instrument_type_id == "nibar"
 
 
-def test___multiple_session_infos___create_sessions___session_infos_yielded(
+def test___multiple_session_infos___initialize_sessions___session_infos_yielded(
     session_management_client: Mock,
 ) -> None:
     reservation = MultiSessionReservation(session_management_client, create_nifake_session_infos(3))
 
-    with reservation.create_sessions(_construct_session, "nifake") as session_infos:
+    with reservation.initialize_sessions(_construct_session, "nifake") as session_infos:
         assert [info.session_name for info in session_infos] == [
             "MySession0",
             "MySession1",
@@ -139,22 +139,22 @@ def test___multiple_session_infos___create_sessions___session_infos_yielded(
         assert [info.instrument_type_id for info in session_infos] == ["nifake", "nifake", "nifake"]
 
 
-def test___multiple_session_infos___create_sessions___sessions_created(
+def test___multiple_session_infos___initialize_sessions___sessions_created(
     session_management_client: Mock,
 ) -> None:
     reservation = MultiSessionReservation(session_management_client, create_nifake_session_infos(3))
 
-    with reservation.create_sessions(_construct_session, "nifake") as session_infos:
+    with reservation.initialize_sessions(_construct_session, "nifake") as session_infos:
         assert all([isinstance(info.session, fake_driver.Session) for info in session_infos])
         assert [info.session.resource_name for info in session_infos] == ["Dev0", "Dev1", "Dev2"]
 
 
-def test___multiple_session_infos___create_sessions___session_lifetime_tracked(
+def test___multiple_session_infos___initialize_sessions___session_lifetime_tracked(
     session_management_client: Mock,
 ) -> None:
     reservation = MultiSessionReservation(session_management_client, create_nifake_session_infos(3))
 
-    with reservation.create_sessions(_construct_session, "nifake") as session_infos:
+    with reservation.initialize_sessions(_construct_session, "nifake") as session_infos:
         assert reservation._session_cache["MySession0"] is session_infos[0].session
         assert reservation._session_cache["MySession1"] is session_infos[1].session
         assert reservation._session_cache["MySession2"] is session_infos[2].session
@@ -164,53 +164,53 @@ def test___multiple_session_infos___create_sessions___session_lifetime_tracked(
     assert all([info.session.is_closed for info in session_infos])
 
 
-def test___empty_instrument_type_id___create_sessions___value_error_raised(
+def test___empty_instrument_type_id___initialize_sessions___value_error_raised(
     session_management_client: Mock,
 ) -> None:
     reservation = MultiSessionReservation(session_management_client, create_nifake_session_infos(3))
 
     with pytest.raises(ValueError) as exc_info:
-        with reservation.create_sessions(_construct_session, ""):
+        with reservation.initialize_sessions(_construct_session, ""):
             pass
 
     assert "This method requires an instrument type ID." in exc_info.value.args[0]
 
 
-def test___no_session_infos___create_sessions___value_error_raised(
+def test___no_session_infos___initialize_sessions___value_error_raised(
     session_management_client: Mock,
 ) -> None:
     reservation = MultiSessionReservation(session_management_client, [])
 
     with pytest.raises(ValueError) as exc_info:
-        with reservation.create_sessions(_construct_session, "nifake"):
+        with reservation.initialize_sessions(_construct_session, "nifake"):
             pass
 
     assert "No reserved sessions matched instrument type ID 'nifake'." in exc_info.value.args[0]
 
 
-def test___session_already_exists___create_sessions___runtime_error_raised(
+def test___session_already_exists___initialize_sessions___runtime_error_raised(
     session_management_client: Mock,
 ) -> None:
     reservation = MultiSessionReservation(session_management_client, create_nifake_session_infos(3))
 
-    with reservation.create_sessions(_construct_session, "nifake"):
+    with reservation.initialize_sessions(_construct_session, "nifake"):
         with pytest.raises(RuntimeError) as exc_info:
-            with reservation.create_sessions(_construct_session, "nifake"):
+            with reservation.initialize_sessions(_construct_session, "nifake"):
                 pass
 
     assert "Session 'MySession0' already exists." in exc_info.value.args[0]
 
 
-def test___heterogenous_session_infos___create_sessions___grouped_by_instrument_type(
+def test___heterogenous_session_infos___initialize_sessions___grouped_by_instrument_type(
     session_management_client: Mock,
 ) -> None:
     grpc_session_infos = create_nifoo_session_infos(3)
     grpc_session_infos[1].instrument_type_id = "nibar"
     reservation = MultiSessionReservation(session_management_client, grpc_session_infos)
 
-    with reservation.create_sessions(
+    with reservation.initialize_sessions(
         _construct_session, "nifoo"
-    ) as nifoo_infos, reservation.create_sessions(_construct_session, "nibar") as nibar_infos:
+    ) as nifoo_infos, reservation.initialize_sessions(_construct_session, "nibar") as nibar_infos:
         assert [info.session_name for info in nifoo_infos] == ["MySession0", "MySession2"]
         assert [info.instrument_type_id for info in nifoo_infos] == ["nifoo", "nifoo"]
         assert [info.session_name for info in nibar_infos] == ["MySession1"]
@@ -224,7 +224,9 @@ def test___single_connection___get_connection___connection_returned(
         grpc_session_infos = create_nifake_session_infos(1)
         grpc_session_infos[0].channel_mappings.add(pin_or_relay_name="Pin1", site=2, channel="3")
         reservation = MultiSessionReservation(session_management_client, grpc_session_infos)
-        session_info = stack.enter_context(reservation.create_session(_construct_session, "nifake"))
+        session_info = stack.enter_context(
+            reservation.initialize_session(_construct_session, "nifake")
+        )
 
         connection = reservation.get_connection(fake_driver.Session)
 
@@ -242,7 +244,7 @@ def test___multiple_connections___get_connection___value_error_raised(
         grpc_session_infos[0].channel_mappings.add(pin_or_relay_name="Pin1", site=2, channel="3")
         grpc_session_infos[0].channel_mappings.add(pin_or_relay_name="Pin4", site=5, channel="6")
         reservation = MultiSessionReservation(session_management_client, grpc_session_infos)
-        _ = stack.enter_context(reservation.create_session(_construct_session, "nifake"))
+        _ = stack.enter_context(reservation.initialize_session(_construct_session, "nifake"))
 
         with pytest.raises(ValueError) as exc_info:
             _ = reservation.get_connection(fake_driver.Session)
@@ -276,7 +278,7 @@ def test___invalid_argument_type___get_connection___type_error_raised(
         grpc_session_infos = create_nifake_session_infos(1)
         grpc_session_infos[0].channel_mappings.add(pin_or_relay_name="Pin1", site=2, channel="3")
         reservation = MultiSessionReservation(session_management_client, grpc_session_infos)
-        _ = stack.enter_context(reservation.create_session(_construct_session, "nifake"))
+        _ = stack.enter_context(reservation.initialize_session(_construct_session, "nifake"))
 
         with pytest.raises(TypeError) as exc_info:
             _ = reservation.get_connection(fake_driver.Session, **kwargs)
@@ -291,7 +293,7 @@ def test___wrong_pins___get_connections___value_error_raised(
         grpc_session_infos = create_nifake_session_infos(1)
         grpc_session_infos[0].channel_mappings.add(pin_or_relay_name="Pin1", site=2, channel="3")
         reservation = MultiSessionReservation(session_management_client, grpc_session_infos)
-        _ = stack.enter_context(reservation.create_session(_construct_session, "nifake"))
+        _ = stack.enter_context(reservation.initialize_session(_construct_session, "nifake"))
 
         with pytest.raises(ValueError) as exc_info:
             _ = reservation.get_connections(fake_driver.Session, ["Pin1", "Pin2", "Pin3"])
@@ -309,7 +311,7 @@ def test___wrong_sites___get_connections___value_error_raised(
         grpc_session_infos = create_nifake_session_infos(1)
         grpc_session_infos[0].channel_mappings.add(pin_or_relay_name="Pin1", site=2, channel="3")
         reservation = MultiSessionReservation(session_management_client, grpc_session_infos)
-        _ = stack.enter_context(reservation.create_session(_construct_session, "nifake"))
+        _ = stack.enter_context(reservation.initialize_session(_construct_session, "nifake"))
 
         with pytest.raises(ValueError) as exc_info:
             _ = reservation.get_connections(fake_driver.Session, sites=[1, 2, 3])
@@ -324,7 +326,7 @@ def test___wrong_instrument_type_id___get_connections___value_error_raised(
         grpc_session_infos = create_nifake_session_infos(1)
         grpc_session_infos[0].channel_mappings.add(pin_or_relay_name="Pin1", site=2, channel="3")
         reservation = MultiSessionReservation(session_management_client, grpc_session_infos)
-        _ = stack.enter_context(reservation.create_session(_construct_session, "nifake"))
+        _ = stack.enter_context(reservation.initialize_session(_construct_session, "nifake"))
 
         with pytest.raises(ValueError) as exc_info:
             _ = reservation.get_connections(fake_driver.Session, instrument_type_id="nifoo")
@@ -346,7 +348,9 @@ def test___multiple_connections___get_connection_with_pin_name___connection_retu
         grpc_session_infos[0].channel_mappings.add(pin_or_relay_name="Pin1", site=2, channel="3")
         grpc_session_infos[0].channel_mappings.add(pin_or_relay_name="Pin4", site=5, channel="6")
         reservation = MultiSessionReservation(session_management_client, grpc_session_infos)
-        session_info = stack.enter_context(reservation.create_session(_construct_session, "nifake"))
+        session_info = stack.enter_context(
+            reservation.initialize_session(_construct_session, "nifake")
+        )
 
         connection = reservation.get_connection(fake_driver.Session, pin_name)
 
@@ -368,7 +372,9 @@ def test___multiple_connections___get_connection_with_site___connection_returned
         grpc_session_infos[0].channel_mappings.add(pin_or_relay_name="Pin1", site=2, channel="3")
         grpc_session_infos[0].channel_mappings.add(pin_or_relay_name="Pin4", site=5, channel="6")
         reservation = MultiSessionReservation(session_management_client, grpc_session_infos)
-        session_info = stack.enter_context(reservation.create_session(_construct_session, "nifake"))
+        session_info = stack.enter_context(
+            reservation.initialize_session(_construct_session, "nifake")
+        )
 
         connection = reservation.get_connection(fake_driver.Session, site=site)
 
@@ -395,8 +401,12 @@ def test___heterogenous_session_infos___get_connection_with_instrument_type_id__
         grpc_session_infos[1].channel_mappings.add(pin_or_relay_name="Pin4", site=5, channel="6")
         grpc_session_infos[1].instrument_type_id = "nibar"
         reservation = MultiSessionReservation(session_management_client, grpc_session_infos)
-        nifoo_info = stack.enter_context(reservation.create_session(_construct_session, "nifoo"))
-        nibar_info = stack.enter_context(reservation.create_session(_construct_session, "nibar"))
+        nifoo_info = stack.enter_context(
+            reservation.initialize_session(_construct_session, "nifoo")
+        )
+        nibar_info = stack.enter_context(
+            reservation.initialize_session(_construct_session, "nibar")
+        )
 
         connection = reservation.get_connection(
             fake_driver.Session, instrument_type_id=instrument_type_id
@@ -420,8 +430,12 @@ def test___heterogenous_session_infos___get_connections___connections_returned(
         grpc_session_infos[1].channel_mappings.add(pin_or_relay_name="Pin4", site=5, channel="6")
         grpc_session_infos[1].instrument_type_id = "nibar"
         reservation = MultiSessionReservation(session_management_client, grpc_session_infos)
-        nifoo_info = stack.enter_context(reservation.create_session(_construct_session, "nifoo"))
-        nibar_info = stack.enter_context(reservation.create_session(_construct_session, "nibar"))
+        nifoo_info = stack.enter_context(
+            reservation.initialize_session(_construct_session, "nifoo")
+        )
+        nibar_info = stack.enter_context(
+            reservation.initialize_session(_construct_session, "nibar")
+        )
 
         connections = reservation.get_connections(fake_driver.Session)
 
@@ -468,8 +482,8 @@ def test___heterogenous_session_infos___get_connections_with_partially_matching_
         grpc_session_infos[1].channel_mappings.add(pin_or_relay_name="Pin4", site=5, channel="6")
         grpc_session_infos[1].instrument_type_id = "nibar"
         reservation = MultiSessionReservation(session_management_client, grpc_session_infos)
-        _ = stack.enter_context(reservation.create_session(_construct_session, "nifoo"))
-        _ = stack.enter_context(reservation.create_session(_construct_session, "nibar"))
+        _ = stack.enter_context(reservation.initialize_session(_construct_session, "nifoo"))
+        _ = stack.enter_context(reservation.initialize_session(_construct_session, "nibar"))
 
         with pytest.raises(ValueError) as exc_info:
             _ = reservation.get_connections(fake_driver.Session, **kwargs)
@@ -484,7 +498,7 @@ def test___wrong_session_type___get_connection___type_error_raised(
         grpc_session_infos = create_nifake_session_infos(1)
         grpc_session_infos[0].channel_mappings.add(pin_or_relay_name="Pin1", site=2, channel="3")
         reservation = MultiSessionReservation(session_management_client, grpc_session_infos)
-        _ = stack.enter_context(reservation.create_session(_construct_session, "nifake"))
+        _ = stack.enter_context(reservation.initialize_session(_construct_session, "nifake"))
 
         with pytest.raises(TypeError) as exc_info:
             _ = reservation.get_connection(int)
@@ -729,7 +743,7 @@ def test___single_session_created___get_session_info___session_info_returned_wit
             session_management_client, create_nifake_session_infos(1)
         )
         expected_session_info = stack.enter_context(
-            reservation.create_session(_construct_session, "nifake")
+            reservation.initialize_session(_construct_session, "nifake")
         )
 
         assert reservation.session_info == expected_session_info
@@ -758,7 +772,7 @@ def test___multiple_sessions_created___get_session_info___session_info_returned_
             session_management_client, create_nifake_session_infos(3)
         )
         expected_session_infos = stack.enter_context(
-            reservation.create_sessions(_construct_session, "nifake")
+            reservation.initialize_sessions(_construct_session, "nifake")
         )
 
         assert reservation.session_info == expected_session_infos


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Rename `create_session(s)` to `initialize_session(s)` for the MI and generic APIs. Keep `create_nidaqmx_task(s)` as-is.

Rename `_create_visa_dmm_session` helper method to `_construct_visa_dmm_session`.

### Why should this Pull Request be merged?

Fixes [AB#2561827](https://dev.azure.com/ni/DevCentral/_workitems/edit/2561827)

Makes the public API more consistent with the `SessionInitializationBehavior` enum and the MI APIs.

### What testing has been done?

Ran tests.