### PR TITLE
examples, generator: Remove GrpcChannelPoolHelper

### DIFF
--- a/examples/game_of_life/_helpers.py
+++ b/examples/game_of_life/_helpers.py
@@ -5,28 +5,6 @@ import pathlib
 from typing import Any, Callable, TypeVar
 
 import click
-import grpc
-from ni_measurementlink_service.discovery import DiscoveryClient
-from ni_measurementlink_service.measurement.service import GrpcChannelPool
-
-
-class GrpcChannelPoolHelper(GrpcChannelPool):
-    """Class that manages gRPC channel lifetimes."""
-
-    def __init__(self) -> None:
-        """Initialize the GrpcChannelPool object."""
-        super().__init__()
-        self._discovery_client = DiscoveryClient()
-
-    @property
-    def pin_map_channel(self) -> grpc.Channel:
-        """Return gRPC channel to pin map service."""
-        return self.get_channel(
-            self._discovery_client.resolve_service(
-                provided_interface="ni.measurementlink.pinmap.v1.PinMapService",
-                service_class="ni.measurementlink.pinmap.v1.PinMapService",
-            ).insecure_address
-        )
 
 
 class TestStandSupport(object):

--- a/examples/nidaqmx_analog_input/_helpers.py
+++ b/examples/nidaqmx_analog_input/_helpers.py
@@ -5,28 +5,6 @@ import pathlib
 from typing import Any, Callable, TypeVar
 
 import click
-import grpc
-from ni_measurementlink_service.discovery import DiscoveryClient
-from ni_measurementlink_service.measurement.service import GrpcChannelPool
-
-
-class GrpcChannelPoolHelper(GrpcChannelPool):
-    """Class that manages gRPC channel lifetimes."""
-
-    def __init__(self) -> None:
-        """Initialize the GrpcChannelPool object."""
-        super().__init__()
-        self._discovery_client = DiscoveryClient()
-
-    @property
-    def pin_map_channel(self) -> grpc.Channel:
-        """Return gRPC channel to pin map service."""
-        return self.get_channel(
-            self._discovery_client.resolve_service(
-                provided_interface="ni.measurementlink.pinmap.v1.PinMapService",
-                service_class="ni.measurementlink.pinmap.v1.PinMapService",
-            ).insecure_address
-        )
 
 
 class TestStandSupport(object):

--- a/examples/nidaqmx_analog_input/pyproject.toml
+++ b/examples/nidaqmx_analog_input/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidaqmx = { version = ">=0.8.0", extras = ["grpc"] }
-ni-measurementlink-service = {version = "^1.3.0-dev0", allow-prereleases = true}
+ni-measurementlink-service = {version = "^1.3.0-dev2", allow-prereleases = true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 
 [tool.poetry.group.dev.dependencies]

--- a/examples/nidaqmx_analog_input/teststand_nidaqmx.py
+++ b/examples/nidaqmx_analog_input/teststand_nidaqmx.py
@@ -1,8 +1,9 @@
 """Functions to set up and tear down sessions of NI-DAQmx devices in NI TestStand."""
 from typing import Any
 
-from _helpers import GrpcChannelPoolHelper, TestStandSupport
+from _helpers import TestStandSupport
 from ni_measurementlink_service.discovery import DiscoveryClient
+from ni_measurementlink_service.grpc.channelpool import GrpcChannelPool
 from ni_measurementlink_service.session_management import (
     INSTRUMENT_TYPE_NI_DAQMX,
     PinMapContext,
@@ -18,7 +19,7 @@ def create_nidaqmx_tasks(sequence_context: Any) -> None:
         sequence_context: The SequenceContext COM object from the TestStand sequence execution.
             (Dynamically typed.)
     """
-    with GrpcChannelPoolHelper() as grpc_channel_pool:
+    with GrpcChannelPool() as grpc_channel_pool:
         teststand_support = TestStandSupport(sequence_context)
         pin_map_id = teststand_support.get_active_pin_map_id()
         pin_map_context = PinMapContext(pin_map_id=pin_map_id, sites=None)
@@ -42,7 +43,7 @@ def create_nidaqmx_tasks(sequence_context: Any) -> None:
 
 def destroy_nidaqmx_tasks() -> None:
     """Destroy and unregister all NI-DAQmx tasks."""
-    with GrpcChannelPoolHelper() as grpc_channel_pool:
+    with GrpcChannelPool() as grpc_channel_pool:
         discovery_client = DiscoveryClient(grpc_channel_pool=grpc_channel_pool)
         session_management_client = SessionManagementClient(
             discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool

--- a/examples/nidcpower_source_dc_voltage/_helpers.py
+++ b/examples/nidcpower_source_dc_voltage/_helpers.py
@@ -5,28 +5,6 @@ import pathlib
 from typing import Any, Callable, TypeVar
 
 import click
-import grpc
-from ni_measurementlink_service.discovery import DiscoveryClient
-from ni_measurementlink_service.measurement.service import GrpcChannelPool
-
-
-class GrpcChannelPoolHelper(GrpcChannelPool):
-    """Class that manages gRPC channel lifetimes."""
-
-    def __init__(self) -> None:
-        """Initialize the GrpcChannelPool object."""
-        super().__init__()
-        self._discovery_client = DiscoveryClient()
-
-    @property
-    def pin_map_channel(self) -> grpc.Channel:
-        """Return gRPC channel to pin map service."""
-        return self.get_channel(
-            self._discovery_client.resolve_service(
-                provided_interface="ni.measurementlink.pinmap.v1.PinMapService",
-                service_class="ni.measurementlink.pinmap.v1.PinMapService",
-            ).insecure_address
-        )
 
 
 class TestStandSupport(object):

--- a/examples/nidcpower_source_dc_voltage/pyproject.toml
+++ b/examples/nidcpower_source_dc_voltage/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidcpower = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurementlink-service = {version = "^1.3.0-dev0", allow-prereleases = true}
+ni-measurementlink-service = {version = "^1.3.0-dev2", allow-prereleases = true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/nidcpower_source_dc_voltage/teststand_nidcpower.py
+++ b/examples/nidcpower_source_dc_voltage/teststand_nidcpower.py
@@ -1,8 +1,9 @@
 """Functions to set up and tear down sessions of NI-DCPower devices in NI TestStand."""
 from typing import Any
 
-from _helpers import GrpcChannelPoolHelper, TestStandSupport
+from _helpers import TestStandSupport
 from ni_measurementlink_service.discovery import DiscoveryClient
+from ni_measurementlink_service.grpc.channelpool import GrpcChannelPool
 from ni_measurementlink_service.session_management import (
     INSTRUMENT_TYPE_NI_DCPOWER,
     PinMapContext,
@@ -18,7 +19,7 @@ def create_nidcpower_sessions(sequence_context: Any) -> None:
         sequence_context: The SequenceContext COM object from the TestStand sequence execution.
             (Dynamically typed.)
     """
-    with GrpcChannelPoolHelper() as grpc_channel_pool:
+    with GrpcChannelPool() as grpc_channel_pool:
         teststand_support = TestStandSupport(sequence_context)
         pin_map_id = teststand_support.get_active_pin_map_id()
         pin_map_context = PinMapContext(pin_map_id=pin_map_id, sites=None)
@@ -40,7 +41,7 @@ def create_nidcpower_sessions(sequence_context: Any) -> None:
 
 def destroy_nidcpower_sessions() -> None:
     """Destroy and unregister all NI-DCPower sessions."""
-    with GrpcChannelPoolHelper() as grpc_channel_pool:
+    with GrpcChannelPool() as grpc_channel_pool:
         discovery_client = DiscoveryClient(grpc_channel_pool=grpc_channel_pool)
         session_management_client = SessionManagementClient(
             discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool

--- a/examples/nidigital_spi/_helpers.py
+++ b/examples/nidigital_spi/_helpers.py
@@ -5,28 +5,6 @@ import pathlib
 from typing import Any, Callable, TypeVar
 
 import click
-import grpc
-from ni_measurementlink_service.discovery import DiscoveryClient
-from ni_measurementlink_service.measurement.service import GrpcChannelPool
-
-
-class GrpcChannelPoolHelper(GrpcChannelPool):
-    """Class that manages gRPC channel lifetimes."""
-
-    def __init__(self) -> None:
-        """Initialize the GrpcChannelPool object."""
-        super().__init__()
-        self._discovery_client = DiscoveryClient()
-
-    @property
-    def pin_map_channel(self) -> grpc.Channel:
-        """Return gRPC channel to pin map service."""
-        return self.get_channel(
-            self._discovery_client.resolve_service(
-                provided_interface="ni.measurementlink.pinmap.v1.PinMapService",
-                service_class="ni.measurementlink.pinmap.v1.PinMapService",
-            ).insecure_address
-        )
 
 
 class TestStandSupport(object):

--- a/examples/nidigital_spi/pyproject.toml
+++ b/examples/nidigital_spi/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidigital = ">=1.4.4"
-ni-measurementlink-service = {version = "^1.3.0-dev0", allow-prereleases = true}
+ni-measurementlink-service = {version = "^1.3.0-dev2", allow-prereleases = true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/nidigital_spi/teststand_nidigital.py
+++ b/examples/nidigital_spi/teststand_nidigital.py
@@ -1,8 +1,9 @@
 """Functions to set up and tear down sessions of NI Digital Pattern instruments in NI TestStand."""
 from typing import Any, Iterable
 
-from _helpers import GrpcChannelPoolHelper, TestStandSupport
+from _helpers import TestStandSupport
 from ni_measurementlink_service.discovery import DiscoveryClient
+from ni_measurementlink_service.grpc.channelpool import GrpcChannelPool
 from ni_measurementlink_service.session_management import (
     INSTRUMENT_TYPE_NI_DIGITAL_PATTERN,
     PinMapContext,
@@ -22,7 +23,7 @@ def create_nidigital_sessions(sequence_context: Any) -> None:
     teststand_support = TestStandSupport(sequence_context)
     pin_map_id = teststand_support.get_active_pin_map_id()
 
-    with GrpcChannelPoolHelper() as grpc_channel_pool:
+    with GrpcChannelPool() as grpc_channel_pool:
         discovery_client = DiscoveryClient(grpc_channel_pool=grpc_channel_pool)
         session_management_client = SessionManagementClient(
             discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool
@@ -50,7 +51,7 @@ def load_nidigital_pin_map(pin_map_path: str, sequence_context: Any) -> None:
     pin_map_id = teststand_support.get_active_pin_map_id()
     pin_map_abs_path = teststand_support.resolve_file_path(pin_map_path)
 
-    with GrpcChannelPoolHelper() as grpc_channel_pool:
+    with GrpcChannelPool() as grpc_channel_pool:
         discovery_client = DiscoveryClient(grpc_channel_pool=grpc_channel_pool)
         session_management_client = SessionManagementClient(
             discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool
@@ -88,7 +89,7 @@ def load_nidigital_specifications_levels_and_timing(
     levels_file_abs_paths = [teststand_support.resolve_file_path(p) for p in levels_file_paths]
     timing_file_abs_paths = [teststand_support.resolve_file_path(p) for p in timing_file_paths]
 
-    with GrpcChannelPoolHelper() as grpc_channel_pool:
+    with GrpcChannelPool() as grpc_channel_pool:
         discovery_client = DiscoveryClient(grpc_channel_pool=grpc_channel_pool)
         session_management_client = SessionManagementClient(
             discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool
@@ -120,7 +121,7 @@ def load_nidigital_patterns(
     pin_map_id = teststand_support.get_active_pin_map_id()
     pattern_file_abs_paths = [teststand_support.resolve_file_path(p) for p in pattern_file_paths]
 
-    with GrpcChannelPoolHelper() as grpc_channel_pool:
+    with GrpcChannelPool() as grpc_channel_pool:
         discovery_client = DiscoveryClient(grpc_channel_pool=grpc_channel_pool)
         session_management_client = SessionManagementClient(
             discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool
@@ -138,7 +139,7 @@ def load_nidigital_patterns(
 
 def destroy_nidigital_sessions() -> None:
     """Destroy and unregister all NI-Digital sessions."""
-    with GrpcChannelPoolHelper() as grpc_channel_pool:
+    with GrpcChannelPool() as grpc_channel_pool:
         discovery_client = DiscoveryClient(grpc_channel_pool=grpc_channel_pool)
         session_management_client = SessionManagementClient(
             discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool

--- a/examples/nidmm_measurement/_helpers.py
+++ b/examples/nidmm_measurement/_helpers.py
@@ -5,28 +5,6 @@ import pathlib
 from typing import Any, Callable, TypeVar
 
 import click
-import grpc
-from ni_measurementlink_service.discovery import DiscoveryClient
-from ni_measurementlink_service.measurement.service import GrpcChannelPool
-
-
-class GrpcChannelPoolHelper(GrpcChannelPool):
-    """Class that manages gRPC channel lifetimes."""
-
-    def __init__(self) -> None:
-        """Initialize the GrpcChannelPool object."""
-        super().__init__()
-        self._discovery_client = DiscoveryClient()
-
-    @property
-    def pin_map_channel(self) -> grpc.Channel:
-        """Return gRPC channel to pin map service."""
-        return self.get_channel(
-            self._discovery_client.resolve_service(
-                provided_interface="ni.measurementlink.pinmap.v1.PinMapService",
-                service_class="ni.measurementlink.pinmap.v1.PinMapService",
-            ).insecure_address
-        )
 
 
 class TestStandSupport(object):

--- a/examples/nidmm_measurement/pyproject.toml
+++ b/examples/nidmm_measurement/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidmm = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurementlink-service = {version = "^1.3.0-dev0", allow-prereleases = true}
+ni-measurementlink-service = {version = "^1.3.0-dev2", allow-prereleases = true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/nidmm_measurement/teststand_nidmm.py
+++ b/examples/nidmm_measurement/teststand_nidmm.py
@@ -1,8 +1,9 @@
 """Functions to set up and tear down sessions of NI-DMM devices in NI TestStand."""
 from typing import Any
 
-from _helpers import GrpcChannelPoolHelper, TestStandSupport
+from _helpers import TestStandSupport
 from ni_measurementlink_service.discovery import DiscoveryClient
+from ni_measurementlink_service.grpc.channelpool import GrpcChannelPool
 from ni_measurementlink_service.session_management import (
     INSTRUMENT_TYPE_NI_DMM,
     PinMapContext,
@@ -18,7 +19,7 @@ def create_nidmm_sessions(sequence_context: Any) -> None:
         sequence_context: The SequenceContext COM object from the TestStand sequence execution.
             (Dynamically typed.)
     """
-    with GrpcChannelPoolHelper() as grpc_channel_pool:
+    with GrpcChannelPool() as grpc_channel_pool:
         teststand_support = TestStandSupport(sequence_context)
         pin_map_id = teststand_support.get_active_pin_map_id()
         pin_map_context = PinMapContext(pin_map_id=pin_map_id, sites=None)
@@ -41,7 +42,7 @@ def create_nidmm_sessions(sequence_context: Any) -> None:
 
 def destroy_nidmm_sessions() -> None:
     """Destroy and unregister all NI-DMM sessions."""
-    with GrpcChannelPoolHelper() as grpc_channel_pool:
+    with GrpcChannelPool() as grpc_channel_pool:
         discovery_client = DiscoveryClient(grpc_channel_pool=grpc_channel_pool)
         session_management_client = SessionManagementClient(
             discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool

--- a/examples/nifgen_standard_function/_helpers.py
+++ b/examples/nifgen_standard_function/_helpers.py
@@ -5,28 +5,6 @@ import pathlib
 from typing import Any, Callable, TypeVar
 
 import click
-import grpc
-from ni_measurementlink_service.discovery import DiscoveryClient
-from ni_measurementlink_service.measurement.service import GrpcChannelPool
-
-
-class GrpcChannelPoolHelper(GrpcChannelPool):
-    """Class that manages gRPC channel lifetimes."""
-
-    def __init__(self) -> None:
-        """Initialize the GrpcChannelPool object."""
-        super().__init__()
-        self._discovery_client = DiscoveryClient()
-
-    @property
-    def pin_map_channel(self) -> grpc.Channel:
-        """Return gRPC channel to pin map service."""
-        return self.get_channel(
-            self._discovery_client.resolve_service(
-                provided_interface="ni.measurementlink.pinmap.v1.PinMapService",
-                service_class="ni.measurementlink.pinmap.v1.PinMapService",
-            ).insecure_address
-        )
 
 
 class TestStandSupport(object):

--- a/examples/nifgen_standard_function/pyproject.toml
+++ b/examples/nifgen_standard_function/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nifgen = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurementlink-service = {version = "^1.3.0-dev0", allow-prereleases = true}
+ni-measurementlink-service = {version = "^1.3.0-dev2", allow-prereleases = true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/nifgen_standard_function/teststand_nifgen.py
+++ b/examples/nifgen_standard_function/teststand_nifgen.py
@@ -1,8 +1,9 @@
 """Functions to set up and tear down sessions of NI-FGEN devices in NI TestStand."""
 from typing import Any
 
-from _helpers import GrpcChannelPoolHelper, TestStandSupport
+from _helpers import TestStandSupport
 from ni_measurementlink_service.discovery import DiscoveryClient
+from ni_measurementlink_service.grpc.channelpool import GrpcChannelPool
 from ni_measurementlink_service.session_management import (
     INSTRUMENT_TYPE_NI_FGEN,
     PinMapContext,
@@ -18,7 +19,7 @@ def create_nifgen_sessions(sequence_context: Any) -> None:
         sequence_context: The SequenceContext COM object from the TestStand sequence execution.
             (Dynamically typed.)
     """
-    with GrpcChannelPoolHelper() as grpc_channel_pool:
+    with GrpcChannelPool() as grpc_channel_pool:
         teststand_support = TestStandSupport(sequence_context)
         pin_map_id = teststand_support.get_active_pin_map_id()
         pin_map_context = PinMapContext(pin_map_id=pin_map_id, sites=None)
@@ -41,7 +42,7 @@ def create_nifgen_sessions(sequence_context: Any) -> None:
 
 def destroy_nifgen_sessions() -> None:
     """Destroy and unregister all NI-FGEN sessions."""
-    with GrpcChannelPoolHelper() as grpc_channel_pool:
+    with GrpcChannelPool() as grpc_channel_pool:
         discovery_client = DiscoveryClient(grpc_channel_pool=grpc_channel_pool)
         session_management_client = SessionManagementClient(
             discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool

--- a/examples/niscope_acquire_waveform/_helpers.py
+++ b/examples/niscope_acquire_waveform/_helpers.py
@@ -5,28 +5,6 @@ import pathlib
 from typing import Any, Callable, TypeVar
 
 import click
-import grpc
-from ni_measurementlink_service.discovery import DiscoveryClient
-from ni_measurementlink_service.measurement.service import GrpcChannelPool
-
-
-class GrpcChannelPoolHelper(GrpcChannelPool):
-    """Class that manages gRPC channel lifetimes."""
-
-    def __init__(self) -> None:
-        """Initialize the GrpcChannelPool object."""
-        super().__init__()
-        self._discovery_client = DiscoveryClient()
-
-    @property
-    def pin_map_channel(self) -> grpc.Channel:
-        """Return gRPC channel to pin map service."""
-        return self.get_channel(
-            self._discovery_client.resolve_service(
-                provided_interface="ni.measurementlink.pinmap.v1.PinMapService",
-                service_class="ni.measurementlink.pinmap.v1.PinMapService",
-            ).insecure_address
-        )
 
 
 class TestStandSupport(object):

--- a/examples/niscope_acquire_waveform/pyproject.toml
+++ b/examples/niscope_acquire_waveform/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 niscope = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurementlink-service = {version = "^1.3.0-dev0", allow-prereleases = true}
+ni-measurementlink-service = {version = "^1.3.0-dev2", allow-prereleases = true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/niscope_acquire_waveform/teststand_niscope.py
+++ b/examples/niscope_acquire_waveform/teststand_niscope.py
@@ -1,8 +1,9 @@
 """Functions to set up and tear down sessions of NI-Scope devices in NI TestStand."""
 from typing import Any
 
-from _helpers import GrpcChannelPoolHelper, TestStandSupport
+from _helpers import TestStandSupport
 from ni_measurementlink_service.discovery import DiscoveryClient
+from ni_measurementlink_service.grpc.channelpool import GrpcChannelPool
 from ni_measurementlink_service.session_management import (
     INSTRUMENT_TYPE_NI_SCOPE,
     PinMapContext,
@@ -18,7 +19,7 @@ def create_niscope_sessions(sequence_context: Any) -> None:
         sequence_context: The SequenceContext COM object from the TestStand sequence execution.
             (Dynamically typed.)
     """
-    with GrpcChannelPoolHelper() as grpc_channel_pool:
+    with GrpcChannelPool() as grpc_channel_pool:
         teststand_support = TestStandSupport(sequence_context)
         pin_map_id = teststand_support.get_active_pin_map_id()
         pin_map_context = PinMapContext(pin_map_id=pin_map_id, sites=None)
@@ -40,7 +41,7 @@ def create_niscope_sessions(sequence_context: Any) -> None:
 
 def destroy_niscope_sessions() -> None:
     """Destroy and unregister all NI-Scope sessions."""
-    with GrpcChannelPoolHelper() as grpc_channel_pool:
+    with GrpcChannelPool() as grpc_channel_pool:
         discovery_client = DiscoveryClient(grpc_channel_pool=grpc_channel_pool)
         session_management_client = SessionManagementClient(
             discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool

--- a/examples/niswitch_control_relays/_helpers.py
+++ b/examples/niswitch_control_relays/_helpers.py
@@ -5,28 +5,6 @@ import pathlib
 from typing import Any, Callable, TypeVar
 
 import click
-import grpc
-from ni_measurementlink_service.discovery import DiscoveryClient
-from ni_measurementlink_service.measurement.service import GrpcChannelPool
-
-
-class GrpcChannelPoolHelper(GrpcChannelPool):
-    """Class that manages gRPC channel lifetimes."""
-
-    def __init__(self) -> None:
-        """Initialize the GrpcChannelPool object."""
-        super().__init__()
-        self._discovery_client = DiscoveryClient()
-
-    @property
-    def pin_map_channel(self) -> grpc.Channel:
-        """Return gRPC channel to pin map service."""
-        return self.get_channel(
-            self._discovery_client.resolve_service(
-                provided_interface="ni.measurementlink.pinmap.v1.PinMapService",
-                service_class="ni.measurementlink.pinmap.v1.PinMapService",
-            ).insecure_address
-        )
 
 
 class TestStandSupport(object):

--- a/examples/niswitch_control_relays/pyproject.toml
+++ b/examples/niswitch_control_relays/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 niswitch = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurementlink-service = {version = "^1.3.0-dev0", allow-prereleases = true}
+ni-measurementlink-service = {version = "^1.3.0-dev2", allow-prereleases = true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/niswitch_control_relays/teststand_niswitch.py
+++ b/examples/niswitch_control_relays/teststand_niswitch.py
@@ -1,8 +1,9 @@
 """Functions to set up and tear down sessions of NI-Switch devices in NI TestStand."""
 from typing import Any
 
-from _helpers import GrpcChannelPoolHelper, TestStandSupport
+from _helpers import TestStandSupport
 from ni_measurementlink_service.discovery import DiscoveryClient
+from ni_measurementlink_service.grpc.channelpool import GrpcChannelPool
 from ni_measurementlink_service.session_management import (
     INSTRUMENT_TYPE_NI_RELAY_DRIVER,
     PinMapContext,
@@ -18,7 +19,7 @@ def create_niswitch_sessions(sequence_context: Any) -> None:
         sequence_context: The SequenceContext COM object from the TestStand sequence execution.
             (Dynamically typed.)
     """
-    with GrpcChannelPoolHelper() as grpc_channel_pool:
+    with GrpcChannelPool() as grpc_channel_pool:
         teststand_support = TestStandSupport(sequence_context)
         pin_map_id = teststand_support.get_active_pin_map_id()
         pin_map_context = PinMapContext(pin_map_id=pin_map_id, sites=None)
@@ -41,7 +42,7 @@ def create_niswitch_sessions(sequence_context: Any) -> None:
 
 def destroy_niswitch_sessions() -> None:
     """Destroy and unregister all NI-Switch sessions."""
-    with GrpcChannelPoolHelper() as grpc_channel_pool:
+    with GrpcChannelPool() as grpc_channel_pool:
         discovery_client = DiscoveryClient(grpc_channel_pool=grpc_channel_pool)
         session_management_client = SessionManagementClient(
             discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool

--- a/examples/nivisa_dmm_measurement/_helpers.py
+++ b/examples/nivisa_dmm_measurement/_helpers.py
@@ -5,28 +5,6 @@ import pathlib
 from typing import Any, Callable, TypeVar
 
 import click
-import grpc
-from ni_measurementlink_service.discovery import DiscoveryClient
-from ni_measurementlink_service.measurement.service import GrpcChannelPool
-
-
-class GrpcChannelPoolHelper(GrpcChannelPool):
-    """Class that manages gRPC channel lifetimes."""
-
-    def __init__(self) -> None:
-        """Initialize the GrpcChannelPool object."""
-        super().__init__()
-        self._discovery_client = DiscoveryClient()
-
-    @property
-    def pin_map_channel(self) -> grpc.Channel:
-        """Return gRPC channel to pin map service."""
-        return self.get_channel(
-            self._discovery_client.resolve_service(
-                provided_interface="ni.measurementlink.pinmap.v1.PinMapService",
-                service_class="ni.measurementlink.pinmap.v1.PinMapService",
-            ).insecure_address
-        )
 
 
 class TestStandSupport(object):

--- a/examples/nivisa_dmm_measurement/pyproject.toml
+++ b/examples/nivisa_dmm_measurement/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-ni-measurementlink-service = {version = "^1.3.0-dev0", allow-prereleases = true}
+ni-measurementlink-service = {version = "^1.3.0-dev2", allow-prereleases = true}
 PyVISA = "^1.13.0"
 PyVISA-sim = "^0.5.1"
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558

--- a/examples/nivisa_dmm_measurement/teststand_nivisa_dmm.py
+++ b/examples/nivisa_dmm_measurement/teststand_nivisa_dmm.py
@@ -2,11 +2,12 @@
 import pathlib
 from typing import Any
 
-from _helpers import GrpcChannelPoolHelper, TestStandSupport
+from _helpers import TestStandSupport
 from _visa_dmm import INSTRUMENT_TYPE_VISA_DMM
 from _visa_dmm_session_management import VisaDmmSessionConstructor
 from decouple import AutoConfig
 from ni_measurementlink_service.discovery import DiscoveryClient
+from ni_measurementlink_service.grpc.channelpool import GrpcChannelPool
 from ni_measurementlink_service.session_management import (
     PinMapContext,
     SessionManagementClient,
@@ -27,7 +28,7 @@ def create_nivisa_dmm_sessions(sequence_context: Any) -> None:
         sequence_context: The SequenceContext COM object from the TestStand sequence execution.
             (Dynamically typed.)
     """
-    with GrpcChannelPoolHelper() as grpc_channel_pool:
+    with GrpcChannelPool() as grpc_channel_pool:
         teststand_support = TestStandSupport(sequence_context)
         pin_map_id = teststand_support.get_active_pin_map_id()
         pin_map_context = PinMapContext(pin_map_id=pin_map_id, sites=None)
@@ -55,7 +56,7 @@ def create_nivisa_dmm_sessions(sequence_context: Any) -> None:
 
 def destroy_nivisa_dmm_sessions() -> None:
     """Destroy and unregister all NI-VISA DMM sessions."""
-    with GrpcChannelPoolHelper() as grpc_channel_pool:
+    with GrpcChannelPool() as grpc_channel_pool:
         discovery_client = DiscoveryClient(grpc_channel_pool=grpc_channel_pool)
         session_management_client = SessionManagementClient(
             discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool

--- a/examples/output_voltage_measurement/_helpers.py
+++ b/examples/output_voltage_measurement/_helpers.py
@@ -5,28 +5,6 @@ import pathlib
 from typing import Any, Callable, TypeVar
 
 import click
-import grpc
-from ni_measurementlink_service.discovery import DiscoveryClient
-from ni_measurementlink_service.measurement.service import GrpcChannelPool
-
-
-class GrpcChannelPoolHelper(GrpcChannelPool):
-    """Class that manages gRPC channel lifetimes."""
-
-    def __init__(self) -> None:
-        """Initialize the GrpcChannelPool object."""
-        super().__init__()
-        self._discovery_client = DiscoveryClient()
-
-    @property
-    def pin_map_channel(self) -> grpc.Channel:
-        """Return gRPC channel to pin map service."""
-        return self.get_channel(
-            self._discovery_client.resolve_service(
-                provided_interface="ni.measurementlink.pinmap.v1.PinMapService",
-                service_class="ni.measurementlink.pinmap.v1.PinMapService",
-            ).insecure_address
-        )
 
 
 class TestStandSupport(object):

--- a/examples/output_voltage_measurement/pyproject.toml
+++ b/examples/output_voltage_measurement/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-ni-measurementlink-service = {version = "^1.3.0-dev0", allow-prereleases = true}
+ni-measurementlink-service = {version = "^1.3.0-dev2", allow-prereleases = true}
 PyVISA = "^1.13.0"
 PyVISA-sim = "^0.5.1"
 nidcpower = { version = ">=1.4.4", extras = ["grpc"] }

--- a/examples/output_voltage_measurement/teststand_nidcpower.py
+++ b/examples/output_voltage_measurement/teststand_nidcpower.py
@@ -1,8 +1,9 @@
 """Functions to set up and tear down sessions of NI-DCPower devices in NI TestStand."""
 from typing import Any
 
-from _helpers import GrpcChannelPoolHelper, TestStandSupport
+from _helpers import TestStandSupport
 from ni_measurementlink_service.discovery import DiscoveryClient
+from ni_measurementlink_service.grpc.channelpool import GrpcChannelPool
 from ni_measurementlink_service.session_management import (
     INSTRUMENT_TYPE_NI_DCPOWER,
     PinMapContext,
@@ -18,7 +19,7 @@ def create_nidcpower_sessions(sequence_context: Any) -> None:
         sequence_context: The SequenceContext COM object from the TestStand sequence execution.
             (Dynamically typed.)
     """
-    with GrpcChannelPoolHelper() as grpc_channel_pool:
+    with GrpcChannelPool() as grpc_channel_pool:
         teststand_support = TestStandSupport(sequence_context)
         pin_map_id = teststand_support.get_active_pin_map_id()
         pin_map_context = PinMapContext(pin_map_id=pin_map_id, sites=None)
@@ -40,7 +41,7 @@ def create_nidcpower_sessions(sequence_context: Any) -> None:
 
 def destroy_nidcpower_sessions() -> None:
     """Destroy and unregister all NI-DCPower sessions."""
-    with GrpcChannelPoolHelper() as grpc_channel_pool:
+    with GrpcChannelPool() as grpc_channel_pool:
         discovery_client = DiscoveryClient(grpc_channel_pool=grpc_channel_pool)
         session_management_client = SessionManagementClient(
             discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool

--- a/examples/output_voltage_measurement/teststand_nivisa_dmm.py
+++ b/examples/output_voltage_measurement/teststand_nivisa_dmm.py
@@ -2,11 +2,12 @@
 import pathlib
 from typing import Any
 
-from _helpers import GrpcChannelPoolHelper, TestStandSupport
+from _helpers import TestStandSupport
 from _visa_dmm import INSTRUMENT_TYPE_VISA_DMM
 from _visa_dmm_session_management import VisaDmmSessionConstructor
 from decouple import AutoConfig
 from ni_measurementlink_service.discovery import DiscoveryClient
+from ni_measurementlink_service.grpc.channelpool import GrpcChannelPool
 from ni_measurementlink_service.session_management import (
     PinMapContext,
     SessionManagementClient,
@@ -27,7 +28,7 @@ def create_nivisa_dmm_sessions(sequence_context: Any) -> None:
         sequence_context: The SequenceContext COM object from the TestStand sequence execution.
             (Dynamically typed.)
     """
-    with GrpcChannelPoolHelper() as grpc_channel_pool:
+    with GrpcChannelPool() as grpc_channel_pool:
         teststand_support = TestStandSupport(sequence_context)
         pin_map_id = teststand_support.get_active_pin_map_id()
         pin_map_context = PinMapContext(pin_map_id=pin_map_id, sites=None)
@@ -55,7 +56,7 @@ def create_nivisa_dmm_sessions(sequence_context: Any) -> None:
 
 def destroy_nivisa_dmm_sessions() -> None:
     """Destroy and unregister all NI-VISA DMM sessions."""
-    with GrpcChannelPoolHelper() as grpc_channel_pool:
+    with GrpcChannelPool() as grpc_channel_pool:
         discovery_client = DiscoveryClient(grpc_channel_pool=grpc_channel_pool)
         session_management_client = SessionManagementClient(
             discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool

--- a/examples/sample_measurement/_helpers.py
+++ b/examples/sample_measurement/_helpers.py
@@ -5,28 +5,6 @@ import pathlib
 from typing import Any, Callable, TypeVar
 
 import click
-import grpc
-from ni_measurementlink_service.discovery import DiscoveryClient
-from ni_measurementlink_service.measurement.service import GrpcChannelPool
-
-
-class GrpcChannelPoolHelper(GrpcChannelPool):
-    """Class that manages gRPC channel lifetimes."""
-
-    def __init__(self) -> None:
-        """Initialize the GrpcChannelPool object."""
-        super().__init__()
-        self._discovery_client = DiscoveryClient()
-
-    @property
-    def pin_map_channel(self) -> grpc.Channel:
-        """Return gRPC channel to pin map service."""
-        return self.get_channel(
-            self._discovery_client.resolve_service(
-                provided_interface="ni.measurementlink.pinmap.v1.PinMapService",
-                service_class="ni.measurementlink.pinmap.v1.PinMapService",
-            ).insecure_address
-        )
 
 
 class TestStandSupport(object):

--- a/ni_measurementlink_generator/ni_measurementlink_generator/templates/_helpers.py.mako
+++ b/ni_measurementlink_generator/ni_measurementlink_generator/templates/_helpers.py.mako
@@ -5,28 +5,6 @@ import pathlib
 from typing import Any, Callable, TypeVar
 
 import click
-import grpc
-from ni_measurementlink_service.discovery import DiscoveryClient
-from ni_measurementlink_service.measurement.service import GrpcChannelPool
-
-
-class GrpcChannelPoolHelper(GrpcChannelPool):
-    """Class that manages gRPC channel lifetimes."""
-
-    def __init__(self) -> None:
-        """Initialize the GrpcChannelPool object."""
-        super().__init__()
-        self._discovery_client = DiscoveryClient()
-
-    @property
-    def pin_map_channel(self) -> grpc.Channel:
-        """Return gRPC channel to pin map service."""
-        return self.get_channel(
-            self._discovery_client.resolve_service(
-                provided_interface="ni.measurementlink.pinmap.v1.PinMapService",
-                service_class="ni.measurementlink.pinmap.v1.PinMapService",
-            ).insecure_address
-        )
 
 
 class TestStandSupport(object):

--- a/ni_measurementlink_generator/tests/test_assets/example_renders/measurement/_helpers.py
+++ b/ni_measurementlink_generator/tests/test_assets/example_renders/measurement/_helpers.py
@@ -5,28 +5,6 @@ import pathlib
 from typing import Any, Callable, TypeVar
 
 import click
-import grpc
-from ni_measurementlink_service.discovery import DiscoveryClient
-from ni_measurementlink_service.measurement.service import GrpcChannelPool
-
-
-class GrpcChannelPoolHelper(GrpcChannelPool):
-    """Class that manages gRPC channel lifetimes."""
-
-    def __init__(self) -> None:
-        """Initialize the GrpcChannelPool object."""
-        super().__init__()
-        self._discovery_client = DiscoveryClient()
-
-    @property
-    def pin_map_channel(self) -> grpc.Channel:
-        """Return gRPC channel to pin map service."""
-        return self.get_channel(
-            self._discovery_client.resolve_service(
-                provided_interface="ni.measurementlink.pinmap.v1.PinMapService",
-                service_class="ni.measurementlink.pinmap.v1.PinMapService",
-            ).insecure_address
-        )
 
 
 class TestStandSupport(object):

--- a/ni_measurementlink_generator/tests/test_assets/example_renders/measurement_with_annotations/_helpers.py
+++ b/ni_measurementlink_generator/tests/test_assets/example_renders/measurement_with_annotations/_helpers.py
@@ -5,28 +5,6 @@ import pathlib
 from typing import Any, Callable, TypeVar
 
 import click
-import grpc
-from ni_measurementlink_service.discovery import DiscoveryClient
-from ni_measurementlink_service.measurement.service import GrpcChannelPool
-
-
-class GrpcChannelPoolHelper(GrpcChannelPool):
-    """Class that manages gRPC channel lifetimes."""
-
-    def __init__(self) -> None:
-        """Initialize the GrpcChannelPool object."""
-        super().__init__()
-        self._discovery_client = DiscoveryClient()
-
-    @property
-    def pin_map_channel(self) -> grpc.Channel:
-        """Return gRPC channel to pin map service."""
-        return self.get_channel(
-            self._discovery_client.resolve_service(
-                provided_interface="ni.measurementlink.pinmap.v1.PinMapService",
-                service_class="ni.measurementlink.pinmap.v1.PinMapService",
-            ).insecure_address
-        )
 
 
 class TestStandSupport(object):


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Remove `GrpcChannelPoolHelper` from `_helpers.py`. This class provided accessors for `pin_map_channel`, `session_management_channel`, and `grpc_device_channel`, but the simplified session management API and the "update pin map" step eliminated all usage of these accessors.

Change example TestStand code modules to directly import `GrpcChannelPool` from `ni_measurementlink_service.grpc.channelpool`.

Update the minimum `ni-measurementlink-service` version for the examples that have TestStand code modules. `ni_measurementlink_service.grpc.channelpool` requires 1.3.0-dev2 or later.

### Why should this Pull Request be merged?

Fix [AB#2576107](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2576107)

### What testing has been done?

Ran ni-python-styleguide and mypy on all affected examples.
Installed examples using `scripts/install_examples.py` and tested in InstrumentStudio and TestStand with simulated devices.