### PR TITLE
fix: use os.path to avoid os errors for invalid file paths

### DIFF
--- a/ni_measurementlink_service/_dotenvpath.py
+++ b/ni_measurementlink_service/_dotenvpath.py
@@ -1,4 +1,5 @@
 import inspect
+import os
 import sys
 import traceback
 from pathlib import Path, PurePath
@@ -44,7 +45,7 @@ def _get_caller_path() -> Optional[Path]:
     for frame, _ in traceback.walk_stack(inspect.currentframe()):
         if frame.f_code.co_filename:
             module_path = Path(frame.f_code.co_filename)
-            if module_path.exists() and not _is_relative_to(module_path, nims_path):
+            if os.path.exists(module_path) and not _is_relative_to(module_path, nims_path):
                 return module_path
 
     return None

--- a/ni_measurementlink_service/_dotenvpath.py
+++ b/ni_measurementlink_service/_dotenvpath.py
@@ -49,6 +49,7 @@ def _get_caller_path() -> Optional[Path]:
 
     return None
 
+
 # Path.exists() throws OSError when the path has invalid file characters.
 # https://github.com/python/cpython/issues/79487
 if sys.version_info >= (3, 10):

--- a/ni_measurementlink_service/_dotenvpath.py
+++ b/ni_measurementlink_service/_dotenvpath.py
@@ -1,5 +1,4 @@
 import inspect
-import os
 import sys
 import traceback
 from pathlib import Path, PurePath
@@ -45,16 +44,34 @@ def _get_caller_path() -> Optional[Path]:
     for frame, _ in traceback.walk_stack(inspect.currentframe()):
         if frame.f_code.co_filename:
             module_path = Path(frame.f_code.co_filename)
-            if os.path.exists(module_path) and not _is_relative_to(module_path, nims_path):
+            if _exists(module_path) and not _is_relative_to(module_path, nims_path):
                 return module_path
 
     return None
 
+# Path.exists() throws OSError when the path has invalid file characters.
+# https://github.com/python/cpython/issues/79487
+if sys.version_info >= (3, 10):
 
-def _is_relative_to(path: PurePath, other: PurePath) -> bool:
-    if sys.version_info >= (3, 9):
+    def _exists(path: Path) -> bool:
+        return path.exists()
+
+else:
+
+    def _exists(path: Path) -> bool:
+        import os
+
+        return os.path.exists(path)
+
+
+if sys.version_info >= (3, 9):
+
+    def _is_relative_to(path: PurePath, other: PurePath) -> bool:
         return path.is_relative_to(other)
-    else:
+
+else:
+
+    def _is_relative_to(path: PurePath, other: PurePath) -> bool:
         try:
             _ = path.relative_to(other)
             return True


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Use [os.path.exists(path)](https://docs.python.org/3/library/os.path.html#os.path.exists) instead of `Path.exists()` to swallow OS errors for invalid file paths for older Python versions. [AB#2606153](https://dev.azure.com/ni/DevCentral/_workitems/edit/2606153)

### Why should this Pull Request be merged?
When the `.env` file isn't present in any of the measurement.py parent directories and if TestStand adaptors use any Python version <3.8.10 or <3.9.5, an OSError is thrown for invalid file paths. Using `os.path.exists(path)` resolves this error.

### What testing has been done?
Ran mypy and manually ran the "nidcpower_source_dc_voltage" example's sequence file in TestStand 2021 SP1 with Python versions 3.8.9, 3.8.10, 3.9.4, 3.9.5, 3.9.13 and 3.10.11.