### PR TITLE
fix: remove feature toggle from MultiplexerSessionContainer's init method

### DIFF
--- a/ni_measurementlink_service/session_management/_reservation.py
+++ b/ni_measurementlink_service/session_management/_reservation.py
@@ -203,7 +203,6 @@ class _BaseSessionContainer(abc.ABC):
 class MultiplexerSessionContainer(_BaseSessionContainer):
     """Manages multiplexer session information."""
 
-    @requires_feature(MULTIPLEXER_SUPPORT_2024Q2)
     def __init__(
         self,
         session_management_client: SessionManagementClient,


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Removes the feature toggle from the `MultiplexerSessionContainer`'s "__init__" method.
[AB#2673383](https://dev.azure.com/ni/DevCentral/_workitems/edit/2673383)

### Why should this Pull Request be merged?
If the examples that don't use multiplexer update their NIMS dependency to `1.4.0-dev0`, a `FeatureNotSupportedError` is thrown.

### What testing has been done?
- Manually verified,
  - the "ni_dcpower_source_dc_voltage" measurement _with_ and _without_ enabling the feature toggle (**no** errors were thrown).
  - the "ni_dcpower_source_dc_voltage_with_multiplexer" _with_ and _without_ enabling the feature toggle and the `FeatureNotSupportedError` was thrown when the feature toggle wasn't enabled. 

- Existing tests should still pass.