### PR TITLE
Add timeout of 10s for reserve_all_registered_sessions() 

### DIFF
--- a/ni_measurementlink_service/session_management/_client.py
+++ b/ni_measurementlink_service/session_management/_client.py
@@ -272,7 +272,7 @@ class SessionManagementClient(object):
 
             timeout: Timeout in seconds.
 
-                Use a timeout in order to wait for the measurement to complete or be canceled.
+                An arbitrary timeout to wait for the measurement to complete or be canceled.
 
                 Allowed values: 0 (non-blocking, fails immediately if resources cannot be
                 reserved), -1 (infinite timeout), or any other positive numeric value (wait for

--- a/ni_measurementlink_service/session_management/_client.py
+++ b/ni_measurementlink_service/session_management/_client.py
@@ -255,7 +255,7 @@ class SessionManagementClient(object):
         self._get_stub().UnregisterSessions(request)
 
     def reserve_all_registered_sessions(
-        self, instrument_type_id: Optional[str] = None, timeout: Optional[float] = 0.0
+        self, instrument_type_id: Optional[str] = None, timeout: Optional[float] = 10.0
     ) -> MultiSessionReservation:
         """Reserve all sessions currently registered with the session management service.
 
@@ -270,7 +270,7 @@ class SessionManagementClient(object):
 
                 For custom instruments, use the instrument type id defined in the pin map file.
 
-            timeout: Timeout in seconds.
+            timeout: Timeout in seconds. Use a timeout in order to wait for the measurement to complete or be canceled.
 
                 Allowed values: 0 (non-blocking, fails immediately if resources cannot be
                 reserved), -1 (infinite timeout), or any other positive numeric value (wait for

--- a/ni_measurementlink_service/session_management/_client.py
+++ b/ni_measurementlink_service/session_management/_client.py
@@ -271,7 +271,7 @@ class SessionManagementClient(object):
                 For custom instruments, use the instrument type id defined in the pin map file.
 
             timeout: Timeout in seconds.
-            
+
                 Use a timeout in order to wait for the measurement to complete or be canceled.
 
                 Allowed values: 0 (non-blocking, fails immediately if resources cannot be

--- a/ni_measurementlink_service/session_management/_client.py
+++ b/ni_measurementlink_service/session_management/_client.py
@@ -270,7 +270,9 @@ class SessionManagementClient(object):
 
                 For custom instruments, use the instrument type id defined in the pin map file.
 
-            timeout: Timeout in seconds. Use a timeout in order to wait for the measurement to complete or be canceled.
+            timeout: Timeout in seconds.
+            
+                Use a timeout in order to wait for the measurement to complete or be canceled.
 
                 Allowed values: 0 (non-blocking, fails immediately if resources cannot be
                 reserved), -1 (infinite timeout), or any other positive numeric value (wait for

--- a/tests/unit/test_session_management.py
+++ b/tests/unit/test_session_management.py
@@ -503,7 +503,7 @@ def test___no_optional_args___reserve_all_registered_sessions___sends_request_wi
     session_management_stub.ReserveAllRegisteredSessions.assert_called_once()
     (request,) = session_management_stub.ReserveAllRegisteredSessions.call_args.args
     assert request.instrument_type_id == ""
-    assert request.timeout_in_milliseconds == 0
+    assert request.timeout_in_milliseconds == 10000
 
 
 def test___explicit_none___reserve_all_registered_sessions___sends_request_with_defaults(


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Adds timeouts while destroying sessions for the measurements in TestStand

### Why should this Pull Request be merged?
Resolves [User Story 2676827](https://dev.azure.com/ni/DevCentral/_workitems/edit/2676827): Add timeout as 10s when destroying sessions in the TestStand sequences

### What testing has been done?
Manually verified by running and aborting the measurement steps in the NI-FGEN and NI-DAQmx examples