### PR TITLE
service: Rename GRPC_DEVICE_SERVER_ADDRESS and change it to a URL

### DIFF
--- a/examples/.env.sample
+++ b/examples/.env.sample
@@ -60,8 +60,8 @@
 # but if you do, you can uncomment the following options to override this
 # behavior:
 #
-# MEASUREMENTLINK_USE_GRPC_DEVICE=1
-# MEASUREMENTLINK_GRPC_DEVICE_ADDRESS=localhost:31763
+# MEASUREMENTLINK_USE_GRPC_DEVICE_SERVER=1
+# MEASUREMENTLINK_GRPC_DEVICE_SERVER_ADDRESS=localhost:31763
 
 #----------------------------------------------------------------------
 # Feature Toggles

--- a/examples/.env.sample
+++ b/examples/.env.sample
@@ -61,7 +61,7 @@
 # behavior:
 #
 # MEASUREMENTLINK_USE_GRPC_DEVICE_SERVER=1
-# MEASUREMENTLINK_GRPC_DEVICE_SERVER_ADDRESS=localhost:31763
+# MEASUREMENTLINK_GRPC_DEVICE_SERVER_ADDRESS=http://localhost:31763
 
 #----------------------------------------------------------------------
 # Feature Toggles

--- a/ni_measurementlink_service/_configuration.py
+++ b/ni_measurementlink_service/_configuration.py
@@ -105,4 +105,4 @@ NISWITCH_OPTIONS = NISwitchOptions("niswitch").update_from_config()
 # NI gRPC Device Server Configuration
 # ----------------------------------------------------------------------
 USE_GRPC_DEVICE_SERVER: bool = _config(f"{_PREFIX}_USE_GRPC_DEVICE_SERVER", default=True, cast=bool)
-GRPC_DEVICE_ADDRESS: str = _config(f"{_PREFIX}_GRPC_DEVICE_ADDRESS", default="")
+GRPC_DEVICE_SERVER_ADDRESS: str = _config(f"{_PREFIX}_GRPC_DEVICE_SERVER_ADDRESS", default="")

--- a/ni_measurementlink_service/_drivers/_grpcdevice.py
+++ b/ni_measurementlink_service/_drivers/_grpcdevice.py
@@ -1,7 +1,9 @@
 """Shared functions for interacting with NI gRPC Device Server."""
 from __future__ import annotations
 
+import logging
 from typing import Optional
+from urllib.parse import urlparse
 
 import grpc
 
@@ -12,8 +14,48 @@ from ni_measurementlink_service._configuration import (
 )
 from ni_measurementlink_service.discovery import DiscoveryClient
 
+_logger = logging.getLogger(__name__)
+
 SERVICE_CLASS = "ni.measurementlink.v1.grpcdeviceserver"
 """The service class for NI gRPC Device Server."""
+
+
+def get_insecure_grpc_device_address(
+    discovery_client: DiscoveryClient,
+    provided_interface: str,
+) -> str:
+    """Get an address targeting NI gRPC Device Server for unencrypted communication."""
+    if not USE_GRPC_DEVICE_SERVER:
+        _logger.debug("Not using NI gRPC Device Server")
+        return ""
+
+    if GRPC_DEVICE_SERVER_ADDRESS:
+        parsed_address = urlparse(GRPC_DEVICE_SERVER_ADDRESS)
+        if parsed_address.scheme != "http":
+            raise ValueError(
+                f"Unsupported URL scheme '{parsed_address.scheme}'"
+                f" for GRPC_DEVICE_SERVER_ADDRESS '{GRPC_DEVICE_SERVER_ADDRESS}'"
+            )
+        if (
+            parsed_address.path not in ("", "/")
+            or parsed_address.params
+            or parsed_address.query
+            or parsed_address.fragment
+        ):
+            raise ValueError(
+                f"Unsupported GRPC_DEVICE_SERVER_ADDRESS '{GRPC_DEVICE_SERVER_ADDRESS}'"
+            )
+        address = parsed_address.netloc
+        _logger.debug("Using NI gRPC Device Server with configured insecure address '%s'", address)
+        return address
+
+    service_location = discovery_client.resolve_service(
+        provided_interface=provided_interface,
+        service_class=SERVICE_CLASS,
+    )
+    address = service_location.insecure_address
+    _logger.debug("Using NI gRPC Device Server with discovered insecure address '%s'", address)
+    return address
 
 
 def get_insecure_grpc_device_channel(
@@ -21,29 +63,9 @@ def get_insecure_grpc_device_channel(
     grpc_channel_pool: GrpcChannelPool,
     provided_interface: str,
 ) -> Optional[grpc.Channel]:
-    """Get an unencrypted gRPC channel targeting NI gRPC Device Server.
-
-    Args:
-        discovery_client: The discovery client.
-
-        grpc_channel_pool: The gRPC channel pool.
-
-        provided_interface: The driver API's NI gRPC Device Server interface
-        name.
-
-    Returns:
-        A gRPC channel targeting the NI gRPC Device Server, or ``None`` if the
-        configuration file specifies that ``USE_GRPC_DEVICE_SERVER`` is false.
-    """
-    if not USE_GRPC_DEVICE_SERVER:
+    """Get an unencrypted gRPC channel targeting NI gRPC Device Server."""
+    address = get_insecure_grpc_device_address(discovery_client, provided_interface)
+    if address:
+        return grpc_channel_pool.get_channel(address)
+    else:
         return None
-
-    address = GRPC_DEVICE_SERVER_ADDRESS
-    if not address:
-        service_location = discovery_client.resolve_service(
-            provided_interface=provided_interface,
-            service_class=SERVICE_CLASS,
-        )
-        address = service_location.insecure_address
-
-    return grpc_channel_pool.get_channel(address)

--- a/ni_measurementlink_service/_drivers/_grpcdevice.py
+++ b/ni_measurementlink_service/_drivers/_grpcdevice.py
@@ -59,6 +59,8 @@ def _parse_url_to_service_location(url: str) -> ServiceLocation:
         raise ValueError(f"Unsupported query '?{parsed_url.query}' in '{url}'")
     if parsed_url.fragment:
         raise ValueError(f"Unsupported fragment '#{parsed_url.fragment}' in '{url}'")
+    if parsed_url.hostname is None:
+        raise ValueError(f"No host specified in '{url}'")
     if parsed_url.port is None:
         raise ValueError(f"No port number specified in '{url}'")
 

--- a/ni_measurementlink_service/_drivers/_grpcdevice.py
+++ b/ni_measurementlink_service/_drivers/_grpcdevice.py
@@ -54,7 +54,11 @@ def get_insecure_grpc_device_server_address(
         service_class=SERVICE_CLASS,
     )
     address = service_location.insecure_address
-    _logger.debug("Using NI gRPC Device Server with discovered insecure address '%s'", address)
+    _logger.debug(
+        "Using NI gRPC Device Server interface '%s' with discovered insecure address '%s'",
+        provided_interface,
+        address,
+    )
     return address
 
 

--- a/ni_measurementlink_service/_drivers/_grpcdevice.py
+++ b/ni_measurementlink_service/_drivers/_grpcdevice.py
@@ -20,7 +20,7 @@ SERVICE_CLASS = "ni.measurementlink.v1.grpcdeviceserver"
 """The service class for NI gRPC Device Server."""
 
 
-def get_insecure_grpc_device_address(
+def get_insecure_grpc_device_server_address(
     discovery_client: DiscoveryClient,
     provided_interface: str,
 ) -> str:
@@ -58,13 +58,13 @@ def get_insecure_grpc_device_address(
     return address
 
 
-def get_insecure_grpc_device_channel(
+def get_insecure_grpc_device_server_channel(
     discovery_client: DiscoveryClient,
     grpc_channel_pool: GrpcChannelPool,
     provided_interface: str,
 ) -> Optional[grpc.Channel]:
     """Get an unencrypted gRPC channel targeting NI gRPC Device Server."""
-    address = get_insecure_grpc_device_address(discovery_client, provided_interface)
+    address = get_insecure_grpc_device_server_address(discovery_client, provided_interface)
     if address:
         return grpc_channel_pool.get_channel(address)
     else:

--- a/ni_measurementlink_service/_drivers/_grpcdevice.py
+++ b/ni_measurementlink_service/_drivers/_grpcdevice.py
@@ -7,7 +7,7 @@ import grpc
 
 from ni_measurementlink_service._channelpool import GrpcChannelPool
 from ni_measurementlink_service._configuration import (
-    GRPC_DEVICE_ADDRESS,
+    GRPC_DEVICE_SERVER_ADDRESS,
     USE_GRPC_DEVICE_SERVER,
 )
 from ni_measurementlink_service.discovery import DiscoveryClient
@@ -38,7 +38,7 @@ def get_insecure_grpc_device_channel(
     if not USE_GRPC_DEVICE_SERVER:
         return None
 
-    address = GRPC_DEVICE_ADDRESS
+    address = GRPC_DEVICE_SERVER_ADDRESS
     if not address:
         service_location = discovery_client.resolve_service(
             provided_interface=provided_interface,

--- a/ni_measurementlink_service/_drivers/_grpcdevice.py
+++ b/ni_measurementlink_service/_drivers/_grpcdevice.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 from typing import Optional
-from urllib.parse import urlparse
+from urllib.parse import urlsplit
 
 import grpc
 
@@ -12,7 +12,7 @@ from ni_measurementlink_service._configuration import (
     GRPC_DEVICE_SERVER_ADDRESS,
     USE_GRPC_DEVICE_SERVER,
 )
-from ni_measurementlink_service.discovery import DiscoveryClient
+from ni_measurementlink_service.discovery import DiscoveryClient, ServiceLocation
 
 _logger = logging.getLogger(__name__)
 
@@ -20,46 +20,58 @@ SERVICE_CLASS = "ni.measurementlink.v1.grpcdeviceserver"
 """The service class for NI gRPC Device Server."""
 
 
-def get_insecure_grpc_device_server_address(
+def get_grpc_device_server_location(
     discovery_client: DiscoveryClient,
     provided_interface: str,
-) -> str:
+) -> Optional[ServiceLocation]:
     """Get an address targeting NI gRPC Device Server for unencrypted communication."""
     if not USE_GRPC_DEVICE_SERVER:
         _logger.debug("Not using NI gRPC Device Server")
-        return ""
+        return None
 
     if GRPC_DEVICE_SERVER_ADDRESS:
-        parsed_address = urlparse(GRPC_DEVICE_SERVER_ADDRESS)
-        if parsed_address.scheme != "http":
-            raise ValueError(
-                f"Unsupported URL scheme '{parsed_address.scheme}'"
-                f" for GRPC_DEVICE_SERVER_ADDRESS '{GRPC_DEVICE_SERVER_ADDRESS}'"
-            )
-        if (
-            parsed_address.path not in ("", "/")
-            or parsed_address.params
-            or parsed_address.query
-            or parsed_address.fragment
-        ):
-            raise ValueError(
-                f"Unsupported GRPC_DEVICE_SERVER_ADDRESS '{GRPC_DEVICE_SERVER_ADDRESS}'"
-            )
-        address = parsed_address.netloc
-        _logger.debug("Using NI gRPC Device Server with configured insecure address '%s'", address)
-        return address
+        service_location = _parse_url_to_service_location(GRPC_DEVICE_SERVER_ADDRESS)
+        _logger.debug(
+            "NI gRPC Device Server location (from GRPC_DEVICE_SERVER_ADDRESS): %r", service_location
+        )
+        return service_location
 
     service_location = discovery_client.resolve_service(
         provided_interface=provided_interface,
         service_class=SERVICE_CLASS,
     )
-    address = service_location.insecure_address
     _logger.debug(
-        "Using NI gRPC Device Server interface '%s' with discovered insecure address '%s'",
+        "NI gRPC Device Server location (for interface '%s'): %r",
         provided_interface,
-        address,
+        service_location,
     )
-    return address
+    return service_location
+
+
+def _parse_url_to_service_location(url: str) -> ServiceLocation:
+    parsed_url = urlsplit(url)
+
+    if parsed_url.scheme not in ("http", "https"):
+        raise ValueError(f"Unsupported URL scheme '{parsed_url.scheme}' in '{url}'")
+    if parsed_url.path not in ("", "/"):
+        raise ValueError(f"Unsupported path '{parsed_url.path}' in '{url}'")
+    if parsed_url.query:
+        raise ValueError(f"Unsupported query '?{parsed_url.query}' in '{url}'")
+    if parsed_url.fragment:
+        raise ValueError(f"Unsupported fragment '#{parsed_url.fragment}' in '{url}'")
+    if parsed_url.port is None:
+        raise ValueError(f"No port number specified in '{url}'")
+
+    host = parsed_url.hostname
+    port = str(parsed_url.port)
+    if "[" in parsed_url.netloc and "]" in parsed_url.netloc:
+        # Preserve IPv6 address brackets
+        host = "[" + host + "]"
+
+    if parsed_url.scheme == "http":
+        return ServiceLocation(location=host, insecure_port=port, ssl_authenticated_port="")
+    else:
+        return ServiceLocation(location=host, insecure_port="", ssl_authenticated_port=port)
 
 
 def get_insecure_grpc_device_server_channel(
@@ -68,8 +80,9 @@ def get_insecure_grpc_device_server_channel(
     provided_interface: str,
 ) -> Optional[grpc.Channel]:
     """Get an unencrypted gRPC channel targeting NI gRPC Device Server."""
-    address = get_insecure_grpc_device_server_address(discovery_client, provided_interface)
-    if address:
-        return grpc_channel_pool.get_channel(address)
-    else:
+    service_location = get_grpc_device_server_location(discovery_client, provided_interface)
+    if not service_location:
         return None
+    if not service_location.insecure_port:
+        raise ValueError(f"No insecure port specified in {service_location!r}")
+    return grpc_channel_pool.get_channel(service_location.insecure_address)

--- a/ni_measurementlink_service/_drivers/_nidaqmx.py
+++ b/ni_measurementlink_service/_drivers/_nidaqmx.py
@@ -6,7 +6,7 @@ import nidaqmx
 
 from ni_measurementlink_service._channelpool import GrpcChannelPool
 from ni_measurementlink_service._drivers._grpcdevice import (
-    get_insecure_grpc_device_channel,
+    get_insecure_grpc_device_server_channel,
 )
 from ni_measurementlink_service.discovery import DiscoveryClient
 from ni_measurementlink_service.session_management._types import (
@@ -33,7 +33,7 @@ class SessionConstructor:
         initialization_behavior: SessionInitializationBehavior,
     ) -> None:
         """Initialize the session constructor."""
-        self._grpc_channel = get_insecure_grpc_device_channel(
+        self._grpc_channel = get_insecure_grpc_device_server_channel(
             discovery_client, grpc_channel_pool, nidaqmx.GRPC_SERVICE_INTERFACE_NAME
         )
         self._initialization_behavior = _INITIALIZATION_BEHAVIOR[initialization_behavior]

--- a/ni_measurementlink_service/_drivers/_nidcpower.py
+++ b/ni_measurementlink_service/_drivers/_nidcpower.py
@@ -7,7 +7,7 @@ import nidcpower
 from ni_measurementlink_service._channelpool import GrpcChannelPool
 from ni_measurementlink_service._configuration import NIDCPOWER_OPTIONS
 from ni_measurementlink_service._drivers._grpcdevice import (
-    get_insecure_grpc_device_channel,
+    get_insecure_grpc_device_server_channel,
 )
 from ni_measurementlink_service.discovery import DiscoveryClient
 from ni_measurementlink_service.session_management._types import (
@@ -36,7 +36,7 @@ class SessionConstructor:
         initialization_behavior: SessionInitializationBehavior,
     ) -> None:
         """Initialize the session constructor."""
-        self._grpc_channel = get_insecure_grpc_device_channel(
+        self._grpc_channel = get_insecure_grpc_device_server_channel(
             discovery_client, grpc_channel_pool, nidcpower.GRPC_SERVICE_INTERFACE_NAME
         )
         self._reset = reset

--- a/ni_measurementlink_service/_drivers/_nidigital.py
+++ b/ni_measurementlink_service/_drivers/_nidigital.py
@@ -7,7 +7,7 @@ import nidigital
 from ni_measurementlink_service._channelpool import GrpcChannelPool
 from ni_measurementlink_service._configuration import NIDIGITAL_OPTIONS
 from ni_measurementlink_service._drivers._grpcdevice import (
-    get_insecure_grpc_device_channel,
+    get_insecure_grpc_device_server_channel,
 )
 from ni_measurementlink_service.discovery import DiscoveryClient
 from ni_measurementlink_service.session_management._types import (
@@ -36,7 +36,7 @@ class SessionConstructor:
         initialization_behavior: SessionInitializationBehavior,
     ) -> None:
         """Initialize the session constructor."""
-        self._grpc_channel = get_insecure_grpc_device_channel(
+        self._grpc_channel = get_insecure_grpc_device_server_channel(
             discovery_client, grpc_channel_pool, nidigital.GRPC_SERVICE_INTERFACE_NAME
         )
         self._reset_device = reset_device

--- a/ni_measurementlink_service/_drivers/_nidmm.py
+++ b/ni_measurementlink_service/_drivers/_nidmm.py
@@ -7,7 +7,7 @@ import nidmm
 from ni_measurementlink_service._channelpool import GrpcChannelPool
 from ni_measurementlink_service._configuration import NIDMM_OPTIONS
 from ni_measurementlink_service._drivers._grpcdevice import (
-    get_insecure_grpc_device_channel,
+    get_insecure_grpc_device_server_channel,
 )
 from ni_measurementlink_service.discovery import DiscoveryClient
 from ni_measurementlink_service.session_management._types import (
@@ -36,7 +36,7 @@ class SessionConstructor:
         initialization_behavior: SessionInitializationBehavior,
     ) -> None:
         """Initialize the session constructor."""
-        self._grpc_channel = get_insecure_grpc_device_channel(
+        self._grpc_channel = get_insecure_grpc_device_server_channel(
             discovery_client, grpc_channel_pool, nidmm.GRPC_SERVICE_INTERFACE_NAME
         )
         self._reset_device = reset_device

--- a/ni_measurementlink_service/_drivers/_nifgen.py
+++ b/ni_measurementlink_service/_drivers/_nifgen.py
@@ -7,7 +7,7 @@ import nifgen
 from ni_measurementlink_service._channelpool import GrpcChannelPool
 from ni_measurementlink_service._configuration import NIFGEN_OPTIONS
 from ni_measurementlink_service._drivers._grpcdevice import (
-    get_insecure_grpc_device_channel,
+    get_insecure_grpc_device_server_channel,
 )
 from ni_measurementlink_service.discovery import DiscoveryClient
 from ni_measurementlink_service.session_management._types import (
@@ -36,7 +36,7 @@ class SessionConstructor:
         initialization_behavior: SessionInitializationBehavior,
     ) -> None:
         """Initialize the session constructor."""
-        self._grpc_channel = get_insecure_grpc_device_channel(
+        self._grpc_channel = get_insecure_grpc_device_server_channel(
             discovery_client, grpc_channel_pool, nifgen.GRPC_SERVICE_INTERFACE_NAME
         )
         self._reset_device = reset_device

--- a/ni_measurementlink_service/_drivers/_niscope.py
+++ b/ni_measurementlink_service/_drivers/_niscope.py
@@ -7,7 +7,7 @@ import niscope
 from ni_measurementlink_service._channelpool import GrpcChannelPool
 from ni_measurementlink_service._configuration import NISCOPE_OPTIONS
 from ni_measurementlink_service._drivers._grpcdevice import (
-    get_insecure_grpc_device_channel,
+    get_insecure_grpc_device_server_channel,
 )
 from ni_measurementlink_service.discovery import DiscoveryClient
 from ni_measurementlink_service.session_management._types import (
@@ -36,7 +36,7 @@ class SessionConstructor:
         initialization_behavior: SessionInitializationBehavior,
     ) -> None:
         """Initialize the session constructor."""
-        self._grpc_channel = get_insecure_grpc_device_channel(
+        self._grpc_channel = get_insecure_grpc_device_server_channel(
             discovery_client, grpc_channel_pool, niscope.GRPC_SERVICE_INTERFACE_NAME
         )
         self._reset_device = reset_device

--- a/ni_measurementlink_service/_drivers/_niswitch.py
+++ b/ni_measurementlink_service/_drivers/_niswitch.py
@@ -7,7 +7,7 @@ import niswitch
 from ni_measurementlink_service._channelpool import GrpcChannelPool
 from ni_measurementlink_service._configuration import NISWITCH_OPTIONS
 from ni_measurementlink_service._drivers._grpcdevice import (
-    get_insecure_grpc_device_channel,
+    get_insecure_grpc_device_server_channel,
 )
 from ni_measurementlink_service.discovery import DiscoveryClient
 from ni_measurementlink_service.session_management._types import (
@@ -37,7 +37,7 @@ class SessionConstructor:
         initialization_behavior: SessionInitializationBehavior,
     ) -> None:
         """Initialize the session constructor."""
-        self._grpc_channel = get_insecure_grpc_device_channel(
+        self._grpc_channel = get_insecure_grpc_device_server_channel(
             discovery_client, grpc_channel_pool, niswitch.GRPC_SERVICE_INTERFACE_NAME
         )
         self._topology = NISWITCH_OPTIONS.topology if topology is None else topology

--- a/tests/unit/_drivers/test_grpcdevice.py
+++ b/tests/unit/_drivers/test_grpcdevice.py
@@ -51,7 +51,8 @@ def test___grpc_device_server_address_set___get_insecure_grpc_device_channel___r
     mocker: MockerFixture,
 ) -> None:
     mocker.patch(
-        "ni_measurementlink_service._drivers._grpcdevice.GRPC_DEVICE_SERVER_ADDRESS", "[::1]:31763"
+        "ni_measurementlink_service._drivers._grpcdevice.GRPC_DEVICE_SERVER_ADDRESS",
+        "http://[::1]:31763",
     )
     grpc_channel_pool.get_channel.return_value = grpc_channel
 

--- a/tests/unit/_drivers/test_grpcdevice.py
+++ b/tests/unit/_drivers/test_grpcdevice.py
@@ -92,6 +92,10 @@ def test___grpc_device_server_address_set___get_grpc_device_server_location___re
             "Unsupported fragment '#fragment' in 'http://localhost:1234#fragment'",
         ),
         (
+            "http://:1234",
+            "No host specified in 'http://:1234'",
+        ),
+        (
             "http://localhost",
             "No port number specified in 'http://localhost'",
         ),

--- a/tests/unit/_drivers/test_grpcdevice.py
+++ b/tests/unit/_drivers/test_grpcdevice.py
@@ -4,13 +4,13 @@ from pytest_mock import MockerFixture
 
 from ni_measurementlink_service._drivers._grpcdevice import (
     SERVICE_CLASS,
-    get_insecure_grpc_device_channel,
+    get_insecure_grpc_device_server_channel,
 )
 from ni_measurementlink_service.discovery import ServiceLocation
 from tests.utilities import fake_driver
 
 
-def test___default_configuration___get_insecure_grpc_device_channel___returns_service_discovered_and_channel(
+def test___default_configuration___get_insecure_grpc_device_server_channel___returns_discovered_channel(
     discovery_client: Mock,
     grpc_channel: Mock,
     grpc_channel_pool: Mock,
@@ -18,7 +18,7 @@ def test___default_configuration___get_insecure_grpc_device_channel___returns_se
     discovery_client.resolve_service.return_value = ServiceLocation("localhost", "1234", "")
     grpc_channel_pool.get_channel.return_value = grpc_channel
 
-    returned_channel = get_insecure_grpc_device_channel(
+    returned_channel = get_insecure_grpc_device_server_channel(
         discovery_client, grpc_channel_pool, fake_driver.GRPC_SERVICE_INTERFACE_NAME
     )
 
@@ -30,21 +30,21 @@ def test___default_configuration___get_insecure_grpc_device_channel___returns_se
     assert returned_channel is grpc_channel
 
 
-def test___use_grpc_device_server_false___get_insecure_grpc_device_channel___returns_none(
+def test___use_grpc_device_server_false___get_insecure_grpc_device_server_channel___returns_none(
     discovery_client: Mock,
     grpc_channel_pool: Mock,
     mocker: MockerFixture,
 ) -> None:
     mocker.patch("ni_measurementlink_service._drivers._grpcdevice.USE_GRPC_DEVICE_SERVER", False)
 
-    returned_channel = get_insecure_grpc_device_channel(
+    returned_channel = get_insecure_grpc_device_server_channel(
         discovery_client, grpc_channel_pool, fake_driver.GRPC_SERVICE_INTERFACE_NAME
     )
 
     assert returned_channel is None
 
 
-def test___grpc_device_server_address_set___get_insecure_grpc_device_channel___returns_address_used_and_channel(
+def test___grpc_device_server_address_set___get_insecure_grpc_device_server_channel___returns_configured_channel(
     discovery_client: Mock,
     grpc_channel: Mock,
     grpc_channel_pool: Mock,
@@ -56,7 +56,7 @@ def test___grpc_device_server_address_set___get_insecure_grpc_device_channel___r
     )
     grpc_channel_pool.get_channel.return_value = grpc_channel
 
-    returned_channel = get_insecure_grpc_device_channel(
+    returned_channel = get_insecure_grpc_device_server_channel(
         discovery_client, grpc_channel_pool, fake_driver.GRPC_SERVICE_INTERFACE_NAME
     )
 

--- a/tests/unit/_drivers/test_grpcdevice.py
+++ b/tests/unit/_drivers/test_grpcdevice.py
@@ -10,7 +10,7 @@ from ni_measurementlink_service.discovery import ServiceLocation
 from tests.utilities import fake_driver
 
 
-def test___default_configuration___get_insecure_grpc_device_channel___service_discovered_and_channel_returned(
+def test___default_configuration___get_insecure_grpc_device_channel___returns_service_discovered_and_channel(
     discovery_client: Mock,
     grpc_channel: Mock,
     grpc_channel_pool: Mock,
@@ -30,7 +30,7 @@ def test___default_configuration___get_insecure_grpc_device_channel___service_di
     assert returned_channel is grpc_channel
 
 
-def test___use_grpc_device_server_false___get_insecure_grpc_device_channel___none_returned(
+def test___use_grpc_device_server_false___get_insecure_grpc_device_channel___returns_none(
     discovery_client: Mock,
     grpc_channel_pool: Mock,
     mocker: MockerFixture,
@@ -44,14 +44,14 @@ def test___use_grpc_device_server_false___get_insecure_grpc_device_channel___non
     assert returned_channel is None
 
 
-def test___grpc_device_address_set___get_insecure_grpc_device_channel___address_used_and_channel_returned(
+def test___grpc_device_server_address_set___get_insecure_grpc_device_channel___returns_address_used_and_channel(
     discovery_client: Mock,
     grpc_channel: Mock,
     grpc_channel_pool: Mock,
     mocker: MockerFixture,
 ) -> None:
     mocker.patch(
-        "ni_measurementlink_service._drivers._grpcdevice.GRPC_DEVICE_ADDRESS", "[::1]:31763"
+        "ni_measurementlink_service._drivers._grpcdevice.GRPC_DEVICE_SERVER_ADDRESS", "[::1]:31763"
     )
     grpc_channel_pool.get_channel.return_value = grpc_channel
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Extract `get_grpc_device_server_location` in preparation for VISA gRPC support
- Rename gRPC device server option variables and function for consistency
- Change `GRPC_DEVICE_SERVER_ADDRESS` to expect a URL in preparation for TLS support
- Add debug logging
- Add more tests

### Why should this Pull Request be merged?

Consistency & prepare for VISA gRPC (soon) and TLS (later)

### What testing has been done?

Ran unit tests.