### PR TITLE
examples: Update NI-Scope to demonstrate PinGroup usage

### DIFF
--- a/examples/niscope_acquire_waveform/NIScopeAcquireWaveform.pinmap
+++ b/examples/niscope_acquire_waveform/NIScopeAcquireWaveform.pinmap
@@ -9,7 +9,14 @@
 		<DUTPin name="Pin3" />
 		<DUTPin name="Pin4" />
 	</Pins>
-	<PinGroups></PinGroups>
+	<PinGroups>
+		<PinGroup name="PinGroup1">
+			<PinReference pin="Pin1" />
+			<PinReference pin="Pin2" />
+			<PinReference pin="Pin3" />
+			<PinReference pin="Pin4" />
+		</PinGroup>
+	</PinGroups>
 	<Sites>
 		<Site siteNumber="0" />
 	</Sites>

--- a/examples/niscope_acquire_waveform/NIScopeAcquireWaveform.seq
+++ b/examples/niscope_acquire_waveform/NIScopeAcquireWaveform.seq
@@ -2673,7 +2673,7 @@
 																					<value>pin_names</value>
 																				</Name>
 																				<ArgumentValue classname='ExprValue'>
-																					<value>{"Pin1","Pin2","Pin3","Pin4"}</value>
+																					<value>{"PinGroup1"}</value>
 																				</ArgumentValue>
 																				<Direction classname='Str'>
 																					<value>In</value>

--- a/examples/niscope_acquire_waveform/measurement.py
+++ b/examples/niscope_acquire_waveform/measurement.py
@@ -26,7 +26,7 @@ measurement_service = nims.MeasurementService(
 @measurement_service.configuration(
     "pin_names",
     nims.DataType.PinArray1D,
-    ["Pin1", "Pin2", "Pin3", "Pin4"],
+    ["PinGroup1"],
     instrument_type=nims.session_management.INSTRUMENT_TYPE_NI_SCOPE,
 )
 @measurement_service.configuration("vertical_range", nims.DataType.Double, 5.0)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
- Update the `NI-Scope` example to reserve the session using a pin group by grouping existing pins.

### Why should this Pull Request be merged?
To demonstrate obtaining connections at both the individual pin and pin group levels when reserving the session using a pin group:
- Obtain connections using individual pins.
- Obtain connections using pin groups.

### What testing has been done?
- Manually ran the measurement and verified it from both `InstrumentStudio` and `TestStand`.