### PR TITLE
pyproject.toml: Update Tox minimum version to 4.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1192,7 +1192,7 @@ niswitch = ["niswitch"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "5dd5d6946778802e0920b2bf9792a5e28615367efdc708c9e1347d70785caf36"
+content-hash = "88ff76a8419a7295f97797c6f1198ef4ade07b1d8151362f9129c2dad23b50fa"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ grpcio-tools = [
 ]
 pytest-cov = ">=3.0.0"
 pytest-mock = ">=3.0"
-tox = ">=3.24"
+tox = ">=4.0"
 mypy = ">=1.0"
 mypy-protobuf = ">=3.4"
 types-protobuf = "^4.21"


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update Tox version constraint to >=4.0.

### Why should this Pull Request be merged?

https://www.github.com/pypa/virtualenv/issues/2666 caused Tox to be incorrectly downgraded to 3.x.

### What testing has been done?

`poetry lock --no-update` did not complain.