### PR TITLE
nims: update get multiplexer APIs in session management client to return MultiplexerSessionContainer instance

### DIFF
--- a/ni_measurementlink_service/session_management/_client.py
+++ b/ni_measurementlink_service/session_management/_client.py
@@ -24,7 +24,7 @@ from ni_measurementlink_service.session_management._constants import (
     GRPC_SERVICE_INTERFACE_NAME,
 )
 from ni_measurementlink_service.session_management._reservation import (
-    MultiplexerSessionHandler,
+    MultiplexerSessionContainer,
     MultiSessionReservation,
     SingleSessionReservation,
 )
@@ -328,7 +328,7 @@ class SessionManagementClient(object):
     @requires_feature(MULTIPLEXER_SUPPORT_2024Q2)
     def get_multiplexer_sessions(
         self, pin_map_context: PinMapContext, multiplexer_type_id: Optional[str] = None
-    ) -> MultiplexerSessionHandler:
+    ) -> MultiplexerSessionContainer:
         """Get all multiplexer session infos matching the specified criteria.
 
         Returns the information needed to create or access the multiplexer sessions
@@ -343,7 +343,7 @@ class SessionManagementClient(object):
                 type id is ignored when matching multiplexer sessions.
 
         Returns:
-            The multiplexer session handler containing the matching session infos.
+            The multiplexer session container with the matching session infos.
         """
         request = session_management_service_pb2.GetMultiplexerSessionsRequest(
             pin_map_context=pin_map_context._to_grpc()
@@ -353,12 +353,12 @@ class SessionManagementClient(object):
 
         response = self._get_stub().GetMultiplexerSessions(request)
         session_infos = [session for session in response.multiplexer_sessions]
-        return MultiplexerSessionHandler(self, session_infos)
+        return MultiplexerSessionContainer(self, session_infos)
 
     @requires_feature(MULTIPLEXER_SUPPORT_2024Q2)
     def get_all_registered_multiplexer_sessions(
         self, multiplexer_type_id: Optional[str] = None
-    ) -> MultiplexerSessionHandler:
+    ) -> MultiplexerSessionContainer:
         """Get all multiplexer session infos registered with the session management service.
 
         Args:
@@ -367,7 +367,7 @@ class SessionManagementClient(object):
                 type id is ignored when matching multiplexer sessions.
 
         Returns:
-            The multiplexer session handler containing the matching session infos registered
+            The multiplexer session container with the matching session infos registered
             with the session management service.
         """
         request = session_management_service_pb2.GetAllRegisteredMultiplexerSessionsRequest()
@@ -376,7 +376,7 @@ class SessionManagementClient(object):
 
         response = self._get_stub().GetAllRegisteredMultiplexerSessions(request)
         session_infos = [session for session in response.multiplexer_sessions]
-        return MultiplexerSessionHandler(self, session_infos)
+        return MultiplexerSessionContainer(self, session_infos)
 
 
 def _timeout_to_milliseconds(timeout: Optional[float]) -> int:

--- a/ni_measurementlink_service/session_management/_client.py
+++ b/ni_measurementlink_service/session_management/_client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import threading
 import warnings
-from typing import Iterable, Optional, Sequence, Union
+from typing import Iterable, Optional, Union
 
 import grpc
 
@@ -24,6 +24,7 @@ from ni_measurementlink_service.session_management._constants import (
     GRPC_SERVICE_INTERFACE_NAME,
 )
 from ni_measurementlink_service.session_management._reservation import (
+    Multiplexer,
     MultiSessionReservation,
     SingleSessionReservation,
 )
@@ -327,7 +328,7 @@ class SessionManagementClient(object):
     @requires_feature(MULTIPLEXER_SUPPORT_2024Q2)
     def get_multiplexer_sessions(
         self, pin_map_context: PinMapContext, multiplexer_type_id: Optional[str] = None
-    ) -> Sequence[MultiplexerSessionInformation]:
+    ) -> Multiplexer:
         """Get all multiplexer session infos matching the specified criteria.
 
         Returns the information needed to create or access the multiplexer sessions
@@ -342,7 +343,7 @@ class SessionManagementClient(object):
                 type id is ignored when matching multiplexer sessions.
 
         Returns:
-            The matching multiplexer session infos.
+            The multiplexer object containing the matching multiplexer session infos.
         """
         request = session_management_service_pb2.GetMultiplexerSessionsRequest(
             pin_map_context=pin_map_context._to_grpc()
@@ -351,15 +352,13 @@ class SessionManagementClient(object):
             request.multiplexer_type_id = multiplexer_type_id
 
         response = self._get_stub().GetMultiplexerSessions(request)
-        return [
-            MultiplexerSessionInformation._from_grpc_v1(session)
-            for session in response.multiplexer_sessions
-        ]
+        session_infos = [session for session in response.multiplexer_sessions]
+        return Multiplexer(self, session_infos)
 
     @requires_feature(MULTIPLEXER_SUPPORT_2024Q2)
     def get_all_registered_multiplexer_sessions(
         self, multiplexer_type_id: Optional[str] = None
-    ) -> Sequence[MultiplexerSessionInformation]:
+    ) -> Multiplexer:
         """Get all multiplexer session infos registered with the session management service.
 
         Args:
@@ -368,17 +367,16 @@ class SessionManagementClient(object):
                 type id is ignored when matching multiplexer sessions.
 
         Returns:
-            The matching multiplexer session infos registered with the session management service.
+            The multiplexer object containing the matching multiplexer session infos registered
+            with the session management service.
         """
         request = session_management_service_pb2.GetAllRegisteredMultiplexerSessionsRequest()
         if multiplexer_type_id is not None:
             request.multiplexer_type_id = multiplexer_type_id
 
         response = self._get_stub().GetAllRegisteredMultiplexerSessions(request)
-        return [
-            MultiplexerSessionInformation._from_grpc_v1(session)
-            for session in response.multiplexer_sessions
-        ]
+        session_infos = [session for session in response.multiplexer_sessions]
+        return Multiplexer(self, session_infos)
 
 
 def _timeout_to_milliseconds(timeout: Optional[float]) -> int:

--- a/ni_measurementlink_service/session_management/_client.py
+++ b/ni_measurementlink_service/session_management/_client.py
@@ -24,7 +24,7 @@ from ni_measurementlink_service.session_management._constants import (
     GRPC_SERVICE_INTERFACE_NAME,
 )
 from ni_measurementlink_service.session_management._reservation import (
-    Multiplexer,
+    MultiplexerSessionHandler,
     MultiSessionReservation,
     SingleSessionReservation,
 )
@@ -328,7 +328,7 @@ class SessionManagementClient(object):
     @requires_feature(MULTIPLEXER_SUPPORT_2024Q2)
     def get_multiplexer_sessions(
         self, pin_map_context: PinMapContext, multiplexer_type_id: Optional[str] = None
-    ) -> Multiplexer:
+    ) -> MultiplexerSessionHandler:
         """Get all multiplexer session infos matching the specified criteria.
 
         Returns the information needed to create or access the multiplexer sessions
@@ -343,7 +343,7 @@ class SessionManagementClient(object):
                 type id is ignored when matching multiplexer sessions.
 
         Returns:
-            The multiplexer object containing the matching multiplexer session infos.
+            The multiplexer session handler containing the matching session infos.
         """
         request = session_management_service_pb2.GetMultiplexerSessionsRequest(
             pin_map_context=pin_map_context._to_grpc()
@@ -353,12 +353,12 @@ class SessionManagementClient(object):
 
         response = self._get_stub().GetMultiplexerSessions(request)
         session_infos = [session for session in response.multiplexer_sessions]
-        return Multiplexer(self, session_infos)
+        return MultiplexerSessionHandler(self, session_infos)
 
     @requires_feature(MULTIPLEXER_SUPPORT_2024Q2)
     def get_all_registered_multiplexer_sessions(
         self, multiplexer_type_id: Optional[str] = None
-    ) -> Multiplexer:
+    ) -> MultiplexerSessionHandler:
         """Get all multiplexer session infos registered with the session management service.
 
         Args:
@@ -367,7 +367,7 @@ class SessionManagementClient(object):
                 type id is ignored when matching multiplexer sessions.
 
         Returns:
-            The multiplexer object containing the matching multiplexer session infos registered
+            The multiplexer session handler containing the matching session infos registered
             with the session management service.
         """
         request = session_management_service_pb2.GetAllRegisteredMultiplexerSessionsRequest()
@@ -376,7 +376,7 @@ class SessionManagementClient(object):
 
         response = self._get_stub().GetAllRegisteredMultiplexerSessions(request)
         session_infos = [session for session in response.multiplexer_sessions]
-        return Multiplexer(self, session_infos)
+        return MultiplexerSessionHandler(self, session_infos)
 
 
 def _timeout_to_milliseconds(timeout: Optional[float]) -> int:

--- a/tests/unit/test_session_management.py
+++ b/tests/unit/test_session_management.py
@@ -864,8 +864,8 @@ def test___varying_multiplexers___get_multiplexer_sessions___returns_multiplexer
     response = session_management_client.get_multiplexer_sessions(PinMapContext("MyPinMap", [0, 1]))
 
     session_management_stub.GetMultiplexerSessions.assert_called_once()
-    assert len(response) == multiplexer_session_count
-    assert [info.session_name for info in response] == [
+    assert len(response.multiplexer_session_info) == multiplexer_session_count
+    assert [info.session_name for info in response.multiplexer_session_info] == [
         f"MyMultiplexer{i}" for i in range(multiplexer_session_count)
     ]
 
@@ -930,8 +930,8 @@ def test___varying_registered_multiplexers___get_all_registered_multiplexer_sess
     response = session_management_client.get_all_registered_multiplexer_sessions()
 
     session_management_stub.GetAllRegisteredMultiplexerSessions.assert_called_once()
-    assert len(response) == multiplexer_session_count
-    assert [info.session_name for info in response] == [
+    assert len(response.multiplexer_session_info) == multiplexer_session_count
+    assert [info.session_name for info in response.multiplexer_session_info] == [
         f"MyMultiplexer{i}" for i in range(multiplexer_session_count)
     ]
 

--- a/tests/unit/test_session_management.py
+++ b/tests/unit/test_session_management.py
@@ -861,11 +861,11 @@ def test___varying_multiplexers___get_multiplexer_sessions___returns_multiplexer
         )
     )
 
-    response = session_management_client.get_multiplexer_sessions(PinMapContext("MyPinMap", [0, 1]))
+    result = session_management_client.get_multiplexer_sessions(PinMapContext("MyPinMap", [0, 1]))
 
     session_management_stub.GetMultiplexerSessions.assert_called_once()
-    assert len(response.multiplexer_session_info) == multiplexer_session_count
-    assert [info.session_name for info in response.multiplexer_session_info] == [
+    assert len(result.multiplexer_session_info) == multiplexer_session_count
+    assert [info.session_name for info in result.multiplexer_session_info] == [
         f"MyMultiplexer{i}" for i in range(multiplexer_session_count)
     ]
 
@@ -927,11 +927,11 @@ def test___varying_registered_multiplexers___get_all_registered_multiplexer_sess
         )
     )
 
-    response = session_management_client.get_all_registered_multiplexer_sessions()
+    result = session_management_client.get_all_registered_multiplexer_sessions()
 
     session_management_stub.GetAllRegisteredMultiplexerSessions.assert_called_once()
-    assert len(response.multiplexer_session_info) == multiplexer_session_count
-    assert [info.session_name for info in response.multiplexer_session_info] == [
+    assert len(result.multiplexer_session_info) == multiplexer_session_count
+    assert [info.session_name for info in result.multiplexer_session_info] == [
         f"MyMultiplexer{i}" for i in range(multiplexer_session_count)
     ]
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Updates the `get_multiplexer_sessions` and `get_all_registered_multiplexer_sessions` APIs to return the MultiplexerSessionContainer object to expose multiplexer initialization APIs.

### Why should this Pull Request be merged?
To expose the initialize multiplexer APIs in the TestStand fixtures.

### What testing has been done?
Updates existing test cases.