### PR TITLE
examples: remove PinMapClient class from _helpers.py

### DIFF
--- a/examples/game_of_life/_helpers.py
+++ b/examples/game_of_life/_helpers.py
@@ -43,7 +43,7 @@ class TestStandSupport(object):
         self._sequence_context = sequence_context
 
     def get_active_pin_map_id(self) -> str:
-        """Get the active pin map id from the NI.MeasurementLink.PinMapId temporary global variable.
+        """Get the active pin map id from the NI.MeasurementLink.PinMapId runtime variable.
 
         Returns:
             The resource id of the pin map that is registered to the pin map service.

--- a/examples/game_of_life/_helpers.py
+++ b/examples/game_of_life/_helpers.py
@@ -6,42 +6,8 @@ from typing import Any, Callable, TypeVar
 
 import click
 import grpc
-from ni_measurementlink_service._internal.stubs.ni.measurementlink.pinmap.v1 import (
-    pin_map_service_pb2,
-    pin_map_service_pb2_grpc,
-)
 from ni_measurementlink_service.discovery import DiscoveryClient
 from ni_measurementlink_service.measurement.service import GrpcChannelPool
-
-
-class PinMapClient(object):
-    """Class that communicates with the pin map service."""
-
-    def __init__(self, *, grpc_channel: grpc.Channel):
-        """Initialize pin map client."""
-        self._client: pin_map_service_pb2_grpc.PinMapServiceStub = (
-            pin_map_service_pb2_grpc.PinMapServiceStub(grpc_channel)
-        )
-
-    def update_pin_map(self, pin_map_path: str) -> str:
-        """Update registered pin map contents.
-
-        Create and register a pin map if a pin map resource for the specified pin map id is not
-        found.
-
-        Args:
-            pin_map_path: The file path of the pin map to register as a pin map resource.
-
-        Returns:
-            The resource id of the pin map that is registered to the pin map service.
-        """
-        pin_map_path_obj = pathlib.Path(pin_map_path)
-        # By convention, the pin map id is the .pinmap file path.
-        request = pin_map_service_pb2.UpdatePinMapFromXmlRequest(
-            pin_map_id=pin_map_path, pin_map_xml=pin_map_path_obj.read_text(encoding="utf-8")
-        )
-        response: pin_map_service_pb2.PinMap = self._client.UpdatePinMapFromXml(request)
-        return response.pin_map_id
 
 
 class GrpcChannelPoolHelper(GrpcChannelPool):
@@ -82,19 +48,8 @@ class TestStandSupport(object):
         Returns:
             The resource id of the pin map that is registered to the pin map service.
         """
-        return self._sequence_context.Engine.TemporaryGlobals.GetValString(
+        return self._sequence_context.Execution.RunTimeVariables.GetValString(
             "NI.MeasurementLink.PinMapId", 0x0
-        )
-
-    def set_active_pin_map_id(self, pin_map_id: str) -> None:
-        """Set the NI.MeasurementLink.PinMapId temporary global variable to the specified id.
-
-        Args:
-            pin_map_id:
-                The resource id of the pin map that is registered to the pin map service.
-        """
-        self._sequence_context.Engine.TemporaryGlobals.SetValString(
-            "NI.MeasurementLink.PinMapId", 0x1, pin_map_id
         )
 
     def resolve_file_path(self, file_path: str) -> str:

--- a/examples/nidaqmx_analog_input/_helpers.py
+++ b/examples/nidaqmx_analog_input/_helpers.py
@@ -43,7 +43,7 @@ class TestStandSupport(object):
         self._sequence_context = sequence_context
 
     def get_active_pin_map_id(self) -> str:
-        """Get the active pin map id from the NI.MeasurementLink.PinMapId temporary global variable.
+        """Get the active pin map id from the NI.MeasurementLink.PinMapId runtime variable.
 
         Returns:
             The resource id of the pin map that is registered to the pin map service.

--- a/examples/nidaqmx_analog_input/_helpers.py
+++ b/examples/nidaqmx_analog_input/_helpers.py
@@ -6,42 +6,8 @@ from typing import Any, Callable, TypeVar
 
 import click
 import grpc
-from ni_measurementlink_service._internal.stubs.ni.measurementlink.pinmap.v1 import (
-    pin_map_service_pb2,
-    pin_map_service_pb2_grpc,
-)
 from ni_measurementlink_service.discovery import DiscoveryClient
 from ni_measurementlink_service.measurement.service import GrpcChannelPool
-
-
-class PinMapClient(object):
-    """Class that communicates with the pin map service."""
-
-    def __init__(self, *, grpc_channel: grpc.Channel):
-        """Initialize pin map client."""
-        self._client: pin_map_service_pb2_grpc.PinMapServiceStub = (
-            pin_map_service_pb2_grpc.PinMapServiceStub(grpc_channel)
-        )
-
-    def update_pin_map(self, pin_map_path: str) -> str:
-        """Update registered pin map contents.
-
-        Create and register a pin map if a pin map resource for the specified pin map id is not
-        found.
-
-        Args:
-            pin_map_path: The file path of the pin map to register as a pin map resource.
-
-        Returns:
-            The resource id of the pin map that is registered to the pin map service.
-        """
-        pin_map_path_obj = pathlib.Path(pin_map_path)
-        # By convention, the pin map id is the .pinmap file path.
-        request = pin_map_service_pb2.UpdatePinMapFromXmlRequest(
-            pin_map_id=pin_map_path, pin_map_xml=pin_map_path_obj.read_text(encoding="utf-8")
-        )
-        response: pin_map_service_pb2.PinMap = self._client.UpdatePinMapFromXml(request)
-        return response.pin_map_id
 
 
 class GrpcChannelPoolHelper(GrpcChannelPool):

--- a/examples/nidcpower_source_dc_voltage/_helpers.py
+++ b/examples/nidcpower_source_dc_voltage/_helpers.py
@@ -43,7 +43,7 @@ class TestStandSupport(object):
         self._sequence_context = sequence_context
 
     def get_active_pin_map_id(self) -> str:
-        """Get the active pin map id from the NI.MeasurementLink.PinMapId temporary global variable.
+        """Get the active pin map id from the NI.MeasurementLink.PinMapId runtime variable.
 
         Returns:
             The resource id of the pin map that is registered to the pin map service.

--- a/examples/nidcpower_source_dc_voltage/_helpers.py
+++ b/examples/nidcpower_source_dc_voltage/_helpers.py
@@ -6,42 +6,8 @@ from typing import Any, Callable, TypeVar
 
 import click
 import grpc
-from ni_measurementlink_service._internal.stubs.ni.measurementlink.pinmap.v1 import (
-    pin_map_service_pb2,
-    pin_map_service_pb2_grpc,
-)
 from ni_measurementlink_service.discovery import DiscoveryClient
 from ni_measurementlink_service.measurement.service import GrpcChannelPool
-
-
-class PinMapClient(object):
-    """Class that communicates with the pin map service."""
-
-    def __init__(self, *, grpc_channel: grpc.Channel):
-        """Initialize pin map client."""
-        self._client: pin_map_service_pb2_grpc.PinMapServiceStub = (
-            pin_map_service_pb2_grpc.PinMapServiceStub(grpc_channel)
-        )
-
-    def update_pin_map(self, pin_map_path: str) -> str:
-        """Update registered pin map contents.
-
-        Create and register a pin map if a pin map resource for the specified pin map id is not
-        found.
-
-        Args:
-            pin_map_path: The file path of the pin map to register as a pin map resource.
-
-        Returns:
-            The resource id of the pin map that is registered to the pin map service.
-        """
-        pin_map_path_obj = pathlib.Path(pin_map_path)
-        # By convention, the pin map id is the .pinmap file path.
-        request = pin_map_service_pb2.UpdatePinMapFromXmlRequest(
-            pin_map_id=pin_map_path, pin_map_xml=pin_map_path_obj.read_text(encoding="utf-8")
-        )
-        response: pin_map_service_pb2.PinMap = self._client.UpdatePinMapFromXml(request)
-        return response.pin_map_id
 
 
 class GrpcChannelPoolHelper(GrpcChannelPool):

--- a/examples/nidigital_spi/_helpers.py
+++ b/examples/nidigital_spi/_helpers.py
@@ -43,7 +43,7 @@ class TestStandSupport(object):
         self._sequence_context = sequence_context
 
     def get_active_pin_map_id(self) -> str:
-        """Get the active pin map id from the NI.MeasurementLink.PinMapId temporary global variable.
+        """Get the active pin map id from the NI.MeasurementLink.PinMapId runtime variable.
 
         Returns:
             The resource id of the pin map that is registered to the pin map service.

--- a/examples/nidigital_spi/_helpers.py
+++ b/examples/nidigital_spi/_helpers.py
@@ -6,42 +6,8 @@ from typing import Any, Callable, TypeVar
 
 import click
 import grpc
-from ni_measurementlink_service._internal.stubs.ni.measurementlink.pinmap.v1 import (
-    pin_map_service_pb2,
-    pin_map_service_pb2_grpc,
-)
 from ni_measurementlink_service.discovery import DiscoveryClient
 from ni_measurementlink_service.measurement.service import GrpcChannelPool
-
-
-class PinMapClient(object):
-    """Class that communicates with the pin map service."""
-
-    def __init__(self, *, grpc_channel: grpc.Channel):
-        """Initialize pin map client."""
-        self._client: pin_map_service_pb2_grpc.PinMapServiceStub = (
-            pin_map_service_pb2_grpc.PinMapServiceStub(grpc_channel)
-        )
-
-    def update_pin_map(self, pin_map_path: str) -> str:
-        """Update registered pin map contents.
-
-        Create and register a pin map if a pin map resource for the specified pin map id is not
-        found.
-
-        Args:
-            pin_map_path: The file path of the pin map to register as a pin map resource.
-
-        Returns:
-            The resource id of the pin map that is registered to the pin map service.
-        """
-        pin_map_path_obj = pathlib.Path(pin_map_path)
-        # By convention, the pin map id is the .pinmap file path.
-        request = pin_map_service_pb2.UpdatePinMapFromXmlRequest(
-            pin_map_id=pin_map_path, pin_map_xml=pin_map_path_obj.read_text(encoding="utf-8")
-        )
-        response: pin_map_service_pb2.PinMap = self._client.UpdatePinMapFromXml(request)
-        return response.pin_map_id
 
 
 class GrpcChannelPoolHelper(GrpcChannelPool):

--- a/examples/nidmm_measurement/_helpers.py
+++ b/examples/nidmm_measurement/_helpers.py
@@ -43,7 +43,7 @@ class TestStandSupport(object):
         self._sequence_context = sequence_context
 
     def get_active_pin_map_id(self) -> str:
-        """Get the active pin map id from the NI.MeasurementLink.PinMapId temporary global variable.
+        """Get the active pin map id from the NI.MeasurementLink.PinMapId runtime variable.
 
         Returns:
             The resource id of the pin map that is registered to the pin map service.

--- a/examples/nidmm_measurement/_helpers.py
+++ b/examples/nidmm_measurement/_helpers.py
@@ -6,42 +6,8 @@ from typing import Any, Callable, TypeVar
 
 import click
 import grpc
-from ni_measurementlink_service._internal.stubs.ni.measurementlink.pinmap.v1 import (
-    pin_map_service_pb2,
-    pin_map_service_pb2_grpc,
-)
 from ni_measurementlink_service.discovery import DiscoveryClient
 from ni_measurementlink_service.measurement.service import GrpcChannelPool
-
-
-class PinMapClient(object):
-    """Class that communicates with the pin map service."""
-
-    def __init__(self, *, grpc_channel: grpc.Channel):
-        """Initialize pin map client."""
-        self._client: pin_map_service_pb2_grpc.PinMapServiceStub = (
-            pin_map_service_pb2_grpc.PinMapServiceStub(grpc_channel)
-        )
-
-    def update_pin_map(self, pin_map_path: str) -> str:
-        """Update registered pin map contents.
-
-        Create and register a pin map if a pin map resource for the specified pin map id is not
-        found.
-
-        Args:
-            pin_map_path: The file path of the pin map to register as a pin map resource.
-
-        Returns:
-            The resource id of the pin map that is registered to the pin map service.
-        """
-        pin_map_path_obj = pathlib.Path(pin_map_path)
-        # By convention, the pin map id is the .pinmap file path.
-        request = pin_map_service_pb2.UpdatePinMapFromXmlRequest(
-            pin_map_id=pin_map_path, pin_map_xml=pin_map_path_obj.read_text(encoding="utf-8")
-        )
-        response: pin_map_service_pb2.PinMap = self._client.UpdatePinMapFromXml(request)
-        return response.pin_map_id
 
 
 class GrpcChannelPoolHelper(GrpcChannelPool):

--- a/examples/nifgen_standard_function/_helpers.py
+++ b/examples/nifgen_standard_function/_helpers.py
@@ -43,7 +43,7 @@ class TestStandSupport(object):
         self._sequence_context = sequence_context
 
     def get_active_pin_map_id(self) -> str:
-        """Get the active pin map id from the NI.MeasurementLink.PinMapId temporary global variable.
+        """Get the active pin map id from the NI.MeasurementLink.PinMapId runtime variable.
 
         Returns:
             The resource id of the pin map that is registered to the pin map service.

--- a/examples/nifgen_standard_function/_helpers.py
+++ b/examples/nifgen_standard_function/_helpers.py
@@ -6,42 +6,8 @@ from typing import Any, Callable, TypeVar
 
 import click
 import grpc
-from ni_measurementlink_service._internal.stubs.ni.measurementlink.pinmap.v1 import (
-    pin_map_service_pb2,
-    pin_map_service_pb2_grpc,
-)
 from ni_measurementlink_service.discovery import DiscoveryClient
 from ni_measurementlink_service.measurement.service import GrpcChannelPool
-
-
-class PinMapClient(object):
-    """Class that communicates with the pin map service."""
-
-    def __init__(self, *, grpc_channel: grpc.Channel):
-        """Initialize pin map client."""
-        self._client: pin_map_service_pb2_grpc.PinMapServiceStub = (
-            pin_map_service_pb2_grpc.PinMapServiceStub(grpc_channel)
-        )
-
-    def update_pin_map(self, pin_map_path: str) -> str:
-        """Update registered pin map contents.
-
-        Create and register a pin map if a pin map resource for the specified pin map id is not
-        found.
-
-        Args:
-            pin_map_path: The file path of the pin map to register as a pin map resource.
-
-        Returns:
-            The resource id of the pin map that is registered to the pin map service.
-        """
-        pin_map_path_obj = pathlib.Path(pin_map_path)
-        # By convention, the pin map id is the .pinmap file path.
-        request = pin_map_service_pb2.UpdatePinMapFromXmlRequest(
-            pin_map_id=pin_map_path, pin_map_xml=pin_map_path_obj.read_text(encoding="utf-8")
-        )
-        response: pin_map_service_pb2.PinMap = self._client.UpdatePinMapFromXml(request)
-        return response.pin_map_id
 
 
 class GrpcChannelPoolHelper(GrpcChannelPool):

--- a/examples/niscope_acquire_waveform/_helpers.py
+++ b/examples/niscope_acquire_waveform/_helpers.py
@@ -43,7 +43,7 @@ class TestStandSupport(object):
         self._sequence_context = sequence_context
 
     def get_active_pin_map_id(self) -> str:
-        """Get the active pin map id from the NI.MeasurementLink.PinMapId temporary global variable.
+        """Get the active pin map id from the NI.MeasurementLink.PinMapId runtime variable.
 
         Returns:
             The resource id of the pin map that is registered to the pin map service.

--- a/examples/niscope_acquire_waveform/_helpers.py
+++ b/examples/niscope_acquire_waveform/_helpers.py
@@ -6,42 +6,8 @@ from typing import Any, Callable, TypeVar
 
 import click
 import grpc
-from ni_measurementlink_service._internal.stubs.ni.measurementlink.pinmap.v1 import (
-    pin_map_service_pb2,
-    pin_map_service_pb2_grpc,
-)
 from ni_measurementlink_service.discovery import DiscoveryClient
 from ni_measurementlink_service.measurement.service import GrpcChannelPool
-
-
-class PinMapClient(object):
-    """Class that communicates with the pin map service."""
-
-    def __init__(self, *, grpc_channel: grpc.Channel):
-        """Initialize pin map client."""
-        self._client: pin_map_service_pb2_grpc.PinMapServiceStub = (
-            pin_map_service_pb2_grpc.PinMapServiceStub(grpc_channel)
-        )
-
-    def update_pin_map(self, pin_map_path: str) -> str:
-        """Update registered pin map contents.
-
-        Create and register a pin map if a pin map resource for the specified pin map id is not
-        found.
-
-        Args:
-            pin_map_path: The file path of the pin map to register as a pin map resource.
-
-        Returns:
-            The resource id of the pin map that is registered to the pin map service.
-        """
-        pin_map_path_obj = pathlib.Path(pin_map_path)
-        # By convention, the pin map id is the .pinmap file path.
-        request = pin_map_service_pb2.UpdatePinMapFromXmlRequest(
-            pin_map_id=pin_map_path, pin_map_xml=pin_map_path_obj.read_text(encoding="utf-8")
-        )
-        response: pin_map_service_pb2.PinMap = self._client.UpdatePinMapFromXml(request)
-        return response.pin_map_id
 
 
 class GrpcChannelPoolHelper(GrpcChannelPool):

--- a/examples/niswitch_control_relays/_helpers.py
+++ b/examples/niswitch_control_relays/_helpers.py
@@ -43,7 +43,7 @@ class TestStandSupport(object):
         self._sequence_context = sequence_context
 
     def get_active_pin_map_id(self) -> str:
-        """Get the active pin map id from the NI.MeasurementLink.PinMapId temporary global variable.
+        """Get the active pin map id from the NI.MeasurementLink.PinMapId runtime variable.
 
         Returns:
             The resource id of the pin map that is registered to the pin map service.

--- a/examples/niswitch_control_relays/_helpers.py
+++ b/examples/niswitch_control_relays/_helpers.py
@@ -6,42 +6,8 @@ from typing import Any, Callable, TypeVar
 
 import click
 import grpc
-from ni_measurementlink_service._internal.stubs.ni.measurementlink.pinmap.v1 import (
-    pin_map_service_pb2,
-    pin_map_service_pb2_grpc,
-)
 from ni_measurementlink_service.discovery import DiscoveryClient
 from ni_measurementlink_service.measurement.service import GrpcChannelPool
-
-
-class PinMapClient(object):
-    """Class that communicates with the pin map service."""
-
-    def __init__(self, *, grpc_channel: grpc.Channel):
-        """Initialize pin map client."""
-        self._client: pin_map_service_pb2_grpc.PinMapServiceStub = (
-            pin_map_service_pb2_grpc.PinMapServiceStub(grpc_channel)
-        )
-
-    def update_pin_map(self, pin_map_path: str) -> str:
-        """Update registered pin map contents.
-
-        Create and register a pin map if a pin map resource for the specified pin map id is not
-        found.
-
-        Args:
-            pin_map_path: The file path of the pin map to register as a pin map resource.
-
-        Returns:
-            The resource id of the pin map that is registered to the pin map service.
-        """
-        pin_map_path_obj = pathlib.Path(pin_map_path)
-        # By convention, the pin map id is the .pinmap file path.
-        request = pin_map_service_pb2.UpdatePinMapFromXmlRequest(
-            pin_map_id=pin_map_path, pin_map_xml=pin_map_path_obj.read_text(encoding="utf-8")
-        )
-        response: pin_map_service_pb2.PinMap = self._client.UpdatePinMapFromXml(request)
-        return response.pin_map_id
 
 
 class GrpcChannelPoolHelper(GrpcChannelPool):

--- a/examples/nivisa_dmm_measurement/_helpers.py
+++ b/examples/nivisa_dmm_measurement/_helpers.py
@@ -43,7 +43,7 @@ class TestStandSupport(object):
         self._sequence_context = sequence_context
 
     def get_active_pin_map_id(self) -> str:
-        """Get the active pin map id from the NI.MeasurementLink.PinMapId temporary global variable.
+        """Get the active pin map id from the NI.MeasurementLink.PinMapId runtime variable.
 
         Returns:
             The resource id of the pin map that is registered to the pin map service.

--- a/examples/nivisa_dmm_measurement/_helpers.py
+++ b/examples/nivisa_dmm_measurement/_helpers.py
@@ -65,13 +65,7 @@ class TestStandSupport(object):
         """
         if pathlib.Path(file_path).is_absolute():
             return file_path
-        (
-            _,
-            absolute_path,
-            _,
-            _,
-            user_canceled,
-        ) = self._sequence_context.Engine.FindFileEx(
+        (_, absolute_path, _, _, user_canceled) = self._sequence_context.Engine.FindFileEx(
             fileToFind=file_path,
             absolutePath=None,
             srchDirType=None,

--- a/examples/nivisa_dmm_measurement/_helpers.py
+++ b/examples/nivisa_dmm_measurement/_helpers.py
@@ -6,43 +6,8 @@ from typing import Any, Callable, TypeVar
 
 import click
 import grpc
-from ni_measurementlink_service._internal.stubs.ni.measurementlink.pinmap.v1 import (
-    pin_map_service_pb2,
-    pin_map_service_pb2_grpc,
-)
 from ni_measurementlink_service.discovery import DiscoveryClient
 from ni_measurementlink_service.measurement.service import GrpcChannelPool
-
-
-class PinMapClient(object):
-    """Class that communicates with the pin map service."""
-
-    def __init__(self, *, grpc_channel: grpc.Channel):
-        """Initialize pin map client."""
-        self._client: pin_map_service_pb2_grpc.PinMapServiceStub = (
-            pin_map_service_pb2_grpc.PinMapServiceStub(grpc_channel)
-        )
-
-    def update_pin_map(self, pin_map_path: str) -> str:
-        """Update registered pin map contents.
-
-        Create and register a pin map if a pin map resource for the specified pin map id is not
-        found.
-
-        Args:
-            pin_map_path: The file path of the pin map to register as a pin map resource.
-
-        Returns:
-            The resource id of the pin map that is registered to the pin map service.
-        """
-        pin_map_path_obj = pathlib.Path(pin_map_path)
-        # By convention, the pin map id is the .pinmap file path.
-        request = pin_map_service_pb2.UpdatePinMapFromXmlRequest(
-            pin_map_id=pin_map_path,
-            pin_map_xml=pin_map_path_obj.read_text(encoding="utf-8"),
-        )
-        response: pin_map_service_pb2.PinMap = self._client.UpdatePinMapFromXml(request)
-        return response.pin_map_id
 
 
 class GrpcChannelPoolHelper(GrpcChannelPool):

--- a/examples/output_voltage_measurement/_helpers.py
+++ b/examples/output_voltage_measurement/_helpers.py
@@ -43,7 +43,7 @@ class TestStandSupport(object):
         self._sequence_context = sequence_context
 
     def get_active_pin_map_id(self) -> str:
-        """Get the active pin map id from the NI.MeasurementLink.PinMapId temporary global variable.
+        """Get the active pin map id from the NI.MeasurementLink.PinMapId runtime variable.
 
         Returns:
             The resource id of the pin map that is registered to the pin map service.

--- a/examples/output_voltage_measurement/_helpers.py
+++ b/examples/output_voltage_measurement/_helpers.py
@@ -6,42 +6,8 @@ from typing import Any, Callable, TypeVar
 
 import click
 import grpc
-from ni_measurementlink_service._internal.stubs.ni.measurementlink.pinmap.v1 import (
-    pin_map_service_pb2,
-    pin_map_service_pb2_grpc,
-)
 from ni_measurementlink_service.discovery import DiscoveryClient
 from ni_measurementlink_service.measurement.service import GrpcChannelPool
-
-
-class PinMapClient(object):
-    """Class that communicates with the pin map service."""
-
-    def __init__(self, *, grpc_channel: grpc.Channel):
-        """Initialize pin map client."""
-        self._client: pin_map_service_pb2_grpc.PinMapServiceStub = (
-            pin_map_service_pb2_grpc.PinMapServiceStub(grpc_channel)
-        )
-
-    def update_pin_map(self, pin_map_path: str) -> str:
-        """Update registered pin map contents.
-
-        Create and register a pin map if a pin map resource for the specified pin map id is not
-        found.
-
-        Args:
-            pin_map_path: The file path of the pin map to register as a pin map resource.
-
-        Returns:
-            The resource id of the pin map that is registered to the pin map service.
-        """
-        pin_map_path_obj = pathlib.Path(pin_map_path)
-        # By convention, the pin map id is the .pinmap file path.
-        request = pin_map_service_pb2.UpdatePinMapFromXmlRequest(
-            pin_map_id=pin_map_path, pin_map_xml=pin_map_path_obj.read_text(encoding="utf-8")
-        )
-        response: pin_map_service_pb2.PinMap = self._client.UpdatePinMapFromXml(request)
-        return response.pin_map_id
 
 
 class GrpcChannelPoolHelper(GrpcChannelPool):

--- a/examples/sample_measurement/_helpers.py
+++ b/examples/sample_measurement/_helpers.py
@@ -43,7 +43,7 @@ class TestStandSupport(object):
         self._sequence_context = sequence_context
 
     def get_active_pin_map_id(self) -> str:
-        """Get the active pin map id from the NI.MeasurementLink.PinMapId temporary global variable.
+        """Get the active pin map id from the NI.MeasurementLink.PinMapId runtime variable.
 
         Returns:
             The resource id of the pin map that is registered to the pin map service.

--- a/examples/sample_measurement/_helpers.py
+++ b/examples/sample_measurement/_helpers.py
@@ -6,42 +6,8 @@ from typing import Any, Callable, TypeVar
 
 import click
 import grpc
-from ni_measurementlink_service._internal.stubs.ni.measurementlink.pinmap.v1 import (
-    pin_map_service_pb2,
-    pin_map_service_pb2_grpc,
-)
 from ni_measurementlink_service.discovery import DiscoveryClient
 from ni_measurementlink_service.measurement.service import GrpcChannelPool
-
-
-class PinMapClient(object):
-    """Class that communicates with the pin map service."""
-
-    def __init__(self, *, grpc_channel: grpc.Channel):
-        """Initialize pin map client."""
-        self._client: pin_map_service_pb2_grpc.PinMapServiceStub = (
-            pin_map_service_pb2_grpc.PinMapServiceStub(grpc_channel)
-        )
-
-    def update_pin_map(self, pin_map_path: str) -> str:
-        """Update registered pin map contents.
-
-        Create and register a pin map if a pin map resource for the specified pin map id is not
-        found.
-
-        Args:
-            pin_map_path: The file path of the pin map to register as a pin map resource.
-
-        Returns:
-            The resource id of the pin map that is registered to the pin map service.
-        """
-        pin_map_path_obj = pathlib.Path(pin_map_path)
-        # By convention, the pin map id is the .pinmap file path.
-        request = pin_map_service_pb2.UpdatePinMapFromXmlRequest(
-            pin_map_id=pin_map_path, pin_map_xml=pin_map_path_obj.read_text(encoding="utf-8")
-        )
-        response: pin_map_service_pb2.PinMap = self._client.UpdatePinMapFromXml(request)
-        return response.pin_map_id
 
 
 class GrpcChannelPoolHelper(GrpcChannelPool):
@@ -82,19 +48,8 @@ class TestStandSupport(object):
         Returns:
             The resource id of the pin map that is registered to the pin map service.
         """
-        return self._sequence_context.Engine.TemporaryGlobals.GetValString(
+        return self._sequence_context.Execution.RunTimeVariables.GetValString(
             "NI.MeasurementLink.PinMapId", 0x0
-        )
-
-    def set_active_pin_map_id(self, pin_map_id: str) -> None:
-        """Set the NI.MeasurementLink.PinMapId temporary global variable to the specified id.
-
-        Args:
-            pin_map_id:
-                The resource id of the pin map that is registered to the pin map service.
-        """
-        self._sequence_context.Engine.TemporaryGlobals.SetValString(
-            "NI.MeasurementLink.PinMapId", 0x1, pin_map_id
         )
 
     def resolve_file_path(self, file_path: str) -> str:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
This removes the PinMapClient class which is unused in the `_helpers.py`.

### Why should this Pull Request be merged?
With the "Update pin map" step, updating the pin map id to the Pin map service is now abstracted from the user. Hence, the PinMapClient class is not required in the `_helpers.py`.

### What testing has been done?
Ran mypy locally.