### PR TITLE
github: Don't sync dependency dashboard to AzDO

### DIFF
--- a/.github/workflows/sync_github_issues_to_azdo.yml
+++ b/.github/workflows/sync_github_issues_to_azdo.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   alert:
-    if: ${{ !github.event.issue.pull_request }}
+    if: ${{ !github.event.issue.pull_request && github.event.issue.title != "Dependency Dashboard" }}
     runs-on: ubuntu-latest
     steps:
       - name: Choose work item type


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Exclude "Dependency Dashboard" issue when syncing to Azure Devops.

### Why should this Pull Request be merged?

Keep "Dependency Dashboard" out of bug backlog.

### What testing has been done?

None