### PR TITLE
github: Use full Python version in cache key

### DIFF
--- a/.github/workflows/check_examples.yml
+++ b/.github/workflows/check_examples.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
+        id: setup-python
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Set up Poetry
@@ -30,7 +31,7 @@ jobs:
         with:
           path: 'examples/**/poetry.lock'
           # Include the main project's poetry.lock in the hash to detect upstream dependency updates.
-          key: examples-poetry-lock-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('examples/**/pyproject.toml', 'poetry.lock') }}
+          key: examples-poetry-lock-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('examples/**/pyproject.toml', 'poetry.lock') }}
       - name: Lock examples
         if: steps.cache-poetry-lock.outputs.cache-hit != 'true'
         run: |
@@ -46,7 +47,7 @@ jobs:
         id: cache-venv
         with:
           path: 'examples/**/.venv'
-          key: examples-venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('examples/**/poetry.lock') }}
+          key: examples-venv-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('examples/**/poetry.lock') }}
       - name: Install examples
         run: |
           for example in examples/*/; do

--- a/.github/workflows/check_nimg.yml
+++ b/.github/workflows/check_nimg.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
+        id: setup-python
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Set up Poetry
@@ -34,7 +35,7 @@ jobs:
         id: cache
         with:
           path: ni_measurementlink_generator/.venv
-          key: ni-measurementlink-generator-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}
+          key: ni-measurementlink-generator-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}
       - name: Install ni-measurementlink-generator
         run: poetry install -v
       - name: Lint ni-measurementlink-generator

--- a/.github/workflows/check_nims.yml
+++ b/.github/workflows/check_nims.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
+        id: setup-python
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Set up Poetry
@@ -32,7 +33,7 @@ jobs:
         id: restore-nims-all-extras
         with:
           path: .venv
-          key: ni-measurementlink-service-all-extras-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}
+          key: ni-measurementlink-service-all-extras-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}
       - name: Install ni-measurementlink-service (all extras)
         run: poetry install -v --all-extras
       - name: Save cached virtualenv (ni-measurementlink-service, all extras)
@@ -58,7 +59,7 @@ jobs:
         id: restore-nims-all-extras-docs
         with:
           path: .venv
-          key: ni-measurementlink-service-all-extras-docs-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}
+          key: ni-measurementlink-service-all-extras-docs-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}
       - name: Install ni-measurementlink-service (all extras, docs)
         run: poetry install -v --all-extras --with docs
       - name: Save cached virtualenv (ni-measurementlink-service, all extras, docs)

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
+        id: setup-python
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up Poetry
@@ -36,7 +37,7 @@ jobs:
         id: restore-nims-no-extras
         with:
           path: .venv
-          key: ni-measurementlink-service-no-extras-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
+          key: ni-measurementlink-service-no-extras-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}
       - name: Install ni-measurementlink-service (no extras)
         run: poetry install -v
       - name: Save cached virtualenv (ni-measurementlink-service, no extras)
@@ -54,7 +55,7 @@ jobs:
         id: restore-nims-all-extras
         with:
           path: .venv
-          key: ni-measurementlink-service-all-extras-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
+          key: ni-measurementlink-service-all-extras-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}
       - name: Install ni-measurementlink-service (all extras)
         run: poetry install -v --all-extras
       - name: Save cached ni-measurementlink-service virtualenv (all extras)
@@ -72,7 +73,7 @@ jobs:
         id: restore-nimg
         with:
           path: ni_measurementlink_generator/.venv
-          key: ni-measurementlink-generator-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
+          key: ni-measurementlink-generator-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}
       - name: Install ni-measurementlink-generator
         run: poetry install -v
         working-directory: ./ni_measurementlink_generator


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update GitHub workflows to use the full Python version (e.g. 3.12.1) in the venv cache key, rather than the requested version (e.g. 3.12). This invalidates cached venvs when GitHub deploys a new Python update. Otherwise, the cached venv may refer to a different version of Python than the version than is installed.

### Why should this Pull Request be merged?

Fix #560 

### What testing has been done?

PR build