### PR TITLE
renovate: Automerge patch updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "branchPrefix": "users/renovate/",
-  "extends": ["config:recommended", ":maintainLockFilesWeekly"]
+  "extends": [
+    "config:recommended", 
+    ":maintainLockFilesWeekly",
+    ":automergePatch",
+    "schedule:automergeDaily"
+  ]
 }


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Allow Renovate to auto-merge updates to patch versions (1.2.x) and lock file maintenance. It should create a PR at whatever time and then merge it before 4am the next day unless a human reviewer comments on the PR.

Note: I changed the repo settings to allow Renovate to bypass the pull request requirement.

### Why should this Pull Request be merged?

Make approving trivial updates optional.

### What testing has been done?

None