### PR TITLE
github: Fix syntax error in `sync_github_issues_to_azdo.yml`

### DIFF
--- a/.github/workflows/sync_github_issues_to_azdo.yml
+++ b/.github/workflows/sync_github_issues_to_azdo.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   alert:
-    if: ${{ !github.event.issue.pull_request && github.event.issue.title != "Dependency Dashboard" }}
+    if: ${{ !github.event.issue.pull_request && github.event.issue.title != 'Dependency Dashboard' }}
     runs-on: ubuntu-latest
     steps:
       - name: Choose work item type


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Strings in GitHub expressions must use single quotes, not double quotes.

### Why should this Pull Request be merged?

Fix AzDO sync job

### What testing has been done?

None