### PR TITLE
examples: Update TestStand code modules for NI-Fgen and NI-Switch examples

### DIFF
--- a/examples/niswitch_control_relays/teststand_niswitch.py
+++ b/examples/niswitch_control_relays/teststand_niswitch.py
@@ -1,10 +1,14 @@
 """Functions to set up and tear down sessions of NI-Switch devices in NI TestStand."""
 from typing import Any
 
-import ni_measurementlink_service as nims
-import niswitch
 from _helpers import GrpcChannelPoolHelper, TestStandSupport
-from _niswitch_helpers import create_session
+from ni_measurementlink_service.discovery import DiscoveryClient
+from ni_measurementlink_service.session_management import (
+    INSTRUMENT_TYPE_NI_RELAY_DRIVER,
+    PinMapContext,
+    SessionInitializationBehavior,
+    SessionManagementClient,
+)
 
 
 def create_niswitch_sessions(sequence_context: Any) -> None:
@@ -15,28 +19,22 @@ def create_niswitch_sessions(sequence_context: Any) -> None:
             (Dynamically typed.)
     """
     with GrpcChannelPoolHelper() as grpc_channel_pool:
-        session_management_client = nims.session_management.Client(
-            grpc_channel=grpc_channel_pool.session_management_channel
-        )
-
         teststand_support = TestStandSupport(sequence_context)
         pin_map_id = teststand_support.get_active_pin_map_id()
+        pin_map_context = PinMapContext(pin_map_id=pin_map_id, sites=None)
 
-        pin_map_context = nims.session_management.PinMapContext(pin_map_id=pin_map_id, sites=None)
-        grpc_device_channel = grpc_channel_pool.get_grpc_device_channel(
-            niswitch.GRPC_SERVICE_INTERFACE_NAME
+        discovery_client = DiscoveryClient(grpc_channel_pool=grpc_channel_pool)
+        session_management_client = SessionManagementClient(
+            discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool
         )
         with session_management_client.reserve_sessions(
-            context=pin_map_context,
-            instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_RELAY_DRIVER,
+            pin_map_context,
+            instrument_type_id=INSTRUMENT_TYPE_NI_RELAY_DRIVER,
         ) as reservation:
-            for session_info in reservation.session_info:
-                # Leave session open
-                _ = create_session(
-                    session_info,
-                    grpc_device_channel,
-                    initialization_behavior=niswitch.SessionInitializationBehavior.INITIALIZE_SERVER_SESSION,
-                )
+            with reservation.initialize_niswitch_sessions(
+                initialization_behavior=SessionInitializationBehavior.INITIALIZE_SESSION_THEN_DETACH
+            ):
+                pass
 
             session_management_client.register_sessions(reservation.session_info)
 
@@ -44,22 +42,19 @@ def create_niswitch_sessions(sequence_context: Any) -> None:
 def destroy_niswitch_sessions() -> None:
     """Destroy and unregister all NI-Switch sessions."""
     with GrpcChannelPoolHelper() as grpc_channel_pool:
-        session_management_client = nims.session_management.Client(
-            grpc_channel=grpc_channel_pool.session_management_channel
-        )
-        grpc_device_channel = grpc_channel_pool.get_grpc_device_channel(
-            niswitch.GRPC_SERVICE_INTERFACE_NAME
+        discovery_client = DiscoveryClient(grpc_channel_pool=grpc_channel_pool)
+        session_management_client = SessionManagementClient(
+            discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool
         )
         with session_management_client.reserve_all_registered_sessions(
-            instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_RELAY_DRIVER,
+            instrument_type_id=INSTRUMENT_TYPE_NI_RELAY_DRIVER,
         ) as reservation:
+            if not reservation.session_info:
+                return
+
             session_management_client.unregister_sessions(reservation.session_info)
 
-            for session_info in reservation.session_info:
-                session = create_session(
-                    session_info,
-                    grpc_device_channel,
-                    initialization_behavior=niswitch.SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION,
-                )
-
-                session.close()
+            with reservation.initialize_niswitch_sessions(
+                initialization_behavior=SessionInitializationBehavior.ATTACH_TO_SESSION_THEN_CLOSE
+            ):
+                pass

--- a/ni_measurementlink_service/_drivers/_nifgen.py
+++ b/ni_measurementlink_service/_drivers/_nifgen.py
@@ -19,6 +19,8 @@ _INITIALIZATION_BEHAVIOR = {
     SessionInitializationBehavior.AUTO: nifgen.SessionInitializationBehavior.AUTO,
     SessionInitializationBehavior.INITIALIZE_SERVER_SESSION: nifgen.SessionInitializationBehavior.INITIALIZE_SERVER_SESSION,
     SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION: nifgen.SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION,
+    SessionInitializationBehavior.INITIALIZE_SESSION_THEN_DETACH: nifgen.SessionInitializationBehavior.INITIALIZE_SERVER_SESSION,
+    SessionInitializationBehavior.ATTACH_TO_SESSION_THEN_CLOSE: nifgen.SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION,
 }
 
 

--- a/ni_measurementlink_service/_drivers/_niswitch.py
+++ b/ni_measurementlink_service/_drivers/_niswitch.py
@@ -19,6 +19,8 @@ _INITIALIZATION_BEHAVIOR = {
     SessionInitializationBehavior.AUTO: niswitch.SessionInitializationBehavior.AUTO,
     SessionInitializationBehavior.INITIALIZE_SERVER_SESSION: niswitch.SessionInitializationBehavior.INITIALIZE_SERVER_SESSION,
     SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION: niswitch.SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION,
+    SessionInitializationBehavior.INITIALIZE_SESSION_THEN_DETACH: niswitch.SessionInitializationBehavior.INITIALIZE_SERVER_SESSION,
+    SessionInitializationBehavior.ATTACH_TO_SESSION_THEN_CLOSE: niswitch.SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION,
 }
 
 

--- a/ni_measurementlink_service/session_management/_reservation.py
+++ b/ni_measurementlink_service/session_management/_reservation.py
@@ -1175,7 +1175,12 @@ class BaseReservation(abc.ABC):
             options,
             initialization_behavior,
         )
-        return self._initialize_session_core(session_constructor, INSTRUMENT_TYPE_NI_FGEN)
+        closing_function = functools.partial(
+            closing_session_with_ts_code_module_support, initialization_behavior
+        )
+        return self._initialize_session_core(
+            session_constructor, INSTRUMENT_TYPE_NI_FGEN, closing_function
+        )
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
     def initialize_nifgen_sessions(
@@ -1219,7 +1224,12 @@ class BaseReservation(abc.ABC):
             options,
             initialization_behavior,
         )
-        return self._initialize_sessions_core(session_constructor, INSTRUMENT_TYPE_NI_FGEN)
+        closing_function = functools.partial(
+            closing_session_with_ts_code_module_support, initialization_behavior
+        )
+        return self._initialize_sessions_core(
+            session_constructor, INSTRUMENT_TYPE_NI_FGEN, closing_function
+        )
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
     def get_nifgen_connection(

--- a/ni_measurementlink_service/session_management/_reservation.py
+++ b/ni_measurementlink_service/session_management/_reservation.py
@@ -1490,7 +1490,12 @@ class BaseReservation(abc.ABC):
             reset_device,
             initialization_behavior,
         )
-        return self._initialize_session_core(session_constructor, INSTRUMENT_TYPE_NI_RELAY_DRIVER)
+        closing_function = functools.partial(
+            closing_session_with_ts_code_module_support, initialization_behavior
+        )
+        return self._initialize_session_core(
+            session_constructor, INSTRUMENT_TYPE_NI_RELAY_DRIVER, closing_function
+        )
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
     def initialize_niswitch_sessions(
@@ -1541,7 +1546,12 @@ class BaseReservation(abc.ABC):
             reset_device,
             initialization_behavior,
         )
-        return self._initialize_sessions_core(session_constructor, INSTRUMENT_TYPE_NI_RELAY_DRIVER)
+        closing_function = functools.partial(
+            closing_session_with_ts_code_module_support, initialization_behavior
+        )
+        return self._initialize_sessions_core(
+            session_constructor, INSTRUMENT_TYPE_NI_RELAY_DRIVER, closing_function
+        )
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
     def get_niswitch_connection(


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Updates the nifgen and niswitch TestStand code modules to use the new session management API. 

Note: Updating the TestStand code modules to use the new session management API will suffice to make sure the simulation config is read from `.env` file.

### Why should this Pull Request be merged?
Uses the same session creation code as for measurements, with simulation via. `.env` file.

### What testing has been done?
Manually tested with TestStand 2021 SP1.