### PR TITLE
Downgrade back to 1.3.0-dev2 so the publish step can succeed and set it to 1.3.0

### DIFF
--- a/ni_measurementlink_generator/pyproject.toml
+++ b/ni_measurementlink_generator/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ni_measurementlink_generator"
-version = "1.3.0"
+version = "1.3.0-dev2"
 description = "MeasurementLink Code Generator for Python"
 authors = ["NI <opensource@ni.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ extend_exclude = '.tox/,*_pb2_grpc.py,*_pb2_grpc.pyi,*_pb2.py,*_pb2.pyi,ni_measu
 
 [tool.poetry]
 name = "ni_measurementlink_service"
-version = "1.3.0"
+version = "1.3.0-dev2"
 description = "MeasurementLink Support for Python"
 authors = ["NI <opensource@ni.com>"]
 readme = "README.md" # apply the repo readme to the package as well


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

The [publish step](https://github.com/ni/measurementlink-python/blob/main/.github/workflows/Publish_NIMS.yml) wants to set the measurement service and measurement generator versions to 1.3.0. If we do that ahead of time, the publish chokes because it has no changes.

### Why should this Pull Request be merged?

Needed to publish 1.3.0. Another option could be to take the following code out of publish_nims.yml.
```
      - name: Store version from Tag
        id: vars
        run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT

      - name: Update NIMS package version based on tag name.
        run: |
          poetry version ${{ steps.vars.outputs.tag }}
      
      - name: Update NIMG package version based on tag name.
        run: |
          poetry version ${{ steps.vars.outputs.tag }}
        working-directory: ./ni_measurementlink_generator

      - name: Commit file changes
        if: ${{ startsWith(github.event.release.target_commitish, 'main') || startsWith(github.event.release.target_commitish, 'releases/') }}
        run: |
          git config --local user.email "action@github.com"
          git config --local user.name "GitHub Action"
          git add .
          git commit -m "Promote NIMS package version and update Sphinx generated files in _docs" -a
      
      - name: Push changes to the appropriate branch
        if: ${{ startsWith(github.event.release.target_commitish, 'main') || startsWith(github.event.release.target_commitish, 'releases/') }}
        uses: CasperWA/push-protected@v2
        with:
          token: ${{ secrets.ADMIN_PAT }}
          branch: ${{ github.event.release.target_commitish }}  
          unprotect_reviews: true
```

### What testing has been done?

None. Build should do checks.