### PR TITLE
add device reset on channels in measurement

### DIFF
--- a/examples/nidcpower_source_dc_voltage/measurement.py
+++ b/examples/nidcpower_source_dc_voltage/measurement.py
@@ -127,6 +127,10 @@ def measure(
 
                     measurements.extend(session_measurements)
 
+                # Reset the channels to a known state
+                for session_info in session_infos:
+                    session_info.session.channels[session_info.channel_list].reset()
+
     _log_measurements(measured_sites, measured_pins, measurements)
     logging.info("Completed measurement")
     return (


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fixes #689 
Adds a device reset on the channels in the session to be in sync with the recently updated LabVIEW example

### Why should this Pull Request be merged?

To keep python measurements in sync with LabVIEW ones.

### What testing has been done?

Tested using IO Trace using a simulated device on two channels. Trace shown:
![image](https://github.com/ni/measurementlink-python/assets/10726539/2ab7e8c1-2e89-4f6e-97bf-512abd6e68c0)
