### PR TITLE
Update TestStand code modules for NI-DAQmx and NI-DCPower examples

### DIFF
--- a/examples/nidaqmx_analog_input/teststand_nidaqmx.py
+++ b/examples/nidaqmx_analog_input/teststand_nidaqmx.py
@@ -1,11 +1,14 @@
 """Functions to set up and tear down sessions of NI-DAQmx devices in NI TestStand."""
 from typing import Any
 
-import ni_measurementlink_service as nims
-import nidaqmx
 from _helpers import GrpcChannelPoolHelper, TestStandSupport
-from _nidaqmx_helpers import create_task
-
+from ni_measurementlink_service.discovery import DiscoveryClient
+from ni_measurementlink_service.session_management import (
+    INSTRUMENT_TYPE_NI_DAQMX,
+    PinMapContext,
+    SessionInitializationBehavior,
+    SessionManagementClient,
+)
 
 def create_nidaqmx_tasks(sequence_context: Any) -> None:
     """Create and register all NI-DAQmx tasks.
@@ -15,27 +18,23 @@ def create_nidaqmx_tasks(sequence_context: Any) -> None:
             (Dynamically typed.)
     """
     with GrpcChannelPoolHelper() as grpc_channel_pool:
-        session_management_client = nims.session_management.Client(
-            grpc_channel=grpc_channel_pool.session_management_channel
-        )
         teststand_support = TestStandSupport(sequence_context)
         pin_map_id = teststand_support.get_active_pin_map_id()
+        pin_map_context = PinMapContext(pin_map_id=pin_map_id, sites=None)
 
-        pin_map_context = nims.session_management.PinMapContext(pin_map_id=pin_map_id, sites=None)
-        grpc_device_channel = grpc_channel_pool.get_grpc_device_channel(
-            nidaqmx.GRPC_SERVICE_INTERFACE_NAME
+        discovery_client = DiscoveryClient(grpc_channel_pool=grpc_channel_pool)
+        session_management_client = SessionManagementClient(
+            discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool
         )
+
         with session_management_client.reserve_sessions(
-            context=pin_map_context,
-            instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_DAQMX,
+            pin_map_context, instrument_type_id=INSTRUMENT_TYPE_NI_DAQMX
         ) as reservation:
-            for session_info in reservation.session_info:
-                task = create_task(
-                    session_info,
-                    grpc_device_channel,
-                    initialization_behavior=nidaqmx.SessionInitializationBehavior.INITIALIZE_SERVER_SESSION,
-                )
-                task.ai_channels.add_ai_voltage_chan(session_info.channel_list)
+            with reservation.create_nidaqmx_tasks(
+                initialization_behavior=SessionInitializationBehavior.INITIALIZE_SESSION_THEN_DETACH
+            ):
+                pass
+
 
             session_management_client.register_sessions(reservation.session_info)
 
@@ -43,21 +42,18 @@ def create_nidaqmx_tasks(sequence_context: Any) -> None:
 def destroy_nidaqmx_tasks() -> None:
     """Destroy and unregister all NI-DAQmx tasks."""
     with GrpcChannelPoolHelper() as grpc_channel_pool:
-        session_management_client = nims.session_management.Client(
-            grpc_channel=grpc_channel_pool.session_management_channel
-        )
-        grpc_device_channel = grpc_channel_pool.get_grpc_device_channel(
-            nidaqmx.GRPC_SERVICE_INTERFACE_NAME
+        discovery_client = DiscoveryClient(grpc_channel_pool=grpc_channel_pool)
+        session_management_client = SessionManagementClient(
+            discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool
         )
         with session_management_client.reserve_all_registered_sessions(
-            instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_DAQMX,
+            instrument_type_id=INSTRUMENT_TYPE_NI_DAQMX,
         ) as reservation:
+            if not reservation.session_info:
+                return
+            
             session_management_client.unregister_sessions(reservation.session_info)
-
-            for session_info in reservation.session_info:
-                task = create_task(
-                    session_info,
-                    grpc_device_channel,
-                    initialization_behavior=nidaqmx.SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION,
-                )
-                task.close()
+            with reservation.create_nidaqmx_tasks(
+                initialization_behavior=SessionInitializationBehavior.ATTACH_TO_SESSION_THEN_CLOSE
+            ):
+                pass

--- a/examples/nidaqmx_analog_input/teststand_nidaqmx.py
+++ b/examples/nidaqmx_analog_input/teststand_nidaqmx.py
@@ -10,6 +10,7 @@ from ni_measurementlink_service.session_management import (
     SessionManagementClient,
 )
 
+
 def create_nidaqmx_tasks(sequence_context: Any) -> None:
     """Create and register all NI-DAQmx tasks.
 
@@ -32,9 +33,9 @@ def create_nidaqmx_tasks(sequence_context: Any) -> None:
         ) as reservation:
             with reservation.create_nidaqmx_tasks(
                 initialization_behavior=SessionInitializationBehavior.INITIALIZE_SESSION_THEN_DETACH
-            ):
-                pass
-
+            ) as tasks:
+                for task in tasks:
+                    task.session.ai_channels.add_ai_voltage_chan(task.channel_list)
 
             session_management_client.register_sessions(reservation.session_info)
 
@@ -51,7 +52,7 @@ def destroy_nidaqmx_tasks() -> None:
         ) as reservation:
             if not reservation.session_info:
                 return
-            
+
             session_management_client.unregister_sessions(reservation.session_info)
             with reservation.create_nidaqmx_tasks(
                 initialization_behavior=SessionInitializationBehavior.ATTACH_TO_SESSION_THEN_CLOSE

--- a/examples/nidcpower_source_dc_voltage/teststand_nidcpower.py
+++ b/examples/nidcpower_source_dc_voltage/teststand_nidcpower.py
@@ -1,12 +1,14 @@
 """Functions to set up and tear down sessions of NI-DCPower devices in NI TestStand."""
 from typing import Any
 
-import ni_measurementlink_service as nims
-import nidcpower
-from _constants import USE_SIMULATION
 from _helpers import GrpcChannelPoolHelper, TestStandSupport
-from _nidcpower_helpers import create_session
-
+from ni_measurementlink_service.discovery import DiscoveryClient
+from ni_measurementlink_service.session_management import (
+    INSTRUMENT_TYPE_NI_DCPOWER,
+    PinMapContext,
+    SessionInitializationBehavior,
+    SessionManagementClient,
+)
 
 def create_nidcpower_sessions(sequence_context: Any) -> None:
     """Create and register all NI-DCPower sessions.
@@ -16,50 +18,41 @@ def create_nidcpower_sessions(sequence_context: Any) -> None:
             (Dynamically typed.)
     """
     with GrpcChannelPoolHelper() as grpc_channel_pool:
-        session_management_client = nims.session_management.Client(
-            grpc_channel=grpc_channel_pool.session_management_channel
-        )
-
+        
         teststand_support = TestStandSupport(sequence_context)
         pin_map_id = teststand_support.get_active_pin_map_id()
-        pin_map_context = nims.session_management.PinMapContext(pin_map_id=pin_map_id, sites=None)
-        grpc_device_channel = grpc_channel_pool.get_grpc_device_channel(
-            nidcpower.GRPC_SERVICE_INTERFACE_NAME
+        pin_map_context = PinMapContext(pin_map_id=pin_map_id, sites=None)
+
+        discovery_client = DiscoveryClient(grpc_channel_pool=grpc_channel_pool)
+        session_management_client = SessionManagementClient(
+            discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool
         )
         with session_management_client.reserve_sessions(
-            context=pin_map_context,
-            instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_DCPOWER,
+            pin_map_context, instrument_type_id=INSTRUMENT_TYPE_NI_DCPOWER
         ) as reservation:
-            for session_info in reservation.session_info:
-                # Leave session open
-                _ = create_session(
-                    session_info,
-                    USE_SIMULATION,
-                    grpc_device_channel,
-                    initialization_behavior=nidcpower.SessionInitializationBehavior.INITIALIZE_SERVER_SESSION,
-                )
+            with reservation.create_nidcpower_sessions(
+                initialization_behavior=SessionInitializationBehavior.INITIALIZE_SESSION_THEN_DETACH
+            ):
+                pass
+            
             session_management_client.register_sessions(reservation.session_info)
 
 
 def destroy_nidcpower_sessions() -> None:
     """Destroy and unregister all NI-DCPower sessions."""
     with GrpcChannelPoolHelper() as grpc_channel_pool:
-        session_management_client = nims.session_management.Client(
-            grpc_channel=grpc_channel_pool.session_management_channel
-        )
-        grpc_device_channel = grpc_channel_pool.get_grpc_device_channel(
-            nidcpower.GRPC_SERVICE_INTERFACE_NAME
+        discovery_client = DiscoveryClient(grpc_channel_pool=grpc_channel_pool)
+        session_management_client = SessionManagementClient(
+            discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool
         )
         with session_management_client.reserve_all_registered_sessions(
-            instrument_type_id=nims.session_management.INSTRUMENT_TYPE_NI_DCPOWER,
+            instrument_type_id=INSTRUMENT_TYPE_NI_DCPOWER,
         ) as reservation:
-            session_management_client.unregister_sessions(reservation.session_info)
+            if not reservation.session_info:
+                return
 
-            for session_info in reservation.session_info:
-                session = create_session(
-                    session_info,
-                    USE_SIMULATION,
-                    grpc_device_channel,
-                    initialization_behavior=nidcpower.SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION,
-                )
-                session.close()
+            session_management_client.unregister_sessions(reservation.session_info)
+            with reservation.create_nidcpower_sessions(
+                initialization_behavior=SessionInitializationBehavior.ATTACH_TO_SESSION_THEN_CLOSE
+            ):
+                pass

--- a/examples/nidcpower_source_dc_voltage/teststand_nidcpower.py
+++ b/examples/nidcpower_source_dc_voltage/teststand_nidcpower.py
@@ -10,6 +10,7 @@ from ni_measurementlink_service.session_management import (
     SessionManagementClient,
 )
 
+
 def create_nidcpower_sessions(sequence_context: Any) -> None:
     """Create and register all NI-DCPower sessions.
 
@@ -18,7 +19,6 @@ def create_nidcpower_sessions(sequence_context: Any) -> None:
             (Dynamically typed.)
     """
     with GrpcChannelPoolHelper() as grpc_channel_pool:
-        
         teststand_support = TestStandSupport(sequence_context)
         pin_map_id = teststand_support.get_active_pin_map_id()
         pin_map_context = PinMapContext(pin_map_id=pin_map_id, sites=None)
@@ -34,7 +34,7 @@ def create_nidcpower_sessions(sequence_context: Any) -> None:
                 initialization_behavior=SessionInitializationBehavior.INITIALIZE_SESSION_THEN_DETACH
             ):
                 pass
-            
+
             session_management_client.register_sessions(reservation.session_info)
 
 

--- a/ni_measurementlink_service/_drivers/_nidaqmx.py
+++ b/ni_measurementlink_service/_drivers/_nidaqmx.py
@@ -18,6 +18,8 @@ _INITIALIZATION_BEHAVIOR = {
     SessionInitializationBehavior.AUTO: nidaqmx.SessionInitializationBehavior.AUTO,
     SessionInitializationBehavior.INITIALIZE_SERVER_SESSION: nidaqmx.SessionInitializationBehavior.INITIALIZE_SERVER_SESSION,
     SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION: nidaqmx.SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION,
+    SessionInitializationBehavior.INITIALIZE_SESSION_THEN_DETACH: nidaqmx.SessionInitializationBehavior.INITIALIZE_SERVER_SESSION,
+    SessionInitializationBehavior.ATTACH_TO_SESSION_THEN_CLOSE: nidaqmx.SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION,
 }
 
 

--- a/ni_measurementlink_service/_drivers/_nidcpower.py
+++ b/ni_measurementlink_service/_drivers/_nidcpower.py
@@ -19,6 +19,8 @@ _INITIALIZATION_BEHAVIOR = {
     SessionInitializationBehavior.AUTO: nidcpower.SessionInitializationBehavior.AUTO,
     SessionInitializationBehavior.INITIALIZE_SERVER_SESSION: nidcpower.SessionInitializationBehavior.INITIALIZE_SERVER_SESSION,
     SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION: nidcpower.SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION,
+    SessionInitializationBehavior.INITIALIZE_SESSION_THEN_DETACH: nidcpower.SessionInitializationBehavior.INITIALIZE_SERVER_SESSION,
+    SessionInitializationBehavior.ATTACH_TO_SESSION_THEN_CLOSE: nidcpower.SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION,
 }
 
 

--- a/ni_measurementlink_service/session_management/_reservation.py
+++ b/ni_measurementlink_service/session_management/_reservation.py
@@ -611,7 +611,12 @@ class BaseReservation(abc.ABC):
         session_constructor = SessionConstructor(
             self._discovery_client, self._grpc_channel_pool, initialization_behavior
         )
-        return self._initialize_session_core(session_constructor, INSTRUMENT_TYPE_NI_DAQMX)
+        closing_function = functools.partial(
+            closing_session_with_ts_code_module_support, initialization_behavior
+        )
+        return self._initialize_session_core(
+            session_constructor, INSTRUMENT_TYPE_NI_DAQMX, closing_function
+        )
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
     def create_nidaqmx_tasks(
@@ -643,7 +648,12 @@ class BaseReservation(abc.ABC):
         session_constructor = SessionConstructor(
             self._discovery_client, self._grpc_channel_pool, initialization_behavior
         )
-        return self._initialize_sessions_core(session_constructor, INSTRUMENT_TYPE_NI_DAQMX)
+        closing_function = functools.partial(
+            closing_session_with_ts_code_module_support, initialization_behavior
+        )
+        return self._initialize_sessions_core(
+            session_constructor, INSTRUMENT_TYPE_NI_DAQMX, closing_function
+        )
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
     def get_nidaqmx_connection(
@@ -738,7 +748,12 @@ class BaseReservation(abc.ABC):
         session_constructor = SessionConstructor(
             self._discovery_client, self._grpc_channel_pool, reset, options, initialization_behavior
         )
-        return self._initialize_session_core(session_constructor, INSTRUMENT_TYPE_NI_DCPOWER)
+        closing_function = functools.partial(
+            closing_session_with_ts_code_module_support, initialization_behavior
+        )
+        return self._initialize_session_core(
+            session_constructor, INSTRUMENT_TYPE_NI_DCPOWER, closing_function
+        )
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
     def create_nidcpower_sessions(
@@ -778,7 +793,12 @@ class BaseReservation(abc.ABC):
         session_constructor = SessionConstructor(
             self._discovery_client, self._grpc_channel_pool, reset, options, initialization_behavior
         )
-        return self._initialize_sessions_core(session_constructor, INSTRUMENT_TYPE_NI_DCPOWER)
+        closing_function = functools.partial(
+            closing_session_with_ts_code_module_support, initialization_behavior
+        )
+        return self._initialize_sessions_core(
+            session_constructor, INSTRUMENT_TYPE_NI_DCPOWER, closing_function
+        )
 
     @requires_feature(SESSION_MANAGEMENT_2024Q1)
     def get_nidcpower_connection(


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Updates the ni-daqmx and ni-dcpower TestStand code modules to use the new session management API.

### Why should this Pull Request be merged?
Uses the same session creation code as for measurements, with simulation via. `.env` file.

### What testing has been done?
Manually tested with TestStand 2021 SP1.