### PR TITLE
Move examples to released package dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ you are using a previous version of MeasurementLink, download the appropriate ex
 - MeasurementLink 2023 Q3: [measurementlink-python-examples-1.1.0.zip](https://github.com/ni/measurementlink-python/releases/download/1.1.0/measurementlink-python-examples-1.1.0.zip)
 - MeasurementLink 2023 Q4: [measurementlink-python-examples-1.2.0.zip](https://github.com/ni/measurementlink-python/releases/download/1.2.0/measurementlink-python-examples-1.2.0.zip)
 - MeasurementLink 2024 Q1: [measurementlink-python-examples-1.3.0.zip](https://github.com/ni/measurementlink-python/releases/download/1.3.0/measurementlink-python-examples-1.3.0.zip)
+- MeasurementLink 2024 Q2: [measurementlink-python-examples-1.4.0.zip](https://github.com/ni/measurementlink-python/releases/download/1.4.0/measurementlink-python-examples-1.4.0.zip)
+
 
 For more information on setting up and running the example measurements, see the included `README.md` file.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,6 +10,7 @@ If you are using a previous version of MeasurementLink, download the appropriate
 - MeasurementLink 2023 Q3: [measurementlink-python-examples-1.1.0.zip](https://github.com/ni/measurementlink-python/releases/download/1.1.0/measurementlink-python-examples-1.1.0.zip)
 - MeasurementLink 2023 Q4: [measurementlink-python-examples-1.2.0.zip](https://github.com/ni/measurementlink-python/releases/download/1.2.0/measurementlink-python-examples-1.2.0.zip)
 - MeasurementLink 2024 Q1: [measurementlink-python-examples-1.3.0.zip](https://github.com/ni/measurementlink-python/releases/download/1.3.0/measurementlink-python-examples-1.3.0.zip)
+- MeasurementLink 2024 Q2: [measurementlink-python-examples-1.4.0.zip](https://github.com/ni/measurementlink-python/releases/download/1.4.0/measurementlink-python-examples-1.4.0.zip)
 
 For best results, use the example measurements corresponding to the version of MeasurementLink
 that you are using. Newer examples may demonstrate features that are not available in older

--- a/examples/nidcpower_source_dc_voltage_with_multiplexer/pyproject.toml
+++ b/examples/nidcpower_source_dc_voltage_with_multiplexer/pyproject.toml
@@ -9,7 +9,7 @@ authors = ["National Instruments"]
 python = "^3.8"
 nidcpower = { version = ">=1.4.4", extras = ["grpc"] }
 niswitch = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurementlink-service = {version = "^1.4.0-dev0", allow-prereleases = true}
+ni-measurementlink-service = {version = "^1.4.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/niscope_acquire_waveform/pyproject.toml
+++ b/examples/niscope_acquire_waveform/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 niscope = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurementlink-service = {version = "^1.4.0-dev1", allow-prereleases = true}
+ni-measurementlink-service = {version = "^1.4.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 

--- a/examples/niswitch_control_relays/pyproject.toml
+++ b/examples/niswitch_control_relays/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 niswitch = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurementlink-service = {version = "^1.4.0-dev0", allow-prereleases = true}
+ni-measurementlink-service = {version = "^1.4.0"}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update examples in main that were depending on prerelease dependencies to depend on the newly released 1.4.0 version.

### Why should this Pull Request be merged?

Examples are now using released features, so should depend on released packages.

### What testing has been done?

Depending on the automated tests.