### PR TITLE
Add timeouts while destroying sessions for the measurements when running in TestStand

### DIFF
--- a/examples/nidaqmx_analog_input/teststand_nidaqmx.py
+++ b/examples/nidaqmx_analog_input/teststand_nidaqmx.py
@@ -49,8 +49,8 @@ def destroy_nidaqmx_tasks() -> None:
         session_management_client = SessionManagementClient(
             discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool
         )
-        # Timeouts are added when destroying sessions to ensure that if a cancellation is performed for the measurement,
-        # session is closed within an appropriate timeframe.
+        # Timeout is added when destroying sessions to ensure that if a cancellation is performed
+        # for the measurement, session is closed within an appropriate timeframe.
         with session_management_client.reserve_all_registered_sessions(
             instrument_type_id=INSTRUMENT_TYPE_NI_DAQMX,
             timeout=60,

--- a/examples/nidaqmx_analog_input/teststand_nidaqmx.py
+++ b/examples/nidaqmx_analog_input/teststand_nidaqmx.py
@@ -53,7 +53,7 @@ def destroy_nidaqmx_tasks() -> None:
         # for the measurement, session is closed within an appropriate timeframe.
         with session_management_client.reserve_all_registered_sessions(
             instrument_type_id=INSTRUMENT_TYPE_NI_DAQMX,
-            timeout=60,
+            timeout=10,
         ) as reservation:
             if not reservation.session_info:
                 return

--- a/examples/nidaqmx_analog_input/teststand_nidaqmx.py
+++ b/examples/nidaqmx_analog_input/teststand_nidaqmx.py
@@ -49,8 +49,11 @@ def destroy_nidaqmx_tasks() -> None:
         session_management_client = SessionManagementClient(
             discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool
         )
+        # Timeouts are added when destroying sessions to ensure that if a cancellation is performed for the measurement,
+        # session is closed within an appropriate timeframe.
         with session_management_client.reserve_all_registered_sessions(
             instrument_type_id=INSTRUMENT_TYPE_NI_DAQMX,
+            timeout=60,
         ) as reservation:
             if not reservation.session_info:
                 return

--- a/examples/nidcpower_source_dc_voltage/teststand_nidcpower.py
+++ b/examples/nidcpower_source_dc_voltage/teststand_nidcpower.py
@@ -47,8 +47,11 @@ def destroy_nidcpower_sessions() -> None:
         session_management_client = SessionManagementClient(
             discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool
         )
+        # Timeout is added when destroying sessions to ensure that if a cancellation is performed
+        # for the measurement, session is closed within an appropriate timeframe.
         with session_management_client.reserve_all_registered_sessions(
             instrument_type_id=INSTRUMENT_TYPE_NI_DCPOWER,
+            timeout=10,
         ) as reservation:
             if not reservation.session_info:
                 return

--- a/examples/nidcpower_source_dc_voltage_with_multiplexer/teststand_nidcpower.py
+++ b/examples/nidcpower_source_dc_voltage_with_multiplexer/teststand_nidcpower.py
@@ -47,8 +47,11 @@ def destroy_nidcpower_sessions() -> None:
         session_management_client = SessionManagementClient(
             discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool
         )
+        # Timeout is added when destroying sessions to ensure that if a cancellation is performed
+        # for the measurement, session is closed within an appropriate timeframe.
         with session_management_client.reserve_all_registered_sessions(
             instrument_type_id=INSTRUMENT_TYPE_NI_DCPOWER,
+            timeout=10,
         ) as reservation:
             if not reservation.session_info:
                 return

--- a/examples/nidcpower_source_dc_voltage_with_multiplexer/teststand_niswitch.py
+++ b/examples/nidcpower_source_dc_voltage_with_multiplexer/teststand_niswitch.py
@@ -48,8 +48,11 @@ def destroy_niswitch_sessions() -> None:
         session_management_client = SessionManagementClient(
             discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool
         )
+        # Timeout is added when destroying sessions to ensure that if a cancellation is performed
+        # for the measurement, session is closed within an appropriate timeframe.
         with session_management_client.reserve_all_registered_sessions(
             instrument_type_id=INSTRUMENT_TYPE_NI_RELAY_DRIVER,
+            timeout=10,
         ) as reservation:
             if not reservation.session_info:
                 return

--- a/examples/nidigital_spi/teststand_nidigital.py
+++ b/examples/nidigital_spi/teststand_nidigital.py
@@ -147,8 +147,11 @@ def destroy_nidigital_sessions() -> None:
         session_management_client = SessionManagementClient(
             discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool
         )
+        # Timeout is added when destroying sessions to ensure that if a cancellation is performed
+        # for the measurement, session is closed within an appropriate timeframe.
         with session_management_client.reserve_all_registered_sessions(
             instrument_type_id=INSTRUMENT_TYPE_NI_DIGITAL_PATTERN,
+            timeout=10,
         ) as reservation:
             if not reservation.session_info:
                 return

--- a/examples/nidmm_measurement/teststand_nidmm.py
+++ b/examples/nidmm_measurement/teststand_nidmm.py
@@ -48,8 +48,11 @@ def destroy_nidmm_sessions() -> None:
         session_management_client = SessionManagementClient(
             discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool
         )
+        # Timeout is added when destroying sessions to ensure that if a cancellation is performed
+        # for the measurement, session is closed within an appropriate timeframe.
         with session_management_client.reserve_all_registered_sessions(
             instrument_type_id=INSTRUMENT_TYPE_NI_DMM,
+            timeout=10,
         ) as reservation:
             if not reservation.session_info:
                 return

--- a/examples/nifgen_standard_function/teststand_nifgen.py
+++ b/examples/nifgen_standard_function/teststand_nifgen.py
@@ -48,8 +48,8 @@ def destroy_nifgen_sessions() -> None:
         session_management_client = SessionManagementClient(
             discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool
         )
-        # Timeouts are added when destroying sessions to ensure that if a cancellation is performed for the measurement,
-        # session is closed within an appropriate timeframe.
+        # Timeout is added when destroying sessions to ensure that if a cancellation is performed
+        # for the measurement, session is closed within an appropriate timeframe.
         with session_management_client.reserve_all_registered_sessions(
             instrument_type_id=INSTRUMENT_TYPE_NI_FGEN,
             timeout=60,

--- a/examples/nifgen_standard_function/teststand_nifgen.py
+++ b/examples/nifgen_standard_function/teststand_nifgen.py
@@ -48,8 +48,11 @@ def destroy_nifgen_sessions() -> None:
         session_management_client = SessionManagementClient(
             discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool
         )
+        # Timeouts are added when destroying sessions to ensure that if a cancellation is performed for the measurement,
+        # session is closed within an appropriate timeframe.
         with session_management_client.reserve_all_registered_sessions(
             instrument_type_id=INSTRUMENT_TYPE_NI_FGEN,
+            timeout=60,
         ) as reservation:
             if not reservation.session_info:
                 return

--- a/examples/nifgen_standard_function/teststand_nifgen.py
+++ b/examples/nifgen_standard_function/teststand_nifgen.py
@@ -52,7 +52,7 @@ def destroy_nifgen_sessions() -> None:
         # for the measurement, session is closed within an appropriate timeframe.
         with session_management_client.reserve_all_registered_sessions(
             instrument_type_id=INSTRUMENT_TYPE_NI_FGEN,
-            timeout=60,
+            timeout=10,
         ) as reservation:
             if not reservation.session_info:
                 return

--- a/examples/niscope_acquire_waveform/teststand_niscope.py
+++ b/examples/niscope_acquire_waveform/teststand_niscope.py
@@ -47,8 +47,11 @@ def destroy_niscope_sessions() -> None:
         session_management_client = SessionManagementClient(
             discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool
         )
+        # Timeout is added when destroying sessions to ensure that if a cancellation is performed
+        # for the measurement, session is closed within an appropriate timeframe.
         with session_management_client.reserve_all_registered_sessions(
             instrument_type_id=INSTRUMENT_TYPE_NI_SCOPE,
+            timeout=10,
         ) as reservation:
             if not reservation.session_info:
                 return

--- a/examples/niswitch_control_relays/teststand_niswitch.py
+++ b/examples/niswitch_control_relays/teststand_niswitch.py
@@ -48,8 +48,11 @@ def destroy_niswitch_sessions() -> None:
         session_management_client = SessionManagementClient(
             discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool
         )
+        # Timeout is added when destroying sessions to ensure that if a cancellation is performed
+        # for the measurement, session is closed within an appropriate timeframe.
         with session_management_client.reserve_all_registered_sessions(
             instrument_type_id=INSTRUMENT_TYPE_NI_RELAY_DRIVER,
+            timeout=10,
         ) as reservation:
             if not reservation.session_info:
                 return

--- a/examples/nivisa_dmm_measurement/teststand_nivisa_dmm.py
+++ b/examples/nivisa_dmm_measurement/teststand_nivisa_dmm.py
@@ -67,9 +67,11 @@ def destroy_nivisa_dmm_sessions() -> None:
             discovery_client,
             SessionInitializationBehavior.ATTACH_TO_SESSION_THEN_CLOSE,
         )
-
+        # Timeout is added when destroying sessions to ensure that if a cancellation is performed
+        # for the measurement, session is closed within an appropriate timeframe.
         with session_management_client.reserve_all_registered_sessions(
             instrument_type_id=INSTRUMENT_TYPE_VISA_DMM,
+            timeout=10,
         ) as reservation:
             if not reservation.session_info:
                 return

--- a/examples/output_voltage_measurement/teststand_nidcpower.py
+++ b/examples/output_voltage_measurement/teststand_nidcpower.py
@@ -47,8 +47,11 @@ def destroy_nidcpower_sessions() -> None:
         session_management_client = SessionManagementClient(
             discovery_client=discovery_client, grpc_channel_pool=grpc_channel_pool
         )
+        # Timeout is added when destroying sessions to ensure that if a cancellation is performed
+        # for the measurement, session is closed within an appropriate timeframe.
         with session_management_client.reserve_all_registered_sessions(
             instrument_type_id=INSTRUMENT_TYPE_NI_DCPOWER,
+            timeout=10,
         ) as reservation:
             if not reservation.session_info:
                 return

--- a/examples/output_voltage_measurement/teststand_nivisa_dmm.py
+++ b/examples/output_voltage_measurement/teststand_nivisa_dmm.py
@@ -67,9 +67,11 @@ def destroy_nivisa_dmm_sessions() -> None:
             discovery_client,
             SessionInitializationBehavior.ATTACH_TO_SESSION_THEN_CLOSE,
         )
-
+        # Timeout is added when destroying sessions to ensure that if a cancellation is performed
+        # for the measurement, session is closed within an appropriate timeframe.
         with session_management_client.reserve_all_registered_sessions(
             instrument_type_id=INSTRUMENT_TYPE_VISA_DMM,
+            timeout=10,
         ) as reservation:
             if not reservation.session_info:
                 return


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Adds timeouts while destroying sessions for the measurements in TestStand

### Why should this Pull Request be merged?
Resolves [User Story 2676827](https://dev.azure.com/ni/DevCentral/_workitems/edit/2676827): Add timeout as 10s when destroying sessions in the TestStand sequences

### What testing has been done?
Manually verified by running and aborting the measurement steps in the example sequences.