### PR TITLE
[Releases/1.4] Bump example versions that need it to 1.4.0

### DIFF
--- a/examples/nidcpower_source_dc_voltage_with_multiplexer/pyproject.toml
+++ b/examples/nidcpower_source_dc_voltage_with_multiplexer/pyproject.toml
@@ -9,7 +9,7 @@ authors = ["National Instruments"]
 python = "^3.8"
 nidcpower = { version = ">=1.4.4", extras = ["grpc"] }
 niswitch = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurementlink-service = {version = "^1.4.0-dev0", allow-prereleases = true}
+ni-measurementlink-service = {version = "^1.4.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/niscope_acquire_waveform/pyproject.toml
+++ b/examples/niscope_acquire_waveform/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 niscope = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurementlink-service = {version = "^1.4.0-dev1", allow-prereleases = true}
+ni-measurementlink-service = {version = "^1.4.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/niswitch_control_relays/pyproject.toml
+++ b/examples/niswitch_control_relays/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 niswitch = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurementlink-service = {version = "^1.4.0-dev0", allow-prereleases = true}
+ni-measurementlink-service = {version = "^1.4.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Bump example versions to depend on a released version. Remove allow-prereleases flag.

### Why should this Pull Request be merged?

When the publish happens, the examples should work with a released version.

### What testing has been done?

None. Waiting for publish of the release to test.