### PR TITLE
Turn on Mux feature toggle for release

### DIFF
--- a/ni_measurementlink_service/_featuretoggles.py
+++ b/ni_measurementlink_service/_featuretoggles.py
@@ -147,4 +147,4 @@ def requires_feature(
 # Define feature toggle constants here:
 # --------------------------------------
 
-MULTIPLEXER_SUPPORT_2024Q2 = FeatureToggle("MULTIPLEXER_SUPPORT_2024Q2", CodeReadiness.NEXT_RELEASE)
+MULTIPLEXER_SUPPORT_2024Q2 = FeatureToggle("MULTIPLEXER_SUPPORT_2024Q2", CodeReadiness.RELEASE)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Turns the `MULTIPLEXER_SUPPORT_2024Q2` feature toggle to RELEASE status, making it on by default.

### Why should this Pull Request be merged?

Mux feature is ready to go. We are about to create the 1.4.0 release branch.

### What testing has been done?

Automated tests. After we create the release, we'll test the examples which need the feature toggle.