### PR TITLE
[Internal] Update the _reserved_pin_or_relay_names to hold the reserved pins obtained from the SessionManager

### DIFF
--- a/ni_measurementlink_service/session_management/_client.py
+++ b/ni_measurementlink_service/session_management/_client.py
@@ -145,7 +145,6 @@ class SessionManagementClient(object):
                 session_management_client=self,
                 session_info=response.sessions,
                 multiplexer_session_info=response.multiplexer_sessions,
-                reserved_pin_or_relay_names=pin_or_relay_names,
                 reserved_sites=context.sites,
             )
 
@@ -196,7 +195,6 @@ class SessionManagementClient(object):
             session_management_client=self,
             session_info=response.sessions,
             multiplexer_session_info=response.multiplexer_sessions,
-            reserved_pin_or_relay_names=pin_or_relay_names,
             reserved_sites=context.sites,
         )
 

--- a/ni_measurementlink_service/session_management/_reservation.py
+++ b/ni_measurementlink_service/session_management/_reservation.py
@@ -209,7 +209,6 @@ class BaseReservation(_BaseSessionContainer):
         multiplexer_session_info: Optional[
             Sequence[session_management_service_pb2.MultiplexerSessionInformation]
         ] = None,
-        reserved_pin_or_relay_names: Union[str, Iterable[str], None] = None,
         reserved_sites: Optional[Iterable[int]] = None,
     ) -> None:
         """Initialize reservation object."""

--- a/ni_measurementlink_service/session_management/_reservation.py
+++ b/ni_measurementlink_service/session_management/_reservation.py
@@ -229,26 +229,18 @@ class BaseReservation(_BaseSessionContainer):
                 for info in multiplexer_session_info
             ]
 
-        # If __init__ doesn't initialize _reserved_pin_or_relay_names or
-        # _reserved_sites, the cached properties lazily initialize them.
-        if reserved_pin_or_relay_names is not None:
-            self._reserved_pin_or_relay_names = _to_ordered_set(
-                _to_iterable(reserved_pin_or_relay_names)
-            )
-
-        if reserved_sites is not None:
-            self._reserved_sites = _to_ordered_set(reserved_sites)
-
-    @cached_property
-    def _reserved_pin_or_relay_names(self) -> AbstractSet[str]:
-        # If __init__ doesn't initialize reserved_pin_or_relay_names, this
-        # cached property initializes it to the pin/relay names listed in the
+        # Initialize the property with the pin/relay names listed in the
         # session info (in insertion order, no duplicates).
-        return _to_ordered_set(
+        self._reserved_pin_or_relay_names = _to_ordered_set(
             channel_mapping.pin_or_relay_name
             for session_info in self._session_info
             for channel_mapping in session_info.channel_mappings
         )
+
+        # If __init__ doesn't initialize _reserved_sites,
+        # the cached properties lazily initialize them.
+        if reserved_sites is not None:
+            self._reserved_sites = _to_ordered_set(reserved_sites)
 
     @cached_property
     def _reserved_sites(self) -> AbstractSet[int]:

--- a/tests/integration/session_management/test_reservation.py
+++ b/tests/integration/session_management/test_reservation.py
@@ -50,14 +50,14 @@ def test___sessions_reserved___get_connections___connections_returned(
 
         nidcpower_resource = "DCPower1/0, DCPower1/1, DCPower1/2, DCPower1/3, DCPower2/1"
         assert [get_connection_subset(conn) for conn in connections] == [
+            ConnectionSubset("C", 0, "SCOPE1", "0"),
             ConnectionSubset("A", 0, nidcpower_resource, "DCPower1/0"),
             ConnectionSubset("B", 0, nidcpower_resource, "DCPower1/2"),
-            ConnectionSubset("C", 0, "SCOPE1", "0"),
+            ConnectionSubset("C", 1, "SCOPE1", "1"),
             ConnectionSubset("A", 1, nidcpower_resource, "DCPower1/1"),
             ConnectionSubset("B", 1, nidcpower_resource, "DCPower2/1"),
-            ConnectionSubset("C", 1, "SCOPE1", "1"),
-            ConnectionSubset("S1", -1, nidcpower_resource, "DCPower1/3"),
             ConnectionSubset("S2", -1, "SCOPE1", "3"),
+            ConnectionSubset("S1", -1, nidcpower_resource, "DCPower1/3"),
         ]
 
 
@@ -117,18 +117,18 @@ def test___sessions_reserved___get_connections_by_site___connections_returned(
         nidcpower_resource = "DCPower1/0, DCPower1/1, DCPower1/2, DCPower1/3, DCPower2/1"
         assert [[get_connection_subset(conn) for conn in group] for group in connections] == [
             [
+                ConnectionSubset("C", 0, "SCOPE1", "0"),
                 ConnectionSubset("A", 0, nidcpower_resource, "DCPower1/0"),
                 ConnectionSubset("B", 0, nidcpower_resource, "DCPower1/2"),
-                ConnectionSubset("C", 0, "SCOPE1", "0"),
-                ConnectionSubset("S1", -1, nidcpower_resource, "DCPower1/3"),
                 ConnectionSubset("S2", -1, "SCOPE1", "3"),
+                ConnectionSubset("S1", -1, nidcpower_resource, "DCPower1/3"),
             ],
             [
+                ConnectionSubset("C", 1, "SCOPE1", "1"),
                 ConnectionSubset("A", 1, nidcpower_resource, "DCPower1/1"),
                 ConnectionSubset("B", 1, nidcpower_resource, "DCPower2/1"),
-                ConnectionSubset("C", 1, "SCOPE1", "1"),
-                ConnectionSubset("S1", -1, nidcpower_resource, "DCPower1/3"),
                 ConnectionSubset("S2", -1, "SCOPE1", "3"),
+                ConnectionSubset("S1", -1, nidcpower_resource, "DCPower1/3"),
             ],
         ]
 
@@ -184,21 +184,21 @@ def test___reserve_sessions_with_multiplexer___get_connections_with_multiplexer_
 
         nidcpower_resource = "DCPower1/0, DCPower1/1, DCPower1/3, DCPower2/2"
         assert [get_connection_subset_with_multiplexer(conn) for conn in connections] == [
+            ConnectionSubset("C", 0, "SCOPE1", "0", "", ""),
             ConnectionSubset(
                 "A", 0, nidcpower_resource, "DCPower1/0", "Multiplexer1", "C1->r0,C2->r0"
             ),
             ConnectionSubset(
                 "B", 0, nidcpower_resource, "DCPower1/0", "Multiplexer1", "C3->r0,C4->r0"
             ),
-            ConnectionSubset("C", 0, "SCOPE1", "0", "", ""),
             ConnectionSubset(
                 "D", 0, nidcpower_resource, "DCPower2/2", "Multiplexer2", "C3->r2,C4->r2"
             ),
+            ConnectionSubset("C", 1, "SCOPE1", "1", "", ""),
             ConnectionSubset("A", 1, nidcpower_resource, "DCPower1/1", "", ""),
             ConnectionSubset(
                 "B", 1, nidcpower_resource, "DCPower2/2", "Multiplexer2", "C1->r2,C2->r2"
             ),
-            ConnectionSubset("C", 1, "SCOPE1", "1", "", ""),
             ConnectionSubset("D", 1, nidcpower_resource, "DCPower1/3", "", ""),
         ]
 
@@ -277,23 +277,23 @@ def test___reserve_sessions_with_multiplexer___get_connections_with_multiplexer_
             for group in connections
         ] == [
             [
+                ConnectionSubset("C", 0, "SCOPE1", "0", "", ""),
                 ConnectionSubset(
                     "A", 0, nidcpower_resource, "DCPower1/0", "Multiplexer1", "C1->r0,C2->r0"
                 ),
                 ConnectionSubset(
                     "B", 0, nidcpower_resource, "DCPower1/0", "Multiplexer1", "C3->r0,C4->r0"
                 ),
-                ConnectionSubset("C", 0, "SCOPE1", "0", "", ""),
                 ConnectionSubset(
                     "D", 0, nidcpower_resource, "DCPower2/2", "Multiplexer2", "C3->r2,C4->r2"
                 ),
             ],
             [
+                ConnectionSubset("C", 1, "SCOPE1", "1", "", ""),
                 ConnectionSubset("A", 1, nidcpower_resource, "DCPower1/1", "", ""),
                 ConnectionSubset(
                     "B", 1, nidcpower_resource, "DCPower2/2", "Multiplexer2", "C1->r2,C2->r2"
                 ),
-                ConnectionSubset("C", 1, "SCOPE1", "1", "", ""),
                 ConnectionSubset("D", 1, nidcpower_resource, "DCPower1/3", "", ""),
             ],
         ]
@@ -364,12 +364,12 @@ def test___sessions_reserved_with_shared_pins_all_sites___get_connections___retu
 
         nidcpower_resource = "DCPower1/0, DCPower1/2, DCPower2/1"
         assert [get_connection_subset(conn) for conn in connections] == [
+            ConnectionSubset("C", 0, "SCOPE1", "2"),
             ConnectionSubset("A", 0, nidcpower_resource, "DCPower1/0"),
             ConnectionSubset("B", 0, nidcpower_resource, "DCPower2/1"),
-            ConnectionSubset("C", 0, "SCOPE1", "2"),
+            ConnectionSubset("C", 1, "SCOPE1", "2"),
             ConnectionSubset("A", 1, nidcpower_resource, "DCPower1/0"),
             ConnectionSubset("B", 1, nidcpower_resource, "DCPower2/1"),
-            ConnectionSubset("C", 1, "SCOPE1", "2"),
             ConnectionSubset("S1", -1, "SCOPE1", "1"),
             ConnectionSubset("S2", -1, nidcpower_resource, "DCPower1/2"),
         ]
@@ -391,9 +391,9 @@ def test___sessions_reserved_with_shared_pins_site0___get_connections___connecti
 
         nidcpower_resource = "DCPower1/0, DCPower1/2, DCPower2/1"
         assert [get_connection_subset(conn) for conn in connections] == [
+            ConnectionSubset("C", 0, "SCOPE1", "2"),
             ConnectionSubset("A", 0, nidcpower_resource, "DCPower1/0"),
             ConnectionSubset("B", 0, nidcpower_resource, "DCPower2/1"),
-            ConnectionSubset("C", 0, "SCOPE1", "2"),
             ConnectionSubset("S1", -1, "SCOPE1", "1"),
             ConnectionSubset("S2", -1, nidcpower_resource, "DCPower1/2"),
         ]
@@ -415,9 +415,9 @@ def test___sessions_reserved_with_shared_pins_site1___get_connections___connecti
 
         nidcpower_resource = "DCPower1/0, DCPower1/2, DCPower2/1"
         assert [get_connection_subset(conn) for conn in connections] == [
+            ConnectionSubset("C", 1, "SCOPE1", "2"),
             ConnectionSubset("A", 1, nidcpower_resource, "DCPower1/0"),
             ConnectionSubset("B", 1, nidcpower_resource, "DCPower2/1"),
-            ConnectionSubset("C", 1, "SCOPE1", "2"),
             ConnectionSubset("S1", -1, "SCOPE1", "1"),
             ConnectionSubset("S2", -1, nidcpower_resource, "DCPower1/2"),
         ]

--- a/tests/unit/test_reservation.py
+++ b/tests/unit/test_reservation.py
@@ -563,7 +563,6 @@ def test___reservation_order___get_connections_with_specified_order___connection
     reservation = MultiSessionReservation(
         session_management_client,
         grpc_session_infos,
-        reserved_pin_or_relay_names=["Pin3", "Pin1", "Pin4", "Pin2"],
         reserved_sites=[1, 0],
     )
 
@@ -582,10 +581,10 @@ def test___reservation_order___get_connections_with_specified_order___connection
     assert [[get_connection_subset(conn) for conn in group] for group in connections] == [
         [
             ConnectionSubset("Pin1", 0, "Dev0", "0"),
-            ConnectionSubset("Pin3", 0, "Dev1", "2"),
-            ConnectionSubset("Pin2", 0, "Dev0", "1"),
-            ConnectionSubset("Pin1", 1, "Dev1", "3"),
-            ConnectionSubset("Pin3", 1, "Dev2", "5"),
+            ConnectionSubset("Pin3", 0, "Dev0", "2"),
+            ConnectionSubset("Pin2", 0, "Dev1", "1"),
+            ConnectionSubset("Pin1", 1, "Dev2", "3"),
+            ConnectionSubset("Pin3", 1, "Dev1", "5"),
             ConnectionSubset("Pin2", 1, "Dev2", "4"),
         ],
         [
@@ -602,21 +601,20 @@ def test___reservation_order___get_connections___connections_returned_in_reserva
     reservation = MultiSessionReservation(
         session_management_client,
         grpc_session_infos,
-        reserved_pin_or_relay_names=["Pin3", "Pin1", "Pin4", "Pin2"],
         reserved_sites=[1, 0],
     )
 
     connections = reservation.get_connections(object)
 
     assert [get_connection_subset(conn) for conn in connections] == [
-        ConnectionSubset("Pin3", 1, "Dev2", "5"),
-        ConnectionSubset("Pin1", 1, "Dev1", "3"),
-        ConnectionSubset("Pin4", 1, "Dev3", "7"),
+        ConnectionSubset("Pin3", 1, "Dev1", "5"),
+        ConnectionSubset("Pin1", 1, "Dev2", "3"),
         ConnectionSubset("Pin2", 1, "Dev2", "4"),
-        ConnectionSubset("Pin3", 0, "Dev1", "2"),
+        ConnectionSubset("Pin4", 1, "Dev3", "7"),
+        ConnectionSubset("Pin3", 0, "Dev0", "2"),
         ConnectionSubset("Pin1", 0, "Dev0", "0"),
+        ConnectionSubset("Pin2", 0, "Dev1", "1"),
         ConnectionSubset("Pin4", 0, "Dev3", "6"),
-        ConnectionSubset("Pin2", 0, "Dev0", "1"),
     ]
 
 
@@ -629,13 +627,13 @@ def test___no_reservation_order___get_connections___connections_returned_in_defa
     connections = reservation.get_connections(object)
 
     assert [get_connection_subset(conn) for conn in connections] == [
+        ConnectionSubset("Pin3", 0, "Dev0", "2"),
         ConnectionSubset("Pin1", 0, "Dev0", "0"),
-        ConnectionSubset("Pin2", 0, "Dev0", "1"),
-        ConnectionSubset("Pin3", 0, "Dev1", "2"),
+        ConnectionSubset("Pin2", 0, "Dev1", "1"),
         ConnectionSubset("Pin4", 0, "Dev3", "6"),
-        ConnectionSubset("Pin1", 1, "Dev1", "3"),
+        ConnectionSubset("Pin3", 1, "Dev1", "5"),
+        ConnectionSubset("Pin1", 1, "Dev2", "3"),
         ConnectionSubset("Pin2", 1, "Dev2", "4"),
-        ConnectionSubset("Pin3", 1, "Dev2", "5"),
         ConnectionSubset("Pin4", 1, "Dev3", "7"),
     ]
 
@@ -776,12 +774,12 @@ def _create_grpc_session_infos_for_ordering() -> (
     List[session_management_service_pb2.SessionInformation]
 ):
     grpc_session_infos = create_nifoo_session_infos(4)
+    grpc_session_infos[0].channel_mappings.add(pin_or_relay_name="Pin3", site=0, channel="2")
     grpc_session_infos[0].channel_mappings.add(pin_or_relay_name="Pin1", site=0, channel="0")
-    grpc_session_infos[0].channel_mappings.add(pin_or_relay_name="Pin2", site=0, channel="1")
-    grpc_session_infos[1].channel_mappings.add(pin_or_relay_name="Pin3", site=0, channel="2")
-    grpc_session_infos[1].channel_mappings.add(pin_or_relay_name="Pin1", site=1, channel="3")
+    grpc_session_infos[1].channel_mappings.add(pin_or_relay_name="Pin2", site=0, channel="1")
+    grpc_session_infos[1].channel_mappings.add(pin_or_relay_name="Pin3", site=1, channel="5")
+    grpc_session_infos[2].channel_mappings.add(pin_or_relay_name="Pin1", site=1, channel="3")
     grpc_session_infos[2].channel_mappings.add(pin_or_relay_name="Pin2", site=1, channel="4")
-    grpc_session_infos[2].channel_mappings.add(pin_or_relay_name="Pin3", site=1, channel="5")
     grpc_session_infos[3].channel_mappings.add(pin_or_relay_name="Pin4", site=0, channel="6")
     grpc_session_infos[3].channel_mappings.add(pin_or_relay_name="Pin4", site=1, channel="7")
     grpc_session_infos[3].instrument_type_id = "nibar"

--- a/tests/unit/test_reservation_multiplexer.py
+++ b/tests/unit/test_reservation_multiplexer.py
@@ -524,7 +524,6 @@ def test___reservation_order___get_connections_with_multiplexer_in_specific_orde
         session_management_client,
         grpc_session_infos,
         grpc_multiplexer_session_infos,
-        reserved_pin_or_relay_names=["Pin3", "Pin1", "Pin4", "Pin2"],
         reserved_sites=[1, 0],
     )
 
@@ -545,16 +544,16 @@ def test___reservation_order___get_connections_with_multiplexer_in_specific_orde
         [get_connection_subset_with_multiplexer(conn) for conn in group] for group in connections
     ] == [
         [
-            ConnectionSubset("Pin1", 0, "Dev0", "0", "Mux0", "route1"),
-            ConnectionSubset("Pin3", 0, "Dev1", "2", "Mux0", "route3"),
-            ConnectionSubset("Pin2", 0, "Dev0", "1", "Mux0", "route2"),
-            ConnectionSubset("Pin1", 1, "Dev1", "3", "Mux0", "route4"),
-            ConnectionSubset("Pin3", 1, "Dev2", "5", "Mux0", "route6"),
-            ConnectionSubset("Pin2", 1, "Dev2", "4", "Mux0", "route5"),
+            ConnectionSubset("Pin1", 0, "Dev0", "0", "Mux0", "route0"),
+            ConnectionSubset("Pin3", 0, "Dev0", "2", "Mux0", "route2"),
+            ConnectionSubset("Pin2", 0, "Dev1", "1", "Mux0", "route1"),
+            ConnectionSubset("Pin1", 1, "Dev2", "3", "Mux0", "route3"),
+            ConnectionSubset("Pin3", 1, "Dev1", "5", "Mux0", "route5"),
+            ConnectionSubset("Pin2", 1, "Dev2", "4", "Mux0", "route4"),
         ],
         [
-            ConnectionSubset("Pin4", 0, "Dev3", "6", "Mux0", "route7"),
-            ConnectionSubset("Pin4", 1, "Dev3", "7", "Mux0", "route8"),
+            ConnectionSubset("Pin4", 0, "Dev3", "6", "Mux0", "route6"),
+            ConnectionSubset("Pin4", 1, "Dev3", "7", "Mux0", "route7"),
         ],
     ]
 
@@ -570,21 +569,20 @@ def test___reservation_order___get_connections_with_multiplexer___returns_connec
         session_management_client,
         grpc_session_infos,
         grpc_multiplexer_session_infos,
-        reserved_pin_or_relay_names=["Pin3", "Pin1", "Pin4", "Pin2"],
         reserved_sites=[1, 0],
     )
 
     connections = reservation.get_connections_with_multiplexer(object, object)
 
     assert [get_connection_subset_with_multiplexer(conn) for conn in connections] == [
-        ConnectionSubset("Pin3", 1, "Dev2", "5", "Mux0", "route6"),
-        ConnectionSubset("Pin1", 1, "Dev1", "3", "Mux0", "route4"),
-        ConnectionSubset("Pin4", 1, "Dev3", "7", "Mux0", "route8"),
-        ConnectionSubset("Pin2", 1, "Dev2", "4", "Mux0", "route5"),
-        ConnectionSubset("Pin3", 0, "Dev1", "2", "Mux0", "route3"),
-        ConnectionSubset("Pin1", 0, "Dev0", "0", "Mux0", "route1"),
-        ConnectionSubset("Pin4", 0, "Dev3", "6", "Mux0", "route7"),
-        ConnectionSubset("Pin2", 0, "Dev0", "1", "Mux0", "route2"),
+        ConnectionSubset("Pin3", 1, "Dev1", "5", "Mux0", "route5"),
+        ConnectionSubset("Pin1", 1, "Dev2", "3", "Mux0", "route3"),
+        ConnectionSubset("Pin2", 1, "Dev2", "4", "Mux0", "route4"),
+        ConnectionSubset("Pin4", 1, "Dev3", "7", "Mux0", "route7"),
+        ConnectionSubset("Pin3", 0, "Dev0", "2", "Mux0", "route2"),
+        ConnectionSubset("Pin1", 0, "Dev0", "0", "Mux0", "route0"),
+        ConnectionSubset("Pin2", 0, "Dev1", "1", "Mux0", "route1"),
+        ConnectionSubset("Pin4", 0, "Dev3", "6", "Mux0", "route6"),
     ]
 
 
@@ -602,14 +600,14 @@ def test___no_reservation_order___get_connections_with_multiplexer___returns_con
     connections = reservation.get_connections_with_multiplexer(object, object)
 
     assert [get_connection_subset_with_multiplexer(conn) for conn in connections] == [
-        ConnectionSubset("Pin1", 0, "Dev0", "0", "Mux0", "route1"),
-        ConnectionSubset("Pin2", 0, "Dev0", "1", "Mux0", "route2"),
-        ConnectionSubset("Pin3", 0, "Dev1", "2", "Mux0", "route3"),
-        ConnectionSubset("Pin4", 0, "Dev3", "6", "Mux0", "route7"),
-        ConnectionSubset("Pin1", 1, "Dev1", "3", "Mux0", "route4"),
-        ConnectionSubset("Pin2", 1, "Dev2", "4", "Mux0", "route5"),
-        ConnectionSubset("Pin3", 1, "Dev2", "5", "Mux0", "route6"),
-        ConnectionSubset("Pin4", 1, "Dev3", "7", "Mux0", "route8"),
+        ConnectionSubset("Pin3", 0, "Dev0", "2", "Mux0", "route2"),
+        ConnectionSubset("Pin1", 0, "Dev0", "0", "Mux0", "route0"),
+        ConnectionSubset("Pin2", 0, "Dev1", "1", "Mux0", "route1"),
+        ConnectionSubset("Pin4", 0, "Dev3", "6", "Mux0", "route6"),
+        ConnectionSubset("Pin3", 1, "Dev1", "5", "Mux0", "route5"),
+        ConnectionSubset("Pin1", 1, "Dev2", "3", "Mux0", "route3"),
+        ConnectionSubset("Pin2", 1, "Dev2", "4", "Mux0", "route4"),
+        ConnectionSubset("Pin4", 1, "Dev3", "7", "Mux0", "route7"),
     ]
 
 
@@ -872,60 +870,60 @@ def _create_grpc_session_and_multiplexer_session_infos_for_ordering() -> Tuple[
 ]:
     grpc_session_infos = create_nifake_session_infos(4)
     grpc_session_infos[0].channel_mappings.add(
-        pin_or_relay_name="Pin1",
-        site=0,
-        channel="0",
-        multiplexer_resource_name="Mux0",
-        multiplexer_route="route1",
-    )
-    grpc_session_infos[0].channel_mappings.add(
-        pin_or_relay_name="Pin2",
-        site=0,
-        channel="1",
-        multiplexer_resource_name="Mux0",
-        multiplexer_route="route2",
-    )
-    grpc_session_infos[1].channel_mappings.add(
         pin_or_relay_name="Pin3",
         site=0,
         channel="2",
         multiplexer_resource_name="Mux0",
-        multiplexer_route="route3",
+        multiplexer_route="route2",
+    )
+    grpc_session_infos[0].channel_mappings.add(
+        pin_or_relay_name="Pin1",
+        site=0,
+        channel="0",
+        multiplexer_resource_name="Mux0",
+        multiplexer_route="route0",
     )
     grpc_session_infos[1].channel_mappings.add(
+        pin_or_relay_name="Pin2",
+        site=0,
+        channel="1",
+        multiplexer_resource_name="Mux0",
+        multiplexer_route="route1",
+    )
+    grpc_session_infos[1].channel_mappings.add(
+        pin_or_relay_name="Pin3",
+        site=1,
+        channel="5",
+        multiplexer_resource_name="Mux0",
+        multiplexer_route="route5",
+    )
+    grpc_session_infos[2].channel_mappings.add(
         pin_or_relay_name="Pin1",
         site=1,
         channel="3",
         multiplexer_resource_name="Mux0",
-        multiplexer_route="route4",
+        multiplexer_route="route3",
     )
     grpc_session_infos[2].channel_mappings.add(
         pin_or_relay_name="Pin2",
         site=1,
         channel="4",
         multiplexer_resource_name="Mux0",
-        multiplexer_route="route5",
-    )
-    grpc_session_infos[2].channel_mappings.add(
-        pin_or_relay_name="Pin3",
-        site=1,
-        channel="5",
-        multiplexer_resource_name="Mux0",
-        multiplexer_route="route6",
+        multiplexer_route="route4",
     )
     grpc_session_infos[3].channel_mappings.add(
         pin_or_relay_name="Pin4",
         site=0,
         channel="6",
         multiplexer_resource_name="Mux0",
-        multiplexer_route="route7",
+        multiplexer_route="route6",
     )
     grpc_session_infos[3].channel_mappings.add(
         pin_or_relay_name="Pin4",
         site=1,
         channel="7",
         multiplexer_resource_name="Mux0",
-        multiplexer_route="route8",
+        multiplexer_route="route7",
     )
     grpc_session_infos[3].instrument_type_id = "nibar"
 

--- a/tests/unit/test_session_management.py
+++ b/tests/unit/test_session_management.py
@@ -207,9 +207,15 @@ def test___too_many_sessions___reserve_session___raises_too_many_sessions_value_
 def test___all_optional_args___reserve_session___args_passed_to_reservation(
     session_management_client: SessionManagementClient, session_management_stub: Mock
 ) -> None:
+
+    session = _create_grpc_session_infos(1)
+    session[0].channel_mappings.add(pin_or_relay_name="Pin3")
+    session[0].channel_mappings.add(pin_or_relay_name="Pin1")
+    session[0].channel_mappings.add(pin_or_relay_name="Pin4")
+    session[0].channel_mappings.add(pin_or_relay_name="Pin2")
     session_management_stub.ReserveSessions.return_value = (
         session_management_service_pb2.ReserveSessionsResponse(
-            sessions=_create_grpc_session_infos(1)
+            sessions=session
         )
     )
 
@@ -372,8 +378,15 @@ def test___varying_session_count___reserve_sessions___returns_multiple_session_i
 def test___all_optional_args___reserve_sessions___args_passed_to_reservation(
     session_management_client: SessionManagementClient, session_management_stub: Mock
 ) -> None:
+    sessions = _create_grpc_session_infos(2)
+    sessions[0].channel_mappings.add(pin_or_relay_name="Pin3")
+    sessions[0].channel_mappings.add(pin_or_relay_name="Pin1")
+    sessions[1].channel_mappings.add(pin_or_relay_name="Pin4")
+    sessions[1].channel_mappings.add(pin_or_relay_name="Pin2")
     session_management_stub.ReserveSessions.return_value = (
-        session_management_service_pb2.ReserveSessionsResponse()
+        session_management_service_pb2.ReserveSessionsResponse(
+            sessions=sessions
+        )
     )
 
     reservation = session_management_client.reserve_sessions(

--- a/tests/unit/test_session_management.py
+++ b/tests/unit/test_session_management.py
@@ -214,9 +214,7 @@ def test___all_optional_args___reserve_session___args_passed_to_reservation(
     session[0].channel_mappings.add(pin_or_relay_name="Pin4")
     session[0].channel_mappings.add(pin_or_relay_name="Pin2")
     session_management_stub.ReserveSessions.return_value = (
-        session_management_service_pb2.ReserveSessionsResponse(
-            sessions=session
-        )
+        session_management_service_pb2.ReserveSessionsResponse(sessions=session)
     )
 
     reservation = session_management_client.reserve_session(
@@ -384,9 +382,7 @@ def test___all_optional_args___reserve_sessions___args_passed_to_reservation(
     sessions[1].channel_mappings.add(pin_or_relay_name="Pin4")
     sessions[1].channel_mappings.add(pin_or_relay_name="Pin2")
     session_management_stub.ReserveSessions.return_value = (
-        session_management_service_pb2.ReserveSessionsResponse(
-            sessions=sessions
-        )
+        session_management_service_pb2.ReserveSessionsResponse(sessions=sessions)
     )
 
     reservation = session_management_client.reserve_sessions(


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
- Update the `_reserved_pin_or_relay_names` to hold the reserved pins obtained from the `SessionManager`, not from the request of the `reserve_sessions` call.
- Updated the dependent unit tests.

### Why should this Pull Request be merged?
- [AB#2643157](https://dev.azure.com/ni/DevCentral/_workitems/edit/2643157): Obtain the connections for the reserved pins when the pin group is reserved.

### What testing has been done?
Ran automated tests.