### PR TITLE
service: Include TS code module dir in `.env` search

### DIFF
--- a/examples/nivisa_dmm_measurement/teststand_nivisa_dmm.py
+++ b/examples/nivisa_dmm_measurement/teststand_nivisa_dmm.py
@@ -12,8 +12,8 @@ from ni_measurementlink_service.session_management import (
 )
 from ni_measurementlink_service.session_management._types import SessionInformation
 
-# Search for the `.env` file starting with the current directory.
-_config = AutoConfig(str(pathlib.Path.cwd()))
+# Search for the `.env` file starting with this code module's parent directory.
+_config = AutoConfig(str(pathlib.Path(__file__).resolve().parent))
 _VISA_DMM_SIMULATE: bool = _config("MEASUREMENTLINK_VISA_DMM_SIMULATE", default=False, cast=bool)
 
 

--- a/examples/output_voltage_measurement/teststand_nivisa_dmm.py
+++ b/examples/output_voltage_measurement/teststand_nivisa_dmm.py
@@ -12,8 +12,8 @@ from ni_measurementlink_service.session_management import (
 )
 from ni_measurementlink_service.session_management._types import SessionInformation
 
-# Search for the `.env` file starting with the current directory.
-_config = AutoConfig(str(pathlib.Path.cwd()))
+# Search for the `.env` file starting with this code module's parent directory.
+_config = AutoConfig(str(pathlib.Path(__file__).resolve().parent))
 _VISA_DMM_SIMULATE: bool = _config("MEASUREMENTLINK_VISA_DMM_SIMULATE", default=False, cast=bool)
 
 

--- a/ni_measurementlink_service/_configuration.py
+++ b/ni_measurementlink_service/_configuration.py
@@ -1,11 +1,12 @@
 """MeasurementLink configuration options."""
 from __future__ import annotations
 
-import pathlib
 import sys
 from typing import TYPE_CHECKING, Any, Callable, Dict, NamedTuple, TypeVar, Union
 
 from decouple import AutoConfig, Undefined, undefined
+
+from ni_measurementlink_service._dotenvpath import get_dotenv_search_path
 
 if TYPE_CHECKING:
     if sys.version_info >= (3, 11):
@@ -16,8 +17,7 @@ if TYPE_CHECKING:
 
 _PREFIX = "MEASUREMENTLINK"
 
-# Search for the `.env` file starting with the current directory.
-_config = AutoConfig(str(pathlib.Path.cwd()))
+_config = AutoConfig(str(get_dotenv_search_path()))
 
 if TYPE_CHECKING:
     # Work around decouple's lack of type hints.

--- a/ni_measurementlink_service/_dotenvpath.py
+++ b/ni_measurementlink_service/_dotenvpath.py
@@ -1,6 +1,6 @@
 import sys
 import traceback
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Optional
 
 
@@ -43,10 +43,21 @@ def _get_caller_path() -> Optional[Path]:
     for frame, _ in traceback.walk_stack(None):
         if frame.f_code.co_filename:
             module_path = Path(frame.f_code.co_filename)
-            if module_path.exists() and not module_path.is_relative_to(nims_path):
+            if module_path.exists() and not _is_relative_to(module_path, nims_path):
                 return module_path
 
     return None
+
+
+def _is_relative_to(path: PurePath, other: PurePath) -> bool:
+    if sys.version_info >= (3, 9):
+        return path.is_relative_to(other)
+    else:
+        try:
+            _ = path.relative_to(other)
+            return True
+        except ValueError:
+            return False
 
 
 def _get_nims_path() -> Path:

--- a/ni_measurementlink_service/_dotenvpath.py
+++ b/ni_measurementlink_service/_dotenvpath.py
@@ -63,5 +63,5 @@ def _is_relative_to(path: PurePath, other: PurePath) -> bool:
 def _get_nims_path() -> Path:
     """Get the path of the ni_measurementlink_service package."""
     nims_module = sys.modules["ni_measurementlink_service"]
-    assert nims_module.__file__
-    return Path(nims_module.__file__)
+    assert nims_module.__file__ and nims_module.__file__.endswith("__init__.py")
+    return Path(nims_module.__file__).parent

--- a/ni_measurementlink_service/_dotenvpath.py
+++ b/ni_measurementlink_service/_dotenvpath.py
@@ -1,0 +1,56 @@
+import sys
+import traceback
+from pathlib import Path
+from typing import Optional
+
+
+def get_dotenv_search_path() -> Path:
+    """Get the search path for loading the `.env` file."""
+    # Prefer to load the `.env` file from the current directory or its parents.
+    # If the current directory doesn't have a `.env` file, fall back to the
+    # script/EXE path or the TestStand code module path.
+    cwd = Path.cwd()
+    if not _has_dotenv_file(cwd):
+        if script_or_exe_path := _get_script_or_exe_path():
+            return script_or_exe_path.resolve().parent
+        if caller_path := _get_caller_path():
+            return caller_path.resolve().parent
+    return cwd
+
+
+def _has_dotenv_file(dir: Path) -> bool:
+    """Check whether the dir or its parents contains a `.env` file."""
+    return (dir / ".env").exists() or any((p / ".env").exists() for p in dir.parents)
+
+
+def _get_script_or_exe_path() -> Optional[Path]:
+    """Get the path of the top-level script or PyInstaller EXE, if possible."""
+    if getattr(sys, "frozen", False):
+        return Path(sys.executable)
+
+    main_module = sys.modules.get("__main__")
+    if main_module:
+        script_path = getattr(main_module, "__file__", "")
+        if script_path:
+            return Path(script_path)
+
+    return None
+
+
+def _get_caller_path() -> Optional[Path]:
+    """Get the path of the module calling into ni_measurementlink_service, if possible."""
+    nims_path = _get_nims_path()
+    for frame, _ in traceback.walk_stack(None):
+        if frame.f_code.co_filename:
+            module_path = Path(frame.f_code.co_filename)
+            if module_path.exists() and not module_path.is_relative_to(nims_path):
+                return module_path
+
+    return None
+
+
+def _get_nims_path() -> Path:
+    """Get the path of the ni_measurementlink_service package."""
+    nims_module = sys.modules["ni_measurementlink_service"]
+    assert nims_module.__file__
+    return Path(nims_module.__file__)

--- a/ni_measurementlink_service/_dotenvpath.py
+++ b/ni_measurementlink_service/_dotenvpath.py
@@ -1,3 +1,4 @@
+import inspect
 import sys
 import traceback
 from pathlib import Path, PurePath
@@ -40,7 +41,7 @@ def _get_script_or_exe_path() -> Optional[Path]:
 def _get_caller_path() -> Optional[Path]:
     """Get the path of the module calling into ni_measurementlink_service, if possible."""
     nims_path = _get_nims_path()
-    for frame, _ in traceback.walk_stack(None):
+    for frame, _ in traceback.walk_stack(inspect.currentframe()):
         if frame.f_code.co_filename:
             module_path = Path(frame.f_code.co_filename)
             if module_path.exists() and not _is_relative_to(module_path, nims_path):

--- a/tests/unit/test_dotenvpath.py
+++ b/tests/unit/test_dotenvpath.py
@@ -31,5 +31,4 @@ def test___get_script_or_exe_path___returns_pytest_path() -> None:
     path = _dotenvpath._get_script_or_exe_path()
 
     assert path is not None
-    assert path.parent.name in ["pytest", "pytest.exe"]
-    assert path.name == "__main__.py"
+    assert "pytest" in path.parts or "pytest.exe" in path.parts

--- a/tests/unit/test_dotenvpath.py
+++ b/tests/unit/test_dotenvpath.py
@@ -6,8 +6,8 @@ import ni_measurementlink_service
 from ni_measurementlink_service import _dotenvpath
 
 
-@pytest.mark.parametrize("exists", [False, True])
-def test___exists_varies___has_dotenv_file___returns_exists(
+@pytest.mark.parametrize("dotenv_exists", [False, True])
+def test___dotenv_exists_varies___has_dotenv_file___matches_dotenv_exists(
     dotenv_exists: bool, tmp_path: Path
 ) -> None:
     if dotenv_exists:
@@ -31,4 +31,6 @@ def test___get_nims_path___returns_nims_path() -> None:
 def test___get_script_or_exe_path___returns_pytest_path() -> None:
     path = _dotenvpath._get_script_or_exe_path()
 
-    assert path.parent.name in ["pytest", "pytest.exe"] and path.name == "__main__.py"
+    assert path is not None
+    assert path.parent.name in ["pytest", "pytest.exe"]
+    assert path.name == "__main__.py"

--- a/tests/unit/test_dotenvpath.py
+++ b/tests/unit/test_dotenvpath.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import pytest
 
-import ni_measurementlink_service
 from ni_measurementlink_service import _dotenvpath
 
 
@@ -24,8 +23,8 @@ def test___get_caller_path___returns_this_modules_path() -> None:
     assert _dotenvpath._get_caller_path() == Path(__file__)
 
 
-def test___get_nims_path___returns_nims_path() -> None:
-    assert _dotenvpath._get_nims_path() == Path(ni_measurementlink_service.__file__)
+def test___get_nims_path___returns_package_dir() -> None:
+    assert _dotenvpath._get_nims_path() == Path(_dotenvpath.__file__).parent
 
 
 def test___get_script_or_exe_path___returns_pytest_path() -> None:

--- a/tests/unit/test_dotenvpath.py
+++ b/tests/unit/test_dotenvpath.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+import pytest
+
+import ni_measurementlink_service
+from ni_measurementlink_service import _dotenvpath
+
+
+@pytest.mark.parametrize("exists", [False, True])
+def test___exists_varies___has_dotenv_file___returns_exists(
+    dotenv_exists: bool, tmp_path: Path
+) -> None:
+    if dotenv_exists:
+        (tmp_path / ".env").write_text("")
+    subdirs = [tmp_path / "a", tmp_path / "a" / "b", tmp_path / "a" / "b" / "c"]
+    for dir in subdirs:
+        dir.mkdir()
+
+    assert _dotenvpath._has_dotenv_file(tmp_path) == dotenv_exists
+    assert all([_dotenvpath._has_dotenv_file(p) == dotenv_exists for p in subdirs])
+
+
+def test___get_caller_path___returns_this_modules_path() -> None:
+    assert _dotenvpath._get_caller_path() == Path(__file__)
+
+
+def test___get_nims_path___returns_nims_path() -> None:
+    assert _dotenvpath._get_nims_path() == Path(ni_measurementlink_service.__file__)
+
+
+def test___get_script_or_exe_path___returns_pytest_path() -> None:
+    path = _dotenvpath._get_script_or_exe_path()
+
+    assert path.parent.name in ["pytest", "pytest.exe"] and path.name == "__main__.py"


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update `.env` search to include some fallback options if the current directory and its parents don't contain a `.env` file:
- For PyInstaller, use the EXE path
- For scripts that have a `__main__` module that exists on disk, use the script path
- For TestStand code modules (and possibly other cases), use the path of the topmost caller that isn't part of `ni_measurementlink_service`

### Why should this Pull Request be merged?

Fixes [AB#2565326](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2565326)

### What testing has been done?

Ran tests.
Manually tested with nidcpower_source_dc_voltage TestStand sequence.