### PR TITLE
examples: Add gRPC support to VISA examples

### DIFF
--- a/examples/nivisa_dmm_measurement/_visa_dmm_session_management.py
+++ b/examples/nivisa_dmm_measurement/_visa_dmm_session_management.py
@@ -1,0 +1,62 @@
+import logging
+
+from _visa_dmm import Session
+from _visa_grpc import build_visa_grpc_resource_string, get_visa_grpc_insecure_address
+from decouple import AutoConfig
+from ni_measurementlink_service.discovery import DiscoveryClient
+from ni_measurementlink_service.session_management import (
+    SessionInformation,
+    SessionInitializationBehavior,
+)
+
+_logger = logging.getLogger(__name__)
+
+
+class VisaDmmSessionConstructor:
+    """MeasurementLink session constructor for VISA DMM sessions."""
+
+    def __init__(
+        self,
+        config: AutoConfig,
+        discovery_client: DiscoveryClient,
+        initialization_behavior: SessionInitializationBehavior = SessionInitializationBehavior.AUTO,
+    ) -> None:
+        """Construct a VisaDmmSessionConstructor."""
+        self._config = config
+        self._discovery_client = discovery_client
+        self._initialization_behavior = initialization_behavior
+
+        # Hack: config is a parameter for now so TestStand code modules use the right config path.
+        self._visa_dmm_simulate: bool = config(
+            "MEASUREMENTLINK_VISA_DMM_SIMULATE", default=False, cast=bool
+        )
+
+        if self._visa_dmm_simulate:
+            # _visa_dmm_sim.yaml doesn't include the grpc:// resource names.
+            _logger.debug("Not using NI gRPC Device Server due to simulation")
+            self._address = ""
+        else:
+            self._address = get_visa_grpc_insecure_address(config, discovery_client)
+            if self._address:
+                _logger.debug("NI gRPC Device Server address: http://%s", self._address)
+            else:
+                _logger.debug("Not using NI gRPC Device Server")
+
+    def __call__(self, session_info: SessionInformation) -> Session:
+        """Construct a VISA DMM session based on MeasurementLink session info."""
+        resource_name = session_info.resource_name
+        if self._address:
+            resource_name = build_visa_grpc_resource_string(
+                resource_name,
+                self._address,
+                session_info.session_name,
+                self._initialization_behavior,
+            )
+
+        # When this measurement is called from outside of TestStand (session_exists
+        # == False), reset the instrument to a known state. In TestStand,
+        # ProcessSetup resets the instrument.
+        reset_device = not session_info.session_exists
+
+        _logger.debug("VISA resource name: %s", resource_name)
+        return Session(resource_name, reset_device=reset_device, simulate=self._visa_dmm_simulate)

--- a/examples/nivisa_dmm_measurement/_visa_grpc.py
+++ b/examples/nivisa_dmm_measurement/_visa_grpc.py
@@ -1,0 +1,52 @@
+from urllib.parse import urlencode, urlsplit
+
+from decouple import AutoConfig
+from ni_measurementlink_service.discovery import DiscoveryClient
+from ni_measurementlink_service.session_management import SessionInitializationBehavior
+
+_INITIALIZATION_BEHAVIOR = {
+    SessionInitializationBehavior.AUTO: 0,
+    SessionInitializationBehavior.INITIALIZE_SERVER_SESSION: 1,
+    SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION: 2,
+    SessionInitializationBehavior.INITIALIZE_SESSION_THEN_DETACH: 3,
+    SessionInitializationBehavior.ATTACH_TO_SESSION_THEN_CLOSE: 4,
+}
+
+GRPC_SERVICE_INTERFACE_NAME = "visa_grpc.Visa"
+SERVICE_CLASS = "ni.measurementlink.v1.grpcdeviceserver"
+
+
+def build_visa_grpc_resource_string(
+    resource_name: str,
+    address: str,
+    session_name: str = "",
+    initialization_behavior: SessionInitializationBehavior = SessionInitializationBehavior.AUTO,
+) -> str:
+    """Build an grpc:// resource string for remoting with NI-VISA."""
+    query = {
+        "init_behavior": _INITIALIZATION_BEHAVIOR[initialization_behavior],
+        "session_name": session_name,
+    }
+    return f"grpc://{address}/{resource_name}?" + urlencode(query)
+
+
+def get_visa_grpc_insecure_address(config: AutoConfig, discovery_client: DiscoveryClient) -> str:
+    """Get the insecure address of NI gRPC Device Server's VISA interface in host:port format."""
+    # Hack: config is a parameter for now so TestStand code modules use the right config path.
+    use_grpc_device_server: bool = config(
+        "MEASUREMENTLINK_USE_GRPC_DEVICE_SERVER", default=True, cast=bool
+    )
+    grpc_device_server_address: str = config(
+        "MEASUREMENTLINK_GRPC_DEVICE_SERVER_ADDRESS", default=""
+    )
+
+    if not use_grpc_device_server:
+        return ""
+
+    if grpc_device_server_address:
+        return urlsplit(grpc_device_server_address).netloc
+    else:
+        service_location = discovery_client.resolve_service(
+            "visa_grpc.Visa", "ni.measurementlink.v1.grpcdeviceserver"
+        )
+        return service_location.insecure_address

--- a/examples/output_voltage_measurement/_visa_dmm_session_management.py
+++ b/examples/output_voltage_measurement/_visa_dmm_session_management.py
@@ -1,0 +1,62 @@
+import logging
+
+from _visa_dmm import Session
+from _visa_grpc import build_visa_grpc_resource_string, get_visa_grpc_insecure_address
+from decouple import AutoConfig
+from ni_measurementlink_service.discovery import DiscoveryClient
+from ni_measurementlink_service.session_management import (
+    SessionInformation,
+    SessionInitializationBehavior,
+)
+
+_logger = logging.getLogger(__name__)
+
+
+class VisaDmmSessionConstructor:
+    """MeasurementLink session constructor for VISA DMM sessions."""
+
+    def __init__(
+        self,
+        config: AutoConfig,
+        discovery_client: DiscoveryClient,
+        initialization_behavior: SessionInitializationBehavior = SessionInitializationBehavior.AUTO,
+    ) -> None:
+        """Construct a VisaDmmSessionConstructor."""
+        self._config = config
+        self._discovery_client = discovery_client
+        self._initialization_behavior = initialization_behavior
+
+        # Hack: config is a parameter for now so TestStand code modules use the right config path.
+        self._visa_dmm_simulate: bool = config(
+            "MEASUREMENTLINK_VISA_DMM_SIMULATE", default=False, cast=bool
+        )
+
+        if self._visa_dmm_simulate:
+            # _visa_dmm_sim.yaml doesn't include the grpc:// resource names.
+            _logger.debug("Not using NI gRPC Device Server due to simulation")
+            self._address = ""
+        else:
+            self._address = get_visa_grpc_insecure_address(config, discovery_client)
+            if self._address:
+                _logger.debug("NI gRPC Device Server address: http://%s", self._address)
+            else:
+                _logger.debug("Not using NI gRPC Device Server")
+
+    def __call__(self, session_info: SessionInformation) -> Session:
+        """Construct a VISA DMM session based on MeasurementLink session info."""
+        resource_name = session_info.resource_name
+        if self._address:
+            resource_name = build_visa_grpc_resource_string(
+                resource_name,
+                self._address,
+                session_info.session_name,
+                self._initialization_behavior,
+            )
+
+        # When this measurement is called from outside of TestStand (session_exists
+        # == False), reset the instrument to a known state. In TestStand,
+        # ProcessSetup resets the instrument.
+        reset_device = not session_info.session_exists
+
+        _logger.debug("VISA resource name: %s", resource_name)
+        return Session(resource_name, reset_device=reset_device, simulate=self._visa_dmm_simulate)

--- a/examples/output_voltage_measurement/_visa_grpc.py
+++ b/examples/output_voltage_measurement/_visa_grpc.py
@@ -1,0 +1,52 @@
+from urllib.parse import urlencode, urlsplit
+
+from decouple import AutoConfig
+from ni_measurementlink_service.discovery import DiscoveryClient
+from ni_measurementlink_service.session_management import SessionInitializationBehavior
+
+_INITIALIZATION_BEHAVIOR = {
+    SessionInitializationBehavior.AUTO: 0,
+    SessionInitializationBehavior.INITIALIZE_SERVER_SESSION: 1,
+    SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION: 2,
+    SessionInitializationBehavior.INITIALIZE_SESSION_THEN_DETACH: 3,
+    SessionInitializationBehavior.ATTACH_TO_SESSION_THEN_CLOSE: 4,
+}
+
+GRPC_SERVICE_INTERFACE_NAME = "visa_grpc.Visa"
+SERVICE_CLASS = "ni.measurementlink.v1.grpcdeviceserver"
+
+
+def build_visa_grpc_resource_string(
+    resource_name: str,
+    address: str,
+    session_name: str = "",
+    initialization_behavior: SessionInitializationBehavior = SessionInitializationBehavior.AUTO,
+) -> str:
+    """Build an grpc:// resource string for remoting with NI-VISA."""
+    query = {
+        "init_behavior": _INITIALIZATION_BEHAVIOR[initialization_behavior],
+        "session_name": session_name,
+    }
+    return f"grpc://{address}/{resource_name}?" + urlencode(query)
+
+
+def get_visa_grpc_insecure_address(config: AutoConfig, discovery_client: DiscoveryClient) -> str:
+    """Get the insecure address of NI gRPC Device Server's VISA interface in host:port format."""
+    # Hack: config is a parameter for now so TestStand code modules use the right config path.
+    use_grpc_device_server: bool = config(
+        "MEASUREMENTLINK_USE_GRPC_DEVICE_SERVER", default=True, cast=bool
+    )
+    grpc_device_server_address: str = config(
+        "MEASUREMENTLINK_GRPC_DEVICE_SERVER_ADDRESS", default=""
+    )
+
+    if not use_grpc_device_server:
+        return ""
+
+    if grpc_device_server_address:
+        return urlsplit(grpc_device_server_address).netloc
+    else:
+        service_location = discovery_client.resolve_service(
+            "visa_grpc.Visa", "ni.measurementlink.v1.grpcdeviceserver"
+        )
+        return service_location.insecure_address


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update `nivisa_dmm_measurement` and `output_voltage_measurement` to use NI gRPC Device Server.

`_visa_dmm_session_management.py`, `_visa_grpc.py`, and `teststand_visa_dmm.py` are duplicated or "vendored" in each example.

I would like to move some of the VISA session management code into `ni-measurementlink-service` (https://github.com/ni/measurementlink-python/pull/522 is intended to move in that direction), but for now I'm adding it as example code.

### Why should this Pull Request be merged?

Allow sharing VISA sessions between multiple measurement services.

### What testing has been done?

- Manually tested `nivisa_dmm_measurement` with a physical HP 34401A, simulation, and various permutations of `USE_GRPC_DEVICE_SERVER` and `GRPC_DEVICE_SERVER_ADDRESS`.
- Manually tested `output_voltage_measurement` with physical NI PXIe-4141 and HP 34401A instruments.
- The examples run without errors but I filed [AB#2582855: MeasurementLink VISA gRPC TestStand workflow seems to be opening new sessions instead of attaching/detaching](https://dev.azure.com/ni/DevCentral/_workitems/edit/2582855/).