### PR TITLE
deps: update nims dependency in the NI-Scope example

### DIFF
--- a/examples/niscope_acquire_waveform/pyproject.toml
+++ b/examples/niscope_acquire_waveform/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 niscope = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurementlink-service = {version = "^1.3.0"}
+ni-measurementlink-service = {version = "^1.4.0-dev1", allow-prereleases = true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
References the latest pre-release `ni-measurementlink-service` package (v1.4.0-dev1) in the `niscope_acquire_waveform` example.

### Why should this Pull Request be merged?
As the NI-Scope example demonstrates pin group usage, the `ni-measurementlink-service` version should also support pin groups.

### What testing has been done?
Manually ran the measurement and verified it from both `InstrumentStudio` and `TestStand`.