### PR TITLE
example: update nidcpower's multisite pinmap to have separate channel groups

### DIFF
--- a/examples/nidcpower_source_dc_voltage/NIDCPowerSourceDCVoltageMultiSite.pinmap
+++ b/examples/nidcpower_source_dc_voltage/NIDCPowerSourceDCVoltageMultiSite.pinmap
@@ -2,22 +2,26 @@
 <PinMap xmlns="http://www.ni.com/TestStand/SemiconductorModule/PinMap.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.6">
 	<Instruments>
 		<NIDCPowerInstrument name="DCPower1" numberOfChannels="4">
-			<ChannelGroup name="CommonDCPowerChannelGroup" />
+			<ChannelGroup name="ChannelGroup1" channels="0" />
+			<ChannelGroup name="ChannelGroup2" channels="1" />
+			<ChannelGroup name="ChannelGroup3" channels="2" />
+			<ChannelGroup name="ChannelGroup4" channels="3" />
 		</NIDCPowerInstrument>
 	</Instruments>
 	<Pins>
 		<DUTPin name="Pin1" />
-		<DUTPin name="Pin2" />
 	</Pins>
 	<PinGroups></PinGroups>
 	<Sites>
 		<Site siteNumber="0" />
 		<Site siteNumber="1" />
+		<Site siteNumber="2" />
+		<Site siteNumber="3" />
 	</Sites>
 	<Connections>
 		<Connection pin="Pin1" siteNumber="0" instrument="DCPower1" channel="0" />
-		<Connection pin="Pin1" siteNumber="1" instrument="DCPower1" channel="2" />
-		<Connection pin="Pin2" siteNumber="0" instrument="DCPower1" channel="1" />
-		<Connection pin="Pin2" siteNumber="1" instrument="DCPower1" channel="3" />
+		<Connection pin="Pin1" siteNumber="1" instrument="DCPower1" channel="1" />
+		<Connection pin="Pin1" siteNumber="2" instrument="DCPower1" channel="2" />
+		<Connection pin="Pin1" siteNumber="3" instrument="DCPower1" channel="3" />
 	</Connections>
 </PinMap>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Updates the `NIDCPowerSourceDCVoltageMultiSite.pinmap` to have 4 sites and a separate channel group for each channel in the `DCPower1` instrument.

### Why should this Pull Request be merged?
This enables users to directly reference this pin map in the provided TestStand sequence without any updates.

### What testing has been done?
Manually verified the pin map by using it for Batch model execution in TestStand 2021 SP1.