### PR TITLE
Speed up GitHub workflows

### DIFF
--- a/.github/workflows/Publish_NIMS.yml
+++ b/.github/workflows/Publish_NIMS.yml
@@ -25,12 +25,16 @@ jobs:
     name: Update API reference docs and Publish NIMS Package to PyPI
     runs-on : ubuntu-latest 
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up Poetry
-        run: pipx install poetry==${{ env.POETRY_VERSION }}
-      - uses: actions/setup-python@v4
+      - name: Check out repo
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+      - name: Set up Poetry
+        uses: Gr1N/setup-poetry@v8
+        with:
+          poetry-version: ${{ env.POETRY_VERSION }}
 
       - name: Check for lock changes
         run: poetry lock --check

--- a/.github/workflows/Publish_NIMS.yml
+++ b/.github/workflows/Publish_NIMS.yml
@@ -26,13 +26,12 @@ jobs:
     runs-on : ubuntu-latest 
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Poetry
+        run: pipx install poetry==${{ env.POETRY_VERSION }}
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'poetry'
-      - uses: Gr1N/setup-poetry@v8
-        with:
-          poetry-version: ${{ env.POETRY_VERSION }}
 
       - name: Check for lock changes
         run: poetry lock --check

--- a/.github/workflows/Publish_NIMS.yml
+++ b/.github/workflows/Publish_NIMS.yml
@@ -29,17 +29,13 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'poetry'
       - uses: Gr1N/setup-poetry@v8
         with:
           poetry-version: ${{ env.POETRY_VERSION }}
 
       - name: Check for lock changes
         run: poetry lock --check
-
-      - uses: actions/cache@v3
-        with:
-          path: ~/.cache/pypoetry/virtualenvs
-          key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
 
       # If the tag is 0.1.0, this will set the version of NIMS package to 0.1.0
       - name: Store version from Tag

--- a/.github/workflows/Publish_NIMS.yml
+++ b/.github/workflows/Publish_NIMS.yml
@@ -31,7 +31,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          cache: 'poetry'
 
       - name: Check for lock changes
         run: poetry lock --check

--- a/.github/workflows/check_examples.yml
+++ b/.github/workflows/check_examples.yml
@@ -15,12 +15,14 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
-      - name: Set up Poetry
-        run: pipx install poetry==${{ env.POETRY_VERSION }}
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+      - name: Set up Poetry
+        uses: Gr1N/setup-poetry@v8
+        with:
+          poetry-version: ${{ env.POETRY_VERSION }}
       # Updating poetry.lock for all of the examples takes over 6 minutes, so it's worth caching.
       - name: Cache poetry.lock
         uses: actions/cache@v3

--- a/.github/workflows/check_examples.yml
+++ b/.github/workflows/check_examples.yml
@@ -15,15 +15,13 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
+      - name: Set up Poetry
+        run: pipx install poetry==${{ env.POETRY_VERSION }}
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'poetry'
-      - name: Set up Poetry
-        uses: Gr1N/setup-poetry@v8
-        with:
-          poetry-version: ${{ env.POETRY_VERSION }}
       # Install each example's dependencies so mypy can see their types.
       - name: Install examples
         run: |

--- a/.github/workflows/check_examples.yml
+++ b/.github/workflows/check_examples.yml
@@ -32,10 +32,12 @@ jobs:
           done
       - name: Cache virtualenvs
         uses: actions/cache@v3
+        id: cache
         with:
           path: 'examples/**/.venv'
           key: examples-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('examples/**/poetry.lock') }}
       - name: Install examples
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           for example in examples/*/; do
             echo "::group::$example"

--- a/.github/workflows/check_examples.yml
+++ b/.github/workflows/check_examples.yml
@@ -48,7 +48,6 @@ jobs:
           path: 'examples/**/.venv'
           key: examples-venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('examples/**/poetry.lock') }}
       - name: Install examples
-        if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
           for example in examples/*/; do
             echo "::group::$example"

--- a/.github/workflows/check_examples.yml
+++ b/.github/workflows/check_examples.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           path: 'examples/**/poetry.lock'
           # Include the main project's poetry.lock in the hash to detect upstream dependency updates.
-          key: examples-poetry-lock-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('examples/**/pyproject.toml', 'poetry.lock') }}
+          key: examples-poetry-lock-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('examples/**/pyproject.toml', 'poetry.lock') }}
       - name: Lock examples
         if: steps.cache-poetry-lock.outputs.cache-hit != 'true'
         run: |
@@ -46,7 +46,7 @@ jobs:
         id: cache-venv
         with:
           path: 'examples/**/.venv'
-          key: examples-venv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('examples/**/poetry.lock') }}
+          key: examples-venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('examples/**/poetry.lock') }}
       - name: Install examples
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/check_examples.yml
+++ b/.github/workflows/check_examples.yml
@@ -19,15 +19,11 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'poetry'
       - name: Set up Poetry
         uses: Gr1N/setup-poetry@v8
         with:
           poetry-version: ${{ env.POETRY_VERSION }}
-      - name: Cache Poetry virtualenv
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pypoetry/virtualenvs
-          key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
       # Install each example's dependencies so mypy can see their types.
       - name: Install examples
         run: |

--- a/.github/workflows/check_examples.yml
+++ b/.github/workflows/check_examples.yml
@@ -21,7 +21,16 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+      # Updating poetry.lock for all of the examples takes over 6 minutes, so it's worth caching.
+      - name: Cache poetry.lock
+        uses: actions/cache@v3
+        id: cache-poetry-lock
+        with:
+          path: 'examples/**/poetry.lock'
+          # Include the main project's poetry.lock in the hash to detect upstream dependency updates.
+          key: examples-poetry-lock-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('examples/**/pyproject.toml', 'poetry.lock') }}
       - name: Lock examples
+        if: steps.cache-poetry-lock.outputs.cache-hit != 'true'
         run: |
           for example in examples/*/; do
             echo "::group::$example"
@@ -32,12 +41,12 @@ jobs:
           done
       - name: Cache virtualenvs
         uses: actions/cache@v3
-        id: cache
+        id: cache-venv
         with:
           path: 'examples/**/.venv'
-          key: examples-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('examples/**/poetry.lock') }}
+          key: examples-venv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('examples/**/poetry.lock') }}
       - name: Install examples
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
           for example in examples/*/; do
             echo "::group::$example"

--- a/.github/workflows/check_examples.yml
+++ b/.github/workflows/check_examples.yml
@@ -21,8 +21,20 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          cache: 'poetry'
-      # Install each example's dependencies so mypy can see their types.
+      - name: Lock examples
+        run: |
+          for example in examples/*/; do
+            echo "::group::$example"
+            pushd $example
+            poetry lock
+            popd
+            echo "::endgroup::"
+          done
+      - name: Cache virtualenvs
+        uses: actions/cache@v3
+        with:
+          path: 'examples/**/.venv'
+          key: examples-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('examples/**/poetry.lock') }}
       - name: Install examples
         run: |
           for example in examples/*/; do

--- a/.github/workflows/check_nimg.yml
+++ b/.github/workflows/check_nimg.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'poetry'
+          cache-dependency-path: ni_measurementlink_generator/poetry.lock
       - name: Check for lock changes (ni-measurementlink-generator)
         run: poetry lock --check
       - name: Install ni-measurementlink-generator

--- a/.github/workflows/check_nimg.yml
+++ b/.github/workflows/check_nimg.yml
@@ -25,10 +25,13 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          cache: 'poetry'
-          cache-dependency-path: ni_measurementlink_generator/poetry.lock
       - name: Check for lock changes (ni-measurementlink-generator)
         run: poetry lock --check
+      - name: Cache virtualenv (ni-measurementlink-generator)
+        uses: actions/cache@v3
+        with:
+          path: ni_measurementlink_generator/.venv
+          key: ni-measurementlink-generator-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}
       - name: Install ni-measurementlink-generator
         run: poetry install -v
       - name: Lint ni-measurementlink-generator

--- a/.github/workflows/check_nimg.yml
+++ b/.github/workflows/check_nimg.yml
@@ -19,15 +19,13 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
+      - name: Set up Poetry
+        run: pipx install poetry==${{ env.POETRY_VERSION }}
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'poetry'
-      - name: Set up Poetry
-        uses: Gr1N/setup-poetry@v8
-        with:
-          poetry-version: ${{ env.POETRY_VERSION }}
       - name: Check for lock changes (ni-measurementlink-generator)
         run: poetry lock --check
       - name: Install ni-measurementlink-generator

--- a/.github/workflows/check_nimg.yml
+++ b/.github/workflows/check_nimg.yml
@@ -23,17 +23,13 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'poetry'
       - name: Set up Poetry
         uses: Gr1N/setup-poetry@v8
         with:
           poetry-version: ${{ env.POETRY_VERSION }}
       - name: Check for lock changes (ni-measurementlink-generator)
         run: poetry lock --check
-      - name: Cache Poetry virtualenv
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pypoetry/virtualenvs
-          key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
       - name: Install ni-measurementlink-generator
         run: poetry install -v
       - name: Lint ni-measurementlink-generator

--- a/.github/workflows/check_nimg.yml
+++ b/.github/workflows/check_nimg.yml
@@ -36,7 +36,6 @@ jobs:
           path: ni_measurementlink_generator/.venv
           key: ni-measurementlink-generator-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}
       - name: Install ni-measurementlink-generator
-        if: steps.cache.outputs.cache-hit != 'true'
         run: poetry install -v
       - name: Lint ni-measurementlink-generator
         run: poetry run ni-python-styleguide lint

--- a/.github/workflows/check_nimg.yml
+++ b/.github/workflows/check_nimg.yml
@@ -29,10 +29,12 @@ jobs:
         run: poetry lock --check
       - name: Cache virtualenv (ni-measurementlink-generator)
         uses: actions/cache@v3
+        id: cache
         with:
           path: ni_measurementlink_generator/.venv
           key: ni-measurementlink-generator-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}
       - name: Install ni-measurementlink-generator
+        if: steps.cache.outputs.cache-hit != 'true'
         run: poetry install -v
       - name: Lint ni-measurementlink-generator
         run: poetry run ni-python-styleguide lint

--- a/.github/workflows/check_nimg.yml
+++ b/.github/workflows/check_nimg.yml
@@ -34,7 +34,7 @@ jobs:
         id: cache
         with:
           path: ni_measurementlink_generator/.venv
-          key: ni-measurementlink-generator-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}
+          key: ni-measurementlink-generator-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}
       - name: Install ni-measurementlink-generator
         if: steps.cache.outputs.cache-hit != 'true'
         run: poetry install -v

--- a/.github/workflows/check_nimg.yml
+++ b/.github/workflows/check_nimg.yml
@@ -19,12 +19,14 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
-      - name: Set up Poetry
-        run: pipx install poetry==${{ env.POETRY_VERSION }}
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+      - name: Set up Poetry
+        uses: Gr1N/setup-poetry@v8
+        with:
+          poetry-version: ${{ env.POETRY_VERSION }}
       - name: Check for lock changes (ni-measurementlink-generator)
         run: poetry lock --check
       - name: Cache virtualenv (ni-measurementlink-generator)

--- a/.github/workflows/check_nims.yml
+++ b/.github/workflows/check_nims.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install ni-measurementlink-service (all extras, docs)
         run: poetry install -v --all-extras --with docs
       - name: Save cached virtualenv (ni-measurementlink-service, all extras, docs)
-        uses: actions/cache/restore@v3
+        uses: actions/cache/save@v3
         with:
           path: .venv
           key: ni-measurementlink-service-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}-all-extras-docs

--- a/.github/workflows/check_nims.yml
+++ b/.github/workflows/check_nims.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'poetry'
+          cache-dependency-path: poetry.lock
       - name: Check for lock changes (ni-measurementlink-service)
         run: poetry lock --check
       - name: Install ni-measurementlink-service (all extras)

--- a/.github/workflows/check_nims.yml
+++ b/.github/workflows/check_nims.yml
@@ -32,7 +32,7 @@ jobs:
         id: restore-nims-all-extras
         with:
           path: .venv
-          key: ni-measurementlink-service-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}-all-extras
+          key: ni-measurementlink-service-all-extras-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}
       - name: Install ni-measurementlink-service (all extras)
         if: steps.restore-nims-all-extras.outputs.cache-hit != 'true'
         run: poetry install -v --all-extras
@@ -59,7 +59,7 @@ jobs:
         id: restore-nims-all-extras-docs
         with:
           path: .venv
-          key: ni-measurementlink-service-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}-all-extras-docs
+          key: ni-measurementlink-service-all-extras-docs-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}
       - name: Install ni-measurementlink-service (all extras, docs)
         if: steps.restore-nims-all-extras-docs.outputs.cache-hit != 'true'
         run: poetry install -v --all-extras --with docs

--- a/.github/workflows/check_nims.yml
+++ b/.github/workflows/check_nims.yml
@@ -34,7 +34,6 @@ jobs:
           path: .venv
           key: ni-measurementlink-service-all-extras-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}
       - name: Install ni-measurementlink-service (all extras)
-        if: steps.restore-nims-all-extras.outputs.cache-hit != 'true'
         run: poetry install -v --all-extras
       - name: Save cached virtualenv (ni-measurementlink-service, all extras)
         uses: actions/cache/save@v3
@@ -61,7 +60,6 @@ jobs:
           path: .venv
           key: ni-measurementlink-service-all-extras-docs-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}
       - name: Install ni-measurementlink-service (all extras, docs)
-        if: steps.restore-nims-all-extras-docs.outputs.cache-hit != 'true'
         run: poetry install -v --all-extras --with docs
       - name: Save cached virtualenv (ni-measurementlink-service, all extras, docs)
         uses: actions/cache/save@v3

--- a/.github/workflows/check_nims.yml
+++ b/.github/workflows/check_nims.yml
@@ -19,17 +19,13 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'poetry'
       - name: Set up Poetry
         uses: Gr1N/setup-poetry@v8
         with:
           poetry-version: ${{ env.POETRY_VERSION }}
       - name: Check for lock changes (ni-measurementlink-service)
         run: poetry lock --check
-      - name: Cache Poetry virtualenv
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pypoetry/virtualenvs
-          key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
       - name: Install ni-measurementlink-service (all extras)
         run: poetry install -v --all-extras
       - name: Lint ni-measurementlink-service

--- a/.github/workflows/check_nims.yml
+++ b/.github/workflows/check_nims.yml
@@ -15,15 +15,13 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
+      - name: Set up Poetry
+        run: pipx install poetry==${{ env.POETRY_VERSION }}
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'poetry'
-      - name: Set up Poetry
-        uses: Gr1N/setup-poetry@v8
-        with:
-          poetry-version: ${{ env.POETRY_VERSION }}
       - name: Check for lock changes (ni-measurementlink-service)
         run: poetry lock --check
       - name: Install ni-measurementlink-service (all extras)

--- a/.github/workflows/check_nims.yml
+++ b/.github/workflows/check_nims.yml
@@ -29,16 +29,19 @@ jobs:
       # ni-measurementlink-service, all extras
       - name: Restore cached virtualenv (ni-measurementlink-service, all extras)
         uses: actions/cache/restore@v3
+        id: restore-nims-all-extras
         with:
           path: .venv
           key: ni-measurementlink-service-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}-all-extras
       - name: Install ni-measurementlink-service (all extras)
+        if: steps.restore-nims-all-extras.outputs.cache-hit != 'true'
         run: poetry install -v --all-extras
       - name: Save cached virtualenv (ni-measurementlink-service, all extras)
         uses: actions/cache/save@v3
+        if: steps.restore-nims-all-extras.outputs.cache-hit != 'true'
         with:
           path: .venv
-          key: ni-measurementlink-service-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}-all-extras
+          key: ${{ steps.restore-nims-all-extras.outputs.cache-primary-key }}
       - name: Lint ni-measurementlink-service
         run: poetry run ni-python-styleguide lint
       - name: Mypy static analysis (ni-measurementlink-service, Linux)
@@ -53,16 +56,19 @@ jobs:
       # ni-measurementlink-service, all extras, docs
       - name: Restore cached virtualenv (ni-measurementlink-service, all extras, docs)
         uses: actions/cache/restore@v3
+        id: restore-nims-all-extras-docs
         with:
           path: .venv
           key: ni-measurementlink-service-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}-all-extras-docs
       - name: Install ni-measurementlink-service (all extras, docs)
+        if: steps.restore-nims-all-extras-docs.outputs.cache-hit != 'true'
         run: poetry install -v --all-extras --with docs
       - name: Save cached virtualenv (ni-measurementlink-service, all extras, docs)
         uses: actions/cache/save@v3
+        if: steps.restore-nims-all-extras-docs.outputs.cache-hit != 'true'
         with:
           path: .venv
-          key: ni-measurementlink-service-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}-all-extras-docs
+          key: ${{ steps.restore-nims-all-extras-docs.outputs.cache-primary-key }}
       - name: Build docs and check for errors/warnings
         run: |
           rm -rf docs

--- a/.github/workflows/check_nims.yml
+++ b/.github/workflows/check_nims.yml
@@ -25,8 +25,20 @@ jobs:
           cache-dependency-path: poetry.lock
       - name: Check for lock changes (ni-measurementlink-service)
         run: poetry lock --check
+
+      # ni-measurementlink-service, all extras
+      - name: Restore cached virtualenv (ni-measurementlink-service, all extras)
+        uses: actions/cache/restore@v3
+        with:
+          path: .venv
+          key: ni-measurementlink-service-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}-all-extras
       - name: Install ni-measurementlink-service (all extras)
         run: poetry install -v --all-extras
+      - name: Save cached virtualenv (ni-measurementlink-service, all extras)
+        uses: actions/cache/save@v3
+        with:
+          path: .venv
+          key: ni-measurementlink-service-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}-all-extras
       - name: Lint ni-measurementlink-service
         run: poetry run ni-python-styleguide lint
       - name: Mypy static analysis (ni-measurementlink-service, Linux)
@@ -37,8 +49,20 @@ jobs:
         run:  poetry run mypy tests
       - name: Mypy static analysis (tests, Windows)
         run:  poetry run mypy tests --platform win32
+
+      # ni-measurementlink-service, all extras, docs
+      - name: Restore cached virtualenv (ni-measurementlink-service, all extras, docs)
+        uses: actions/cache/restore@v3
+        with:
+          path: .venv
+          key: ni-measurementlink-service-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}-all-extras-docs
       - name: Install ni-measurementlink-service (all extras, docs)
         run: poetry install -v --all-extras --with docs
+      - name: Save cached virtualenv (ni-measurementlink-service, all extras, docs)
+        uses: actions/cache/restore@v3
+        with:
+          path: .venv
+          key: ni-measurementlink-service-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}-all-extras-docs
       - name: Build docs and check for errors/warnings
         run: |
           rm -rf docs

--- a/.github/workflows/check_nims.yml
+++ b/.github/workflows/check_nims.yml
@@ -32,7 +32,7 @@ jobs:
         id: restore-nims-all-extras
         with:
           path: .venv
-          key: ni-measurementlink-service-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}-all-extras
+          key: ni-measurementlink-service-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}-all-extras
       - name: Install ni-measurementlink-service (all extras)
         if: steps.restore-nims-all-extras.outputs.cache-hit != 'true'
         run: poetry install -v --all-extras
@@ -59,7 +59,7 @@ jobs:
         id: restore-nims-all-extras-docs
         with:
           path: .venv
-          key: ni-measurementlink-service-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}-all-extras-docs
+          key: ni-measurementlink-service-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}-all-extras-docs
       - name: Install ni-measurementlink-service (all extras, docs)
         if: steps.restore-nims-all-extras-docs.outputs.cache-hit != 'true'
         run: poetry install -v --all-extras --with docs

--- a/.github/workflows/check_nims.yml
+++ b/.github/workflows/check_nims.yml
@@ -15,14 +15,14 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
-      - name: Set up Poetry
-        run: pipx install poetry==${{ env.POETRY_VERSION }}
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          cache: 'poetry'
-          cache-dependency-path: poetry.lock
+      - name: Set up Poetry
+        uses: Gr1N/setup-poetry@v8
+        with:
+          poetry-version: ${{ env.POETRY_VERSION }}
       - name: Check for lock changes (ni-measurementlink-service)
         run: poetry lock --check
 

--- a/.github/workflows/run_system_tests.yml
+++ b/.github/workflows/run_system_tests.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
+      - name: Add gzip to path so cache can use tar -z
+        run: echo "C:\Program Files\Git\usr\bin" >> $GITHUB_PATH
       - name: Cache virtualenvs
         uses: actions/cache@v3
         id: cache

--- a/.github/workflows/run_system_tests.yml
+++ b/.github/workflows/run_system_tests.yml
@@ -31,8 +31,7 @@ jobs:
             .tox
           key: run-system-tests-${{ runner.os }}-${{ matrix.configuration }}-${{ hashFiles('poetry.lock') }}
       - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: poetry install
+        run: poetry install -v
       - name: Run system tests
         run: poetry run tox
       - name: Upload test results

--- a/.github/workflows/run_system_tests.yml
+++ b/.github/workflows/run_system_tests.yml
@@ -24,12 +24,14 @@ jobs:
         uses: actions/checkout@v4
       - name: Cache virtualenvs
         uses: actions/cache@v3
+        id: cache
         with:
           path: |
             .venv
             .tox
           key: run-system-tests-${{ runner.os }}-${{ matrix.configuration }}-${{ hashFiles('poetry.lock') }}
       - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: poetry install
       - name: Run system tests
         run: poetry run tox

--- a/.github/workflows/run_system_tests.yml
+++ b/.github/workflows/run_system_tests.yml
@@ -22,6 +22,13 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
+      - name: Cache virtualenvs
+        uses: actions/cache@v3
+        with:
+          path: |
+            .venv
+            .tox
+          key: run-system-tests-${{ runner.os }}-${{ matrix.configuration }}-${{ hashFiles('poetry.lock') }}
       - name: Install dependencies
         run: poetry install
       - name: Run system tests

--- a/.github/workflows/run_system_tests.yml
+++ b/.github/workflows/run_system_tests.yml
@@ -22,8 +22,6 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
-      - name: Add gzip to path so cache can use tar -z
-        run: echo "C:\Program Files\Git\usr\bin" >> $GITHUB_PATH
       - name: Cache virtualenvs
         uses: actions/cache@v3
         id: cache

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -25,15 +25,11 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'poetry'
       - name: Set up Poetry
         uses: Gr1N/setup-poetry@v8
         with:
           poetry-version: ${{ env.POETRY_VERSION }}
-      - name: Cache Poetry virtualenv
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pypoetry/virtualenvs
-          key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
       - name: Install ni-measurementlink-service (no extras)
         run: poetry install -v
       - name: Run unit tests and code coverage (ni-measurementlink-service, no extras)

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -21,15 +21,13 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
+      - name: Set up Poetry
+        run: pipx install poetry==${{ env.POETRY_VERSION }}
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'poetry'
-      - name: Set up Poetry
-        uses: Gr1N/setup-poetry@v8
-        with:
-          poetry-version: ${{ env.POETRY_VERSION }}
       - name: Install ni-measurementlink-service (no extras)
         run: poetry install -v
       - name: Run unit tests and code coverage (ni-measurementlink-service, no extras)

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [windows-latest, ubuntu-latest]
         python-version: [3.8, 3.9, '3.10', 3.11, 3.12]
       # Fail-fast skews the pass/fail ratio and seems to make pytest produce
       # incomplete JUnit XML results.

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -38,7 +38,6 @@ jobs:
           path: .venv
           key: ni-measurementlink-service-no-extras-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
       - name: Install ni-measurementlink-service (no extras)
-        if: steps.restore-nims-no-extras.outputs.cache-hit != 'true'
         run: poetry install -v
       - name: Save cached virtualenv (ni-measurementlink-service, no extras)
         uses: actions/cache/save@v3
@@ -57,7 +56,6 @@ jobs:
           path: .venv
           key: ni-measurementlink-service-all-extras-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
       - name: Install ni-measurementlink-service (all extras)
-        if: steps.restore-nims-all-extras.outputs.cache-hit != 'true'
         run: poetry install -v --all-extras
       - name: Save cached ni-measurementlink-service virtualenv (all extras)
         uses: actions/cache/save@v3
@@ -76,7 +74,6 @@ jobs:
           path: ni_measurementlink_generator/.venv
           key: ni-measurementlink-generator-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
       - name: Install ni-measurementlink-generator
-        if: steps.restore-nimg.outputs.cache-hit != 'true'
         run: poetry install -v
         working-directory: ./ni_measurementlink_generator
       - name: Save cached virtualenv (ni-measurementlink-generator)

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -31,49 +31,58 @@ jobs:
       # ni-measurementlink-service, no extras
       - name: Restore cached virtualenv (ni-measurementlink-service, no extras)
         uses: actions/cache/restore@v3
+        id: restore-nims-no-extras
         with:
           path: .venv
           key: ni-measurementlink-service-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}-no-extras
       - name: Install ni-measurementlink-service (no extras)
+        if: steps.restore-nims-no-extras.outputs.cache-hit != 'true'
         run: poetry install -v
       - name: Save cached virtualenv (ni-measurementlink-service, no extras)
         uses: actions/cache/save@v3
+        if: steps.restore-nims-no-extras.outputs.cache-hit != 'true'
         with:
           path: .venv
-          key: ni-measurementlink-service-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}-no-extras
+          key: ${{ steps.restore-nims-no-extras.outputs.cache-primary-key }}
       - name: Run unit tests and code coverage (ni-measurementlink-service, no extras)
         run: poetry run pytest ./tests/unit -v --cov=ni_measurementlink_service --junitxml=test_results/nims-${{ matrix.os }}-py${{ matrix.python-version}}-no-extras.xml
 
       # ni-measurementlink-service, all extras
       - name: Restore cached virtualenv (ni-measurementlink-service, all extras)
         uses: actions/cache/restore@v3
+        id: restore-nims-all-extras
         with:
           path: .venv
           key: ni-measurementlink-service-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}-all-extras
       - name: Install ni-measurementlink-service (all extras)
+        if: steps.restore-nims-all-extras.outputs.cache-hit != 'true'
         run: poetry install -v --all-extras
       - name: Save cached ni-measurementlink-service virtualenv (all extras)
         uses: actions/cache/save@v3
+        if: steps.restore-nims-all-extras.outputs.cache-hit != 'true'
         with:
           path: .venv
-          key: ni-measurementlink-service-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}-all-extras
+          key: ${{ steps.restore-nims-all-extras.outputs.cache-primary-key }}
       - name: Run unit tests and code coverage (ni-measurementlink-service, all extras)
         run: poetry run pytest ./tests/unit -v --cov=ni_measurementlink_service --junitxml=test_results/nims-${{ matrix.os }}-py${{ matrix.python-version}}-all-extras.xml
 
       # ni-measurementlink-generator
       - name: Restore cached virtualenv (ni-measurementlink-generator)
         uses: actions/cache/restore@v3
+        id: restore-nimg
         with:
           path: ni_measurementlink_generator/.venv
           key: ni-measurementlink-generator-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
       - name: Install ni-measurementlink-generator
+        if: steps.restore-nimg.outputs.cache-hit != 'true'
         run: poetry install -v
         working-directory: ./ni_measurementlink_generator
       - name: Save cached virtualenv (ni-measurementlink-generator)
         uses: actions/cache/save@v3
+        if: steps.restore-nimg.outputs.cache-hit != 'true'
         with:
           path: ni_measurementlink_generator/.venv
-          key: ni-measurementlink-generator-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
+          key: ${{ steps.restore-nimg.outputs.cache-primary-key }}
       - name: Run tests and code coverage (ni-measurementlink-generator)
         run: poetry run pytest -v --cov=ni_measurementlink_generator --junitxml=test_results/nimg-${{ matrix.os }}-py${{ matrix.python-version}}.xml
         working-directory: ./ni_measurementlink_generator

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -36,7 +36,7 @@ jobs:
         id: restore-nims-no-extras
         with:
           path: .venv
-          key: ni-measurementlink-service-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}-no-extras
+          key: ni-measurementlink-service-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}-no-extras
       - name: Install ni-measurementlink-service (no extras)
         if: steps.restore-nims-no-extras.outputs.cache-hit != 'true'
         run: poetry install -v
@@ -55,7 +55,7 @@ jobs:
         id: restore-nims-all-extras
         with:
           path: .venv
-          key: ni-measurementlink-service-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}-all-extras
+          key: ni-measurementlink-service-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}-all-extras
       - name: Install ni-measurementlink-service (all extras)
         if: steps.restore-nims-all-extras.outputs.cache-hit != 'true'
         run: poetry install -v --all-extras
@@ -74,7 +74,7 @@ jobs:
         id: restore-nimg
         with:
           path: ni_measurementlink_generator/.venv
-          key: ni-measurementlink-generator-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
+          key: ni-measurementlink-generator-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
       - name: Install ni-measurementlink-generator
         if: steps.restore-nimg.outputs.cache-hit != 'true'
         run: poetry install -v

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -27,24 +27,57 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'poetry'
-          cache-dependency-path: |
-            poetry.lock
-            ni_measurementlink_generator/poetry.lock
+
+      # ni-measurementlink-service, no extras
+      - name: Restore cached virtualenv (ni-measurementlink-service, no extras)
+        uses: actions/cache/restore@v3
+        with:
+          path: .venv
+          key: ni-measurementlink-service-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}-no-extras
       - name: Install ni-measurementlink-service (no extras)
         run: poetry install -v
+      - name: Save cached virtualenv (ni-measurementlink-service, no extras)
+        uses: actions/cache/save@v3
+        with:
+          path: .venv
+          key: ni-measurementlink-service-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}-no-extras
       - name: Run unit tests and code coverage (ni-measurementlink-service, no extras)
         run: poetry run pytest ./tests/unit -v --cov=ni_measurementlink_service --junitxml=test_results/nims-${{ matrix.os }}-py${{ matrix.python-version}}-no-extras.xml
+
+      # ni-measurementlink-service, all extras
+      - name: Restore cached virtualenv (ni-measurementlink-service, all extras)
+        uses: actions/cache/restore@v3
+        with:
+          path: .venv
+          key: ni-measurementlink-service-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}-all-extras
       - name: Install ni-measurementlink-service (all extras)
         run: poetry install -v --all-extras
+      - name: Save cached ni-measurementlink-service virtualenv (all extras)
+        uses: actions/cache/save@v3
+        with:
+          path: .venv
+          key: ni-measurementlink-service-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}-all-extras
       - name: Run unit tests and code coverage (ni-measurementlink-service, all extras)
         run: poetry run pytest ./tests/unit -v --cov=ni_measurementlink_service --junitxml=test_results/nims-${{ matrix.os }}-py${{ matrix.python-version}}-all-extras.xml
+
+      # ni-measurementlink-generator
+      - name: Restore cached virtualenv (ni-measurementlink-generator)
+        uses: actions/cache/restore@v3
+        with:
+          path: ni_measurementlink_generator/.venv
+          key: ni-measurementlink-generator-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
       - name: Install ni-measurementlink-generator
         run: poetry install -v
         working-directory: ./ni_measurementlink_generator
+      - name: Save cached virtualenv (ni-measurementlink-generator)
+        uses: actions/cache/save@v3
+        with:
+          path: ni_measurementlink_generator/.venv
+          key: ni-measurementlink-generator-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
       - name: Run tests and code coverage (ni-measurementlink-generator)
         run: poetry run pytest -v --cov=ni_measurementlink_generator --junitxml=test_results/nimg-${{ matrix.os }}-py${{ matrix.python-version}}.xml
         working-directory: ./ni_measurementlink_generator
+
       - name: Upload test results
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -21,12 +21,14 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
-      - name: Set up Poetry
-        run: pipx install poetry==${{ env.POETRY_VERSION }}
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Set up Poetry
+        uses: Gr1N/setup-poetry@v8
+        with:
+          poetry-version: ${{ env.POETRY_VERSION }}
 
       # ni-measurementlink-service, no extras
       - name: Restore cached virtualenv (ni-measurementlink-service, no extras)

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'poetry'
+          cache-dependency-path: |
+            poetry.lock
+            ni_measurementlink_generator/poetry.lock
       - name: Install ni-measurementlink-service (no extras)
         run: poetry install -v
       - name: Run unit tests and code coverage (ni-measurementlink-service, no extras)

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -36,7 +36,7 @@ jobs:
         id: restore-nims-no-extras
         with:
           path: .venv
-          key: ni-measurementlink-service-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}-no-extras
+          key: ni-measurementlink-service-no-extras-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
       - name: Install ni-measurementlink-service (no extras)
         if: steps.restore-nims-no-extras.outputs.cache-hit != 'true'
         run: poetry install -v
@@ -55,7 +55,7 @@ jobs:
         id: restore-nims-all-extras
         with:
           path: .venv
-          key: ni-measurementlink-service-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}-all-extras
+          key: ni-measurementlink-service-all-extras-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
       - name: Install ni-measurementlink-service (all extras)
         if: steps.restore-nims-all-extras.outputs.cache-hit != 'true'
         run: poetry install -v --all-extras


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Caching improvements
  - Cache in-project virtualenvs. All of our caching code was still using `~/.cache/pypoetry/virtualenvs`.
  - I originally tried using actions/setup-python's built-in caching, but I ran into two problems:
    - It requires installing Poetry before Python (e.g. with pipx), and when I did this, tests used the wrong Python version. (pipx is slightly faster than Gr1N/setup-poetry, though.)
    - Its cache key setup is limited to simple use cases and can't handle optional extras or Poetry dependency groups.
  - Use restore/save for workflows that run `poetry install` multiple times with different extras and/or dependency groups.
  - Cache example `poetry.lock` files. These lock files are not checked into Git, but generating them takes over 5 minutes, so they are worth caching.
  - For system tests, cache the `.tox` directory as well. Caching on the self-hosted runner has significant overhead, but it seems to be an overall win compared to installing from PyPI for each Python version.
  - Remove caching from `Publish_NIMS.yml`. We don't run this workflow very often and it's better to avoid a possible source of failure.
- Disable unit tests on macOS
  - Running tests on macOS often takes longer than on Linux and Windows
  - Caching virtualenvs on macOS was returning errors about invalid/corrupted virtualenvs. Maybe this was because I was skipping `poetry install` on cache hits at the time, but I don't want to spend any more time on it.

### Why should this Pull Request be merged?

Speed up builds (when there is a cache hit):
- Check NIMG: 1 min -> 30 sec
- Check NIMS: 2 min 30 sec -> 1 min 15 sec
- Check examples: 12-15 min -> 2 min 30 sec
- Run unit tests (Linux): 3 min -> 2 min
- Run unit tests (Windows): 4-6 min -> 3-4 min
- Run system tests: 21-23 min -> 15-16 min (not counting time to scale up new runner instance)
- Total run time: 2 hr -> 1 hr 
- Total duration: 40 min -> 22 min

### What testing has been done?

Ran PR workflow.