### PR TITLE
service: Get MeasurementLink install paths from registry instead of environment variables

### DIFF
--- a/ni_measurementlink_service/discovery/_support.py
+++ b/ni_measurementlink_service/discovery/_support.py
@@ -158,9 +158,9 @@ def _open_key_file(path: str) -> typing.TextIO:
 
 def _get_nipath(name: str) -> pathlib.Path:
     if sys.platform == "win32":
-        access = winreg.KEY_READ
+        access: int = winreg.KEY_READ
         if "64" in name:
-            access = access | winreg.KEY_WOW64_64KEY
+            access |= winreg.KEY_WOW64_64KEY
         with winreg.OpenKey(
             winreg.HKEY_LOCAL_MACHINE,
             r"SOFTWARE\National Instruments\Common\Installer",

--- a/ni_measurementlink_service/discovery/_support.py
+++ b/ni_measurementlink_service/discovery/_support.py
@@ -15,6 +15,7 @@ from ni_measurementlink_service._internal.stubs.ni.measurementlink.discovery.v1 
 
 if sys.platform == "win32":
     import msvcrt
+    import winreg
 
     import win32con
     import win32file
@@ -55,13 +56,7 @@ def _get_discovery_service_location() -> pathlib.PurePath:
 
 def _get_registration_json_file_path() -> pathlib.Path:
     if sys.platform == "win32":
-        return (
-            pathlib.Path(os.environ["ProgramW6432"])
-            / "National Instruments"
-            / "Shared"
-            / "MeasurementLink"
-            / "MeasurementLinkServices.json"
-        )
+        return _get_nipath("NISHAREDDIR64") / "MeasurementLink" / "MeasurementLinkServices.json"
     else:
         raise NotImplementedError("Platform not supported")
 
@@ -123,13 +118,7 @@ def _get_key_file_path(cluster_id: Optional[str] = None) -> pathlib.Path:
 def _get_key_file_directory() -> pathlib.Path:
     version = discovery_service_pb2.DESCRIPTOR.package.split(".")[-1]
     if sys.platform == "win32":
-        return (
-            pathlib.Path(os.environ["ProgramData"])
-            / "National Instruments"
-            / "MeasurementLink"
-            / "Discovery"
-            / version
-        )
+        return _get_nipath("NIPUBAPPDATADIR") / "MeasurementLink" / "Discovery" / version
     else:
         raise NotImplementedError("Platform not supported")
 
@@ -165,3 +154,20 @@ def _open_key_file(path: str) -> typing.TextIO:
         return os.fdopen(crt_file_descriptor, "r", encoding="utf-8-sig")
     else:
         return open(path, "r")
+
+
+def _get_nipath(name: str) -> pathlib.Path:
+    if sys.platform == "win32":
+        access = winreg.KEY_READ
+        if "64" in name:
+            access = access | winreg.KEY_WOW64_64KEY
+        with winreg.OpenKey(
+            winreg.HKEY_LOCAL_MACHINE,
+            r"SOFTWARE\National Instruments\Common\Installer",
+            access=access,
+        ) as key:
+            value, type = winreg.QueryValueEx(key, name)
+            assert type == winreg.REG_SZ
+            return pathlib.Path(value)
+    else:
+        raise NotImplementedError("Platform not supported")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,18 +61,17 @@ def stub_v2(grpc_channel: grpc.Channel) -> v2_measurement_service_pb2_grpc.Measu
 def discovery_service_process() -> Generator[DiscoveryServiceProcess, None, None]:
     """Test fixture that creates discovery service process."""
     if sys.platform != "win32":
-        pytest.skip(
-            f"Platform {sys.platform} is not supported for starting discovery service."
-            "Could not proceed to run the tests."
-        )
-    elif not _get_registration_json_file_path().exists():
-        pytest.skip(
-            "MeasurementLink registration file not found or MeasurementLink not installed."
-            "Could not proceed to run the tests. Install MeasurementLink to create the registration file."
-        )
-    else:
-        with DiscoveryServiceProcess() as proc:
-            yield proc
+        pytest.skip(f"Platform {sys.platform} is not supported for discovery service tests.")
+
+    try:
+        registration_json_file_exists = _get_registration_json_file_path().exists()
+    except FileNotFoundError:  # registry key not found
+        registration_json_file_exists = False
+    if not registration_json_file_exists:
+        pytest.skip("Registration file not found. Ensure that MeasurementLink is installed.")
+
+    with DiscoveryServiceProcess() as proc:
+        yield proc
 
 
 @pytest.fixture(scope="session")

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist = clean, py{38,39,310,311,312}-all-extras
 [testenv]
 skip_install = true
 allowlist_externals = poetry
-passenv = RUNNER_NAME, ProgramW6432, ProgramData
+passenv = RUNNER_NAME
 commands =
    poetry run python --version
    poetry install -v --all-extras


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Change `discovery/_support.py` to get the MeasurementLink install paths from the Windows registry instead of using environment variables like `ProgramW6432` and `ProgramData`.

### Why should this Pull Request be merged?

Eliminate need to list required environment variables in `passenv` in `tox.ini`.

### What testing has been done?

Ran all tests on Windows with 64-bit Python.