### PR TITLE
[releases/1.2] rtd: Add .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,16 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
+  jobs:
+    post_create_environment:
+      - pip install poetry==1.2.2
+      # Tell poetry to not use a virtual environment
+      - poetry config virtualenvs.create false
+    post_install:
+      - poetry install --with docs
+
+sphinx:
+  configuration: _docs_source/conf.py


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Cherry-pick #505 into releases/1.2.

### Why should this Pull Request be merged?

Enable displaying 1.2 docs in RTD.

### What testing has been done?

The config has been tested with the main branch.