### PR TITLE
service: Enable SESSION_MANAGMEMENT_2024Q1 feature toggle by default

### DIFF
--- a/ni_measurementlink_service/_featuretoggles.py
+++ b/ni_measurementlink_service/_featuretoggles.py
@@ -146,5 +146,5 @@ def requires_feature(
 # Define feature toggle constants here:
 # --------------------------------------
 
-SESSION_MANAGEMENT_2024Q1 = FeatureToggle("SESSION_MANAGEMENT_2024Q1", CodeReadiness.INCOMPLETE)
+SESSION_MANAGEMENT_2024Q1 = FeatureToggle("SESSION_MANAGEMENT_2024Q1", CodeReadiness.RELEASE)
 """Simplified session management APIs for the 2024Q1 release."""


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Enable the SESSION_MANAGMEMENT_2024Q1 feature toggle by default.

### Why should this Pull Request be merged?

The feature is mostly complete and enabling it by default simplifies manual testing.

### What testing has been done?

Ran all tests.