### PR TITLE
fix: DeprecationWarning raised due to Pathlib.Path

### DIFF
--- a/tests/unit/test_discovery_client.py
+++ b/tests/unit/test_discovery_client.py
@@ -4,6 +4,7 @@ import json
 import pathlib
 import subprocess
 import sys
+from io import TextIOBase
 from typing import Any, Dict, Union, cast
 from unittest.mock import Mock
 
@@ -278,7 +279,7 @@ def test___key_file_exist_after_poll___start_discovery_service___discovery_servi
 
     mocker.patch(
         "ni_measurementlink_service.discovery._support._open_key_file",
-        side_effect=[OSError, OSError, OSError, temp_discovery_key_file_path],
+        side_effect=[OSError, OSError, OSError, TextIOBase()],
     )
     mock_popen = mocker.patch("subprocess.Popen")
 

--- a/tests/unit/test_discovery_client.py
+++ b/tests/unit/test_discovery_client.py
@@ -4,7 +4,7 @@ import json
 import pathlib
 import subprocess
 import sys
-from io import TextIOBase
+from io import StringIO
 from typing import Any, Dict, Union, cast
 from unittest.mock import Mock
 
@@ -279,7 +279,7 @@ def test___key_file_exist_after_poll___start_discovery_service___discovery_servi
 
     mocker.patch(
         "ni_measurementlink_service.discovery._support._open_key_file",
-        side_effect=[OSError, OSError, OSError, TextIOBase()],
+        side_effect=[OSError, OSError, OSError, StringIO()],
     )
     mock_popen = mocker.patch("subprocess.Popen")
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Fixes the `DeprecationWarning` raised due to `Pathlib.Path` where it wasn't expected to be. Fixes #428

### Why should this Pull Request be merged?
Provides the correct type of outputs to match the original API's expected return type.

### What testing has been done?
Ran mypy and pytest.