### PR TITLE
[PR1] Move .env.simulation to .env in run_system_tests workflow

### DIFF
--- a/.github/workflows/run_system_tests.yml
+++ b/.github/workflows/run_system_tests.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
+      - name: Rename .env.simulation to .env
+        run: mv .env.simulation .env
       - name: Cache virtualenvs
         uses: actions/cache@v3
         id: cache

--- a/.github/workflows/run_system_tests.yml
+++ b/.github/workflows/run_system_tests.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v4
       - name: Rename .env.simulation to .env
-        run: mv .env.simulation .env
+        run: mv examples/.env.simulation .env
       - name: Cache virtualenvs
         uses: actions/cache@v3
         id: cache

--- a/.github/workflows/run_system_tests.yml
+++ b/.github/workflows/run_system_tests.yml
@@ -22,8 +22,8 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
-      - name: Rename .env.simulation to .env
-        run: mv examples/.env.simulation .env
+      - name: Copy and rename .env.simulation to .env
+        run: cp examples/.env.simulation .env
       - name: Cache virtualenvs
         uses: actions/cache@v3
         id: cache

--- a/tests/unit/_drivers/test_nidcpower.py
+++ b/tests/unit/_drivers/test_nidcpower.py
@@ -44,7 +44,7 @@ def test___single_session_info___initialize_nidcpower_session___session_created(
     session = create_mock_nidcpower_session()
     session_new.side_effect = [session]
 
-    with reservation.initialize_nidcpower_session() as session_info:
+    with reservation.initialize_nidcpower_session(options={}) as session_info:
         assert session_info.session is session
 
     session_new.assert_called_once_with(
@@ -62,7 +62,7 @@ def test___multiple_session_infos___initialize_nidcpower_sessions___sessions_cre
     sessions = create_mock_nidcpower_sessions(3)
     session_new.side_effect = sessions
 
-    with reservation.initialize_nidcpower_sessions() as session_info:
+    with reservation.initialize_nidcpower_sessions(options={}) as session_info:
         assert session_info[0].session == sessions[0]
         assert session_info[1].session == sessions[1]
 

--- a/tests/unit/_drivers/test_nidigital.py
+++ b/tests/unit/_drivers/test_nidigital.py
@@ -44,7 +44,7 @@ def test___single_session_info___initialize_nidigital_session___session_created(
     session = create_mock_nidigital_session()
     session_new.side_effect = [session]
 
-    with reservation.initialize_nidigital_session() as session_info:
+    with reservation.initialize_nidigital_session(options={}) as session_info:
         assert session_info.session is session
 
     session_new.assert_called_once_with(
@@ -62,7 +62,7 @@ def test___multiple_session_infos___initialize_nidigital_sessions___sessions_cre
     sessions = create_mock_nidigital_sessions(3)
     session_new.side_effect = sessions
 
-    with reservation.initialize_nidigital_sessions() as session_info:
+    with reservation.initialize_nidigital_sessions(options={}) as session_info:
         assert session_info[0].session == sessions[0]
         assert session_info[1].session == sessions[1]
 

--- a/tests/unit/_drivers/test_nidmm.py
+++ b/tests/unit/_drivers/test_nidmm.py
@@ -42,7 +42,7 @@ def test___single_session_info___initialize_nidmm_session___session_created(
     session = create_mock_nidmm_session()
     session_new.side_effect = [session]
 
-    with reservation.initialize_nidmm_session() as session_info:
+    with reservation.initialize_nidmm_session(options={}) as session_info:
         assert session_info.session is session
 
     session_new.assert_called_once_with(
@@ -58,7 +58,7 @@ def test___multiple_session_infos___initialize_nidmm_sessions___sessions_created
     sessions = create_mock_nidmm_sessions(3)
     session_new.side_effect = sessions
 
-    with reservation.initialize_nidmm_sessions() as session_info:
+    with reservation.initialize_nidmm_sessions(options={}) as session_info:
         assert session_info[0].session == sessions[0]
         assert session_info[1].session == sessions[1]
 

--- a/tests/unit/_drivers/test_nifgen.py
+++ b/tests/unit/_drivers/test_nifgen.py
@@ -42,7 +42,7 @@ def test___single_session_info___initialize_nifgen_session___session_created(
     session = create_mock_nifgen_session()
     session_new.side_effect = [session]
 
-    with reservation.initialize_nifgen_session() as session_info:
+    with reservation.initialize_nifgen_session(options={}) as session_info:
         assert session_info.session is session
 
     session_new.assert_called_once_with(
@@ -58,7 +58,7 @@ def test___multiple_session_infos___initialize_nifgen_sessions___sessions_create
     sessions = create_mock_nifgen_sessions(3)
     session_new.side_effect = sessions
 
-    with reservation.initialize_nifgen_sessions() as session_info:
+    with reservation.initialize_nifgen_sessions(options={}) as session_info:
         assert session_info[0].session == sessions[0]
         assert session_info[1].session == sessions[1]
 

--- a/tests/unit/_drivers/test_niscope.py
+++ b/tests/unit/_drivers/test_niscope.py
@@ -44,7 +44,7 @@ def test___single_session_info___initialize_niscope_session___session_created(
     session = create_mock_niscope_session()
     session_new.side_effect = [session]
 
-    with reservation.initialize_niscope_session() as session_info:
+    with reservation.initialize_niscope_session(options={}) as session_info:
         assert session_info.session is session
 
     session_new.assert_called_once_with(
@@ -62,7 +62,7 @@ def test___multiple_session_infos___initialize_niscope_sessions___sessions_creat
     sessions = create_mock_niscope_sessions(3)
     session_new.side_effect = sessions
 
-    with reservation.initialize_niscope_sessions() as session_info:
+    with reservation.initialize_niscope_sessions(options={}) as session_info:
         assert session_info[0].session == sessions[0]
         assert session_info[1].session == sessions[1]
 

--- a/tests/unit/_drivers/test_niswitch.py
+++ b/tests/unit/_drivers/test_niswitch.py
@@ -40,7 +40,11 @@ def test___single_session_info___initialize_niswitch_session___session_created(
     session = create_mock_niswitch_session()
     session_new.side_effect = [session]
 
-    with reservation.initialize_niswitch_session() as session_info:
+    with reservation.initialize_niswitch_session(        
+        topology="Configured Topology",
+        simulate=False,
+        reset_device=False,
+    ) as session_info:
         assert session_info.session is session
 
     session_new.assert_called_once_with(
@@ -63,7 +67,11 @@ def test___multiple_session_infos___initialize_niswitch_sessions___sessions_crea
     sessions = create_mock_niswitch_sessions(3)
     session_new.side_effect = sessions
 
-    with reservation.initialize_niswitch_sessions() as session_info:
+    with reservation.initialize_niswitch_sessions(
+        topology="Configured Topology",
+        simulate=False,
+        reset_device=False,
+    ) as session_info:
         assert session_info[0].session == sessions[0]
         assert session_info[1].session == sessions[1]
 

--- a/tests/unit/_drivers/test_niswitch.py
+++ b/tests/unit/_drivers/test_niswitch.py
@@ -40,7 +40,7 @@ def test___single_session_info___initialize_niswitch_session___session_created(
     session = create_mock_niswitch_session()
     session_new.side_effect = [session]
 
-    with reservation.initialize_niswitch_session(        
+    with reservation.initialize_niswitch_session(
         topology="Configured Topology",
         simulate=False,
         reset_device=False,


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).


### What does this Pull Request accomplish?
- Driver acceptance tests needs `.env` file in **root directory** to simulate driver instruments, so moved `examples/.env.simulation` to `.env` in pipeline such that it runs acceptance tests without any errors.
- The configuration in `.env` overrides the session parameter default values in unit tests that doesn't use simulation mode, which fails the tests. So to resolve this issue, passed in the default values when calling initialize session in unit tests.

### Why should this Pull Request be merged?
To run acceptance tests that uses simulated instrument drivers in pipeline.

### What testing has been done?
Manually ran `poetry run pytest`.