### PR TITLE
Update service to use I/O resource specialization instead of Pin

### DIFF
--- a/examples/nidaqmx_analog_input/measurement.py
+++ b/examples/nidaqmx_analog_input/measurement.py
@@ -25,7 +25,7 @@ measurement_service = nims.MeasurementService(
 @measurement_service.register_measurement
 @measurement_service.configuration(
     "pin_name",
-    nims.DataType.Pin,
+    nims.DataType.IOResource,
     "Pin1",
     instrument_type=nims.session_management.INSTRUMENT_TYPE_NI_DAQMX,
 )

--- a/examples/nidaqmx_analog_input/pyproject.toml
+++ b/examples/nidaqmx_analog_input/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidaqmx = { version = ">=0.8.0", extras = ["grpc"] }
-ni-measurementlink-service = {version = "^1.3.0"}
+ni-measurementlink-service = {version = "^1.5.0-dev0", allow-prereleases = true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 
 [tool.poetry.group.dev.dependencies]
@@ -17,7 +17,7 @@ mypy = ">=1.0"
 grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies.
 # nidaqmx = { git = "https://github.com/ni/nidaqmx-python.git", branch = "master", extras = ["grpc"] }
-# ni-measurementlink-service = {path = "../..", develop = true}
+ni-measurementlink-service = {path = "../..", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/examples/nidcpower_source_dc_voltage/measurement.py
+++ b/examples/nidcpower_source_dc_voltage/measurement.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 @measurement_service.register_measurement
 @measurement_service.configuration(
     "pin_names",
-    nims.DataType.PinArray1D,
+    nims.DataType.IOResourceArray1D,
     ["Pin1"],
     instrument_type=nims.session_management.INSTRUMENT_TYPE_NI_DCPOWER,
 )

--- a/examples/nidcpower_source_dc_voltage/pyproject.toml
+++ b/examples/nidcpower_source_dc_voltage/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidcpower = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurementlink-service = {version = "^1.3.0"}
+ni-measurementlink-service = {version = "^1.5.0-dev0", allow-prereleases = true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 
@@ -18,7 +18,7 @@ mypy = ">=1.0"
 grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies.
 # nidcpower = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/nidcpower", extras = ["grpc"] }
-# ni-measurementlink-service = {path = "../..", develop = true}
+ni-measurementlink-service = {path = "../..", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/examples/nidcpower_source_dc_voltage_with_multiplexer/measurement.py
+++ b/examples/nidcpower_source_dc_voltage_with_multiplexer/measurement.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 @measurement_service.register_measurement
 @measurement_service.configuration(
     "pin_name",
-    nims.DataType.Pin,
+    nims.DataType.IOResource,
     "Pin1",
     instrument_type=nims.session_management.INSTRUMENT_TYPE_NI_DCPOWER,
 )

--- a/examples/nidcpower_source_dc_voltage_with_multiplexer/pyproject.toml
+++ b/examples/nidcpower_source_dc_voltage_with_multiplexer/pyproject.toml
@@ -9,7 +9,7 @@ authors = ["National Instruments"]
 python = "^3.8"
 nidcpower = { version = ">=1.4.4", extras = ["grpc"] }
 niswitch = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurementlink-service = {version = "^1.4.0"}
+ni-measurementlink-service = {version = "^1.5.0-dev0", allow-prereleases = true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 
@@ -20,7 +20,7 @@ grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies.
 # nidcpower = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/nidcpower", extras = ["grpc"] }
 # niswitch = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/niswitch", extras = ["grpc"] }
-# ni-measurementlink-service = {path = "../..", develop = true}
+ni-measurementlink-service = {path = "../..", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/examples/nidigital_spi/measurement.py
+++ b/examples/nidigital_spi/measurement.py
@@ -25,7 +25,7 @@ measurement_service = nims.MeasurementService(
 @measurement_service.register_measurement
 @measurement_service.configuration(
     "pin_names",
-    nims.DataType.PinArray1D,
+    nims.DataType.IOResourceArray1D,
     ["SPI_PINS"],
     instrument_type=nims.session_management.INSTRUMENT_TYPE_NI_DIGITAL_PATTERN,
 )

--- a/examples/nidigital_spi/pyproject.toml
+++ b/examples/nidigital_spi/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidigital = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurementlink-service = {version = "^1.3.0"}
+ni-measurementlink-service = {version = "^1.5.0-dev0", allow-prereleases = true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 
@@ -18,7 +18,7 @@ mypy = ">=1.0"
 grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies.
 # nidigital = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/nidigital", extras = ["grpc"] }
-# ni-measurementlink-service = {path = "../..", develop = true}
+ni-measurementlink-service = {path = "../..", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/examples/nidmm_measurement/measurement.py
+++ b/examples/nidmm_measurement/measurement.py
@@ -45,7 +45,7 @@ class Function(Enum):
 @measurement_service.register_measurement
 @measurement_service.configuration(
     "pin_name",
-    nims.DataType.Pin,
+    nims.DataType.IOResource,
     "Pin1",
     instrument_type=nims.session_management.INSTRUMENT_TYPE_NI_DMM,
 )

--- a/examples/nidmm_measurement/pyproject.toml
+++ b/examples/nidmm_measurement/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nidmm = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurementlink-service = {version = "^1.3.0"}
+ni-measurementlink-service = {version = "^1.5.0-dev0", allow-prereleases = true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 
@@ -18,7 +18,7 @@ mypy = ">=1.0"
 grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies.
 # nidmm = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/nidmm", extras = ["grpc"] }
-# ni-measurementlink-service = {path = "../..", develop = true}
+ni-measurementlink-service = {path = "../..", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/examples/nifgen_standard_function/measurement.py
+++ b/examples/nifgen_standard_function/measurement.py
@@ -49,7 +49,7 @@ class Waveform(Enum):
 @measurement_service.register_measurement
 @measurement_service.configuration(
     "pin_names",
-    nims.DataType.PinArray1D,
+    nims.DataType.IOResourceArray1D,
     ["Pin1"],
     instrument_type=nims.session_management.INSTRUMENT_TYPE_NI_FGEN,
 )

--- a/examples/nifgen_standard_function/pyproject.toml
+++ b/examples/nifgen_standard_function/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 nifgen = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurementlink-service = {version = "^1.3.0"}
+ni-measurementlink-service = {version = "^1.3.0-dev0", allow-prereleases = true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 
@@ -18,7 +18,7 @@ mypy = ">=1.0"
 grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies.
 # nifgen = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/nifgen", extras = ["grpc"] }
-# ni-measurementlink-service = {path = "../..", develop = true}
+ni-measurementlink-service = {path = "../..", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/examples/niscope_acquire_waveform/measurement.py
+++ b/examples/niscope_acquire_waveform/measurement.py
@@ -25,7 +25,7 @@ measurement_service = nims.MeasurementService(
 @measurement_service.register_measurement
 @measurement_service.configuration(
     "pin_names",
-    nims.DataType.PinArray1D,
+    nims.DataType.IOResourceArray1D,
     ["PinGroup1"],
     instrument_type=nims.session_management.INSTRUMENT_TYPE_NI_SCOPE,
 )
@@ -41,7 +41,7 @@ measurement_service = nims.MeasurementService(
 @measurement_service.configuration("min_record_length", nims.DataType.Int32, 40000)
 @measurement_service.configuration(
     "trigger_source",
-    nims.DataType.Pin,
+    nims.DataType.IOResource,
     "Pin1",
     instrument_type=nims.session_management.INSTRUMENT_TYPE_NI_SCOPE,
 )

--- a/examples/niscope_acquire_waveform/pyproject.toml
+++ b/examples/niscope_acquire_waveform/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["National Instruments"]
 [tool.poetry.dependencies]
 python = "^3.8"
 niscope = { version = ">=1.4.4", extras = ["grpc"] }
-ni-measurementlink-service = {version = "^1.4.0"}
+ni-measurementlink-service = {version = "^1.5.0-dev0", allow-prereleases = true}
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
 grpcio = "*"
 
@@ -18,7 +18,7 @@ mypy = ">=1.0"
 grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies.
 # niscope = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/niscope", extras = ["grpc"] }
-# ni-measurementlink-service = {path = "../..", develop = true}
+ni-measurementlink-service = {path = "../..", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/examples/nivisa_dmm_measurement/measurement.py
+++ b/examples/nivisa_dmm_measurement/measurement.py
@@ -26,7 +26,7 @@ _config = AutoConfig(str(pathlib.Path.cwd()))
 
 @measurement_service.register_measurement
 @measurement_service.configuration(
-    "pin_name", nims.DataType.Pin, "Pin1", instrument_type=INSTRUMENT_TYPE_VISA_DMM
+    "pin_name", nims.DataType.IOResource, "Pin1", instrument_type=INSTRUMENT_TYPE_VISA_DMM
 )
 @measurement_service.configuration(
     "measurement_type", nims.DataType.Enum, Function.DC_VOLTS, enum_type=Function

--- a/examples/nivisa_dmm_measurement/pyproject.toml
+++ b/examples/nivisa_dmm_measurement/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-ni-measurementlink-service = {version = "^1.3.0"}
+ni-measurementlink-service = {version = "^1.5.0-dev0", allow-prereleases = true}
 PyVISA = "^1.13.0"
 PyVISA-sim = "^0.5.1"
 click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pallets/click/issues/2558
@@ -19,7 +19,7 @@ ni-python-styleguide = ">=0.4.1"
 mypy = ">=1.0"
 grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies.
-# ni-measurementlink-service = {path = "../..", develop = true}
+ni-measurementlink-service = {path = "../..", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/examples/output_voltage_measurement/measurement.py
+++ b/examples/output_voltage_measurement/measurement.py
@@ -44,7 +44,7 @@ _config = AutoConfig(str(pathlib.Path.cwd()))
 @measurement_service.configuration("source_delay", nims.DataType.Double, 0.0)
 @measurement_service.configuration(
     "input_pin",
-    nims.DataType.Pin,
+    nims.DataType.IOResource,
     "InPin",
     instrument_type=nims.session_management.INSTRUMENT_TYPE_NI_DCPOWER,
 )
@@ -59,7 +59,7 @@ _config = AutoConfig(str(pathlib.Path.cwd()))
 @measurement_service.configuration("resolution_digits", nims.DataType.Double, 3.5)
 @measurement_service.configuration(
     "output_pin",
-    nims.DataType.Pin,
+    nims.DataType.IOResource,
     "OutPin",
     instrument_type=_visa_dmm.INSTRUMENT_TYPE_VISA_DMM,
 )

--- a/examples/output_voltage_measurement/pyproject.toml
+++ b/examples/output_voltage_measurement/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["National Instruments"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-ni-measurementlink-service = {version = "^1.3.0"}
+ni-measurementlink-service = {version = "^1.5.0-dev0", allow-prereleases = true}
 PyVISA = "^1.13.0"
 PyVISA-sim = "^0.5.1"
 nidcpower = { version = ">=1.4.4", extras = ["grpc"] }
@@ -21,7 +21,7 @@ mypy = ">=1.0"
 grpc-stubs = "^1.53"
 # Uncomment to use prerelease dependencies.
 # nidcpower = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/nidcpower", extras=["grpc"] }
-# ni-measurementlink-service = {path = "../..", develop = true}
+ni-measurementlink-service = {path = "../..", develop = true}
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/ni_measurementlink_service/_datatypeinfo.py
+++ b/ni_measurementlink_service/_datatypeinfo.py
@@ -51,7 +51,9 @@ _DATATYPE_TO_DATATYPEINFO_LOOKUP = {
         False,
         message_type=xydata_pb2.DoubleXYData.DESCRIPTOR.full_name,
     ),
-    DataType.IOResource: DataTypeInfo(type_pb2.Field.TYPE_STRING, False, TypeSpecialization.IOResource),
+    DataType.IOResource: DataTypeInfo(
+        type_pb2.Field.TYPE_STRING, False, TypeSpecialization.IOResource
+    ),
     DataType.Int32Array1D: DataTypeInfo(type_pb2.Field.TYPE_INT32, True),
     DataType.Int64Array1D: DataTypeInfo(type_pb2.Field.TYPE_INT64, True),
     DataType.UInt32Array1D: DataTypeInfo(type_pb2.Field.TYPE_UINT32, True),
@@ -60,7 +62,9 @@ _DATATYPE_TO_DATATYPEINFO_LOOKUP = {
     DataType.DoubleArray1D: DataTypeInfo(type_pb2.Field.TYPE_DOUBLE, True),
     DataType.BooleanArray1D: DataTypeInfo(type_pb2.Field.TYPE_BOOL, True),
     DataType.StringArray1D: DataTypeInfo(type_pb2.Field.TYPE_STRING, True),
-    DataType.PinArray1D: DataTypeInfo(type_pb2.Field.TYPE_STRING, True, TypeSpecialization.IOResource),
+    DataType.PinArray1D: DataTypeInfo(
+        type_pb2.Field.TYPE_STRING, True, TypeSpecialization.IOResource
+    ),
     DataType.PathArray1D: DataTypeInfo(type_pb2.Field.TYPE_STRING, True, TypeSpecialization.Path),
     DataType.EnumArray1D: DataTypeInfo(type_pb2.Field.TYPE_ENUM, True, TypeSpecialization.Enum),
     DataType.DoubleXYDataArray1D: DataTypeInfo(
@@ -68,5 +72,7 @@ _DATATYPE_TO_DATATYPEINFO_LOOKUP = {
         True,
         message_type=xydata_pb2.DoubleXYData.DESCRIPTOR.full_name,
     ),
-    DataType.IOResourceArray1D: DataTypeInfo(type_pb2.Field.TYPE_STRING, True, TypeSpecialization.IOResource),
+    DataType.IOResourceArray1D: DataTypeInfo(
+        type_pb2.Field.TYPE_STRING, True, TypeSpecialization.IOResource
+    ),
 }

--- a/ni_measurementlink_service/_datatypeinfo.py
+++ b/ni_measurementlink_service/_datatypeinfo.py
@@ -43,7 +43,7 @@ _DATATYPE_TO_DATATYPEINFO_LOOKUP = {
     DataType.Double: DataTypeInfo(type_pb2.Field.TYPE_DOUBLE, False),
     DataType.Boolean: DataTypeInfo(type_pb2.Field.TYPE_BOOL, False),
     DataType.String: DataTypeInfo(type_pb2.Field.TYPE_STRING, False),
-    DataType.Pin: DataTypeInfo(type_pb2.Field.TYPE_STRING, False, TypeSpecialization.Pin),
+    DataType.Pin: DataTypeInfo(type_pb2.Field.TYPE_STRING, False, TypeSpecialization.IOResource),
     DataType.Path: DataTypeInfo(type_pb2.Field.TYPE_STRING, False, TypeSpecialization.Path),
     DataType.Enum: DataTypeInfo(type_pb2.Field.TYPE_ENUM, False, TypeSpecialization.Enum),
     DataType.DoubleXYData: DataTypeInfo(
@@ -51,6 +51,7 @@ _DATATYPE_TO_DATATYPEINFO_LOOKUP = {
         False,
         message_type=xydata_pb2.DoubleXYData.DESCRIPTOR.full_name,
     ),
+    DataType.IOResource: DataTypeInfo(type_pb2.Field.TYPE_STRING, False, TypeSpecialization.IOResource),
     DataType.Int32Array1D: DataTypeInfo(type_pb2.Field.TYPE_INT32, True),
     DataType.Int64Array1D: DataTypeInfo(type_pb2.Field.TYPE_INT64, True),
     DataType.UInt32Array1D: DataTypeInfo(type_pb2.Field.TYPE_UINT32, True),
@@ -59,7 +60,7 @@ _DATATYPE_TO_DATATYPEINFO_LOOKUP = {
     DataType.DoubleArray1D: DataTypeInfo(type_pb2.Field.TYPE_DOUBLE, True),
     DataType.BooleanArray1D: DataTypeInfo(type_pb2.Field.TYPE_BOOL, True),
     DataType.StringArray1D: DataTypeInfo(type_pb2.Field.TYPE_STRING, True),
-    DataType.PinArray1D: DataTypeInfo(type_pb2.Field.TYPE_STRING, True, TypeSpecialization.Pin),
+    DataType.PinArray1D: DataTypeInfo(type_pb2.Field.TYPE_STRING, True, TypeSpecialization.IOResource),
     DataType.PathArray1D: DataTypeInfo(type_pb2.Field.TYPE_STRING, True, TypeSpecialization.Path),
     DataType.EnumArray1D: DataTypeInfo(type_pb2.Field.TYPE_ENUM, True, TypeSpecialization.Enum),
     DataType.DoubleXYDataArray1D: DataTypeInfo(
@@ -67,4 +68,5 @@ _DATATYPE_TO_DATATYPEINFO_LOOKUP = {
         True,
         message_type=xydata_pb2.DoubleXYData.DESCRIPTOR.full_name,
     ),
+    DataType.IOResourceArray1D: DataTypeInfo(type_pb2.Field.TYPE_STRING, True, TypeSpecialization.IOResource),
 }

--- a/ni_measurementlink_service/_datatypeinfo.py
+++ b/ni_measurementlink_service/_datatypeinfo.py
@@ -43,7 +43,7 @@ _DATATYPE_TO_DATATYPEINFO_LOOKUP = {
     DataType.Double: DataTypeInfo(type_pb2.Field.TYPE_DOUBLE, False),
     DataType.Boolean: DataTypeInfo(type_pb2.Field.TYPE_BOOL, False),
     DataType.String: DataTypeInfo(type_pb2.Field.TYPE_STRING, False),
-    DataType.Pin: DataTypeInfo(type_pb2.Field.TYPE_STRING, False, TypeSpecialization.IOResource),
+    DataType.Pin: DataTypeInfo(type_pb2.Field.TYPE_STRING, False, TypeSpecialization.Pin),
     DataType.Path: DataTypeInfo(type_pb2.Field.TYPE_STRING, False, TypeSpecialization.Path),
     DataType.Enum: DataTypeInfo(type_pb2.Field.TYPE_ENUM, False, TypeSpecialization.Enum),
     DataType.DoubleXYData: DataTypeInfo(
@@ -63,7 +63,7 @@ _DATATYPE_TO_DATATYPEINFO_LOOKUP = {
     DataType.BooleanArray1D: DataTypeInfo(type_pb2.Field.TYPE_BOOL, True),
     DataType.StringArray1D: DataTypeInfo(type_pb2.Field.TYPE_STRING, True),
     DataType.PinArray1D: DataTypeInfo(
-        type_pb2.Field.TYPE_STRING, True, TypeSpecialization.IOResource
+        type_pb2.Field.TYPE_STRING, True, TypeSpecialization.Pin
     ),
     DataType.PathArray1D: DataTypeInfo(type_pb2.Field.TYPE_STRING, True, TypeSpecialization.Path),
     DataType.EnumArray1D: DataTypeInfo(type_pb2.Field.TYPE_ENUM, True, TypeSpecialization.Enum),

--- a/ni_measurementlink_service/_datatypeinfo.py
+++ b/ni_measurementlink_service/_datatypeinfo.py
@@ -62,9 +62,7 @@ _DATATYPE_TO_DATATYPEINFO_LOOKUP = {
     DataType.DoubleArray1D: DataTypeInfo(type_pb2.Field.TYPE_DOUBLE, True),
     DataType.BooleanArray1D: DataTypeInfo(type_pb2.Field.TYPE_BOOL, True),
     DataType.StringArray1D: DataTypeInfo(type_pb2.Field.TYPE_STRING, True),
-    DataType.PinArray1D: DataTypeInfo(
-        type_pb2.Field.TYPE_STRING, True, TypeSpecialization.Pin
-    ),
+    DataType.PinArray1D: DataTypeInfo(type_pb2.Field.TYPE_STRING, True, TypeSpecialization.Pin),
     DataType.PathArray1D: DataTypeInfo(type_pb2.Field.TYPE_STRING, True, TypeSpecialization.Path),
     DataType.EnumArray1D: DataTypeInfo(type_pb2.Field.TYPE_ENUM, True, TypeSpecialization.Enum),
     DataType.DoubleXYDataArray1D: DataTypeInfo(

--- a/ni_measurementlink_service/measurement/info.py
+++ b/ni_measurementlink_service/measurement/info.py
@@ -67,7 +67,7 @@ class TypeSpecialization(enum.Enum):
     """Enum that represents the type specializations for measurement parameters."""
 
     NoType = ""
-    Pin = "pin"
+    IOResource = "ioresource"
     Path = "path"
     Enum = "enum"
 
@@ -87,6 +87,7 @@ class DataType(enum.Enum):
     Path = 9
     Enum = 10
     DoubleXYData = 11
+    IOResource = 12
 
     Int32Array1D = 100
     Int64Array1D = 101
@@ -100,3 +101,4 @@ class DataType(enum.Enum):
     PathArray1D = 109
     EnumArray1D = 110
     DoubleXYDataArray1D = 111
+    IOResourceArray1D = 112

--- a/ni_measurementlink_service/measurement/info.py
+++ b/ni_measurementlink_service/measurement/info.py
@@ -67,9 +67,10 @@ class TypeSpecialization(enum.Enum):
     """Enum that represents the type specializations for measurement parameters."""
 
     NoType = ""
-    IOResource = "ioresource"
+    Pin = "pin"
     Path = "path"
     Enum = "enum"
+    IOResource = "ioresource"
 
 
 class DataType(enum.Enum):

--- a/ni_measurementlink_service/measurement/service.py
+++ b/ni_measurementlink_service/measurement/service.py
@@ -408,7 +408,8 @@ class MeasurementService:
             )
         if type == DataType.PinArray1D:
             warnings.warn(
-                "DataType.PinArray1D is deprecated. Use DataType.IOResourceArray1D instead.", DeprecationWarning
+                "DataType.PinArray1D is deprecated. Use DataType.IOResourceArray1D instead.",
+                DeprecationWarning,
             )
         data_type_info = _datatypeinfo.get_type_info(type)
         annotations = self._make_annotations_dict(
@@ -467,7 +468,8 @@ class MeasurementService:
             )
         if type == DataType.PinArray1D:
             warnings.warn(
-                "DataType.PinArray1D is deprecated. Use DataType.IOResourceArray1D instead.", DeprecationWarning
+                "DataType.PinArray1D is deprecated. Use DataType.IOResourceArray1D instead.",
+                DeprecationWarning,
             )
         data_type_info = _datatypeinfo.get_type_info(type)
         annotations = self._make_annotations_dict(

--- a/ni_measurementlink_service/measurement/service.py
+++ b/ni_measurementlink_service/measurement/service.py
@@ -384,7 +384,7 @@ class MeasurementService:
 
             instrument_type (Optional[str]):
                 Filter pins by instrument type. This is only supported when configuration type
-                is DataType.Pin.
+                is DataType.IOResource or DataType.Pin (deprecated).
 
                 For NI instruments, use instrument type id constants defined by
                 :py:mod:`ni_measurementlink_service.session_management`, such as

--- a/ni_measurementlink_service/measurement/service.py
+++ b/ni_measurementlink_service/measurement/service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import sys
 import threading
+import warnings
 from enum import Enum, EnumMeta
 from os import path
 from pathlib import Path
@@ -24,7 +25,6 @@ from typing import (
 )
 
 import grpc
-import warnings
 from deprecation import deprecated
 from google.protobuf.descriptor import EnumDescriptor
 
@@ -402,7 +402,14 @@ class MeasurementService:
             Callable: Callable that takes in Any Python Function
             and returns the same python function.
         """
-        if type == DataType.Pin: warnings.warn(DeprecationWarning, "DataType.Pin is deprecated. Use DataType.IOResource instead.")
+        if type == DataType.Pin:
+            warnings.warn(
+                "DataType.Pin is deprecated. Use DataType.IOResource instead.", DeprecationWarning
+            )
+        if type == DataType.PinArray1D:
+            warnings.warn(
+                "DataType.PinArray1D is deprecated. Use DataType.IOResourceArray1D instead.", DeprecationWarning
+            )
         data_type_info = _datatypeinfo.get_type_info(type)
         annotations = self._make_annotations_dict(
             data_type_info.type_specialization, instrument_type=instrument_type, enum_type=enum_type
@@ -454,7 +461,14 @@ class MeasurementService:
             Callable: Callable that takes in Any Python Function and
             returns the same python function.
         """
-        if type == DataType.Pin: warnings.warn(DeprecationWarning, "DataType.Pin is deprecated. Use DataType.IOResource instead.")
+        if type == DataType.Pin:
+            warnings.warn(
+                "DataType.Pin is deprecated. Use DataType.IOResource instead.", DeprecationWarning
+            )
+        if type == DataType.PinArray1D:
+            warnings.warn(
+                "DataType.PinArray1D is deprecated. Use DataType.IOResourceArray1D instead.", DeprecationWarning
+            )
         data_type_info = _datatypeinfo.get_type_info(type)
         annotations = self._make_annotations_dict(
             data_type_info.type_specialization, enum_type=enum_type

--- a/ni_measurementlink_service/measurement/service.py
+++ b/ni_measurementlink_service/measurement/service.py
@@ -529,6 +529,9 @@ class MeasurementService:
             return annotations
 
         annotations[TYPE_SPECIALIZATION_KEY] = type_specialization.value
+        if type_specialization == TypeSpecialization.Pin:
+            if instrument_type != "" or instrument_type is not None:
+                annotations["ni/pin.instrument_type"] = instrument_type
         if type_specialization == TypeSpecialization.IOResource:
             if instrument_type != "" or instrument_type is not None:
                 annotations["ni/ioresource.instrument_type"] = instrument_type

--- a/ni_measurementlink_service/measurement/service.py
+++ b/ni_measurementlink_service/measurement/service.py
@@ -24,6 +24,7 @@ from typing import (
 )
 
 import grpc
+import warnings
 from deprecation import deprecated
 from google.protobuf.descriptor import EnumDescriptor
 
@@ -401,6 +402,7 @@ class MeasurementService:
             Callable: Callable that takes in Any Python Function
             and returns the same python function.
         """
+        if type == DataType.Pin: warnings.warn(DeprecationWarning, "DataType.Pin is deprecated. Use DataType.IOResource instead.")
         data_type_info = _datatypeinfo.get_type_info(type)
         annotations = self._make_annotations_dict(
             data_type_info.type_specialization, instrument_type=instrument_type, enum_type=enum_type
@@ -452,6 +454,7 @@ class MeasurementService:
             Callable: Callable that takes in Any Python Function and
             returns the same python function.
         """
+        if type == DataType.Pin: warnings.warn(DeprecationWarning, "DataType.Pin is deprecated. Use DataType.IOResource instead.")
         data_type_info = _datatypeinfo.get_type_info(type)
         annotations = self._make_annotations_dict(
             data_type_info.type_specialization, enum_type=enum_type

--- a/ni_measurementlink_service/measurement/service.py
+++ b/ni_measurementlink_service/measurement/service.py
@@ -510,9 +510,9 @@ class MeasurementService:
             return annotations
 
         annotations[TYPE_SPECIALIZATION_KEY] = type_specialization.value
-        if type_specialization == TypeSpecialization.Pin:
+        if type_specialization == TypeSpecialization.IOResource:
             if instrument_type != "" or instrument_type is not None:
-                annotations["ni/pin.instrument_type"] = instrument_type
+                annotations["ni/ioresource.instrument_type"] = instrument_type
         if type_specialization == TypeSpecialization.Enum:
             if enum_type is not None:
                 annotations[ENUM_VALUES_KEY] = self._enum_to_annotations_value(enum_type)

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -91,6 +91,7 @@ def test___measurement_service___add_configuration__configuration_added(
         ("IOResourceArrayConfiguration", DataType.IOResourceArray1D, ["Pin1", "Pin2"], "test instrument 2"),
     ],
 )
+@pytest.mark.filterwarnings("ignore:.*Pin.*:DeprecationWarning")
 def test___measurement_service___add_pin_or_ioresource_configuration__ioresource_configuration_added(
     measurement_service: MeasurementService,
     display_name: str,
@@ -218,11 +219,14 @@ def test___measurement_service___add_non_path_configuration__path_type_annotatio
         ("UInt44", DataType.UInt64, ""),
         ("Pin", DataType.Pin, 1.0),
         ("Pin1DArray", DataType.PinArray1D, [1.009, -1.0009]),
+        ("IOResource", DataType.IOResource, 1.0),
+        ("IOResource1DArray", DataType.IOResourceArray1D, [1.009, -1.0009]),
         ("Path", DataType.Path, 1.0),
         ("Path1DArray", DataType.PathArray1D, [1.009, -1.0009]),
         ("DoubleXYDataArray", DataType.DoubleXYDataArray1D, [1.009, -1.0009]),
     ],
 )
+@pytest.mark.filterwarnings("ignore:.*Pin.*:DeprecationWarning")
 def test___measurement_service___add_configuration_with_mismatch_default_value__raises_type_error(
     measurement_service: MeasurementService,
     display_name: str,

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -89,17 +89,17 @@ def test___measurement_service___add_configuration__configuration_added(
         ("PinArrayConfiguration", DataType.PinArray1D, ["Pin1", "Pin2"], "test instrument 2"),
     ],
 )
-@pytest.mark.filterwarnings("ignore:.*Pin.*:DeprecationWarning")
-def test___measurement_service___add_pin_configuration__pin_configuration_added(
+def test___measurement_service___add_pin_configuration__pin_configuration_added_with_deprecation_warning(
     measurement_service: MeasurementService,
     display_name: str,
     type: DataType,
     default_value: object,
     instrument_type: str,
 ):
-    measurement_service.configuration(
-        display_name, type, default_value, instrument_type=instrument_type
-    )(_fake_measurement_function)
+    with pytest.deprecated_call():
+        measurement_service.configuration(
+            display_name, type, default_value, instrument_type=instrument_type
+        )(_fake_measurement_function)
     data_type_info = _datatypeinfo.get_type_info(type)
 
     assert any(

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -87,9 +87,11 @@ def test___measurement_service___add_configuration__configuration_added(
     [
         ("PinConfiguration", DataType.Pin, "Pin1", "test instrument"),
         ("PinArrayConfiguration", DataType.PinArray1D, ["Pin1", "Pin2"], "test instrument 2"),
+        ("IOResourceConfiguration", DataType.IOResource, "Pin1", "test instrument"),
+        ("IOResourceArrayConfiguration", DataType.IOResourceArray1D, ["Pin1", "Pin2"], "test instrument 2"),
     ],
 )
-def test___measurement_service___add_pin_configuration__pin_configuration_added(
+def test___measurement_service___add_pin_or_ioresource_configuration__ioresource_configuration_added(
     measurement_service: MeasurementService,
     display_name: str,
     type: DataType,
@@ -108,8 +110,8 @@ def test___measurement_service___add_pin_configuration__pin_configuration_added(
         and param.default_value == default_value
         and param.annotations
         == {
-            TYPE_SPECIALIZATION_KEY: TypeSpecialization.Pin.value,
-            "ni/pin.instrument_type": instrument_type,
+            TYPE_SPECIALIZATION_KEY: TypeSpecialization.IOResource.value,
+            "ni/ioresource.instrument_type": instrument_type,
         }
         for param in measurement_service._configuration_parameter_list
     )
@@ -130,7 +132,7 @@ def test___measurement_service___add_pin_configuration__pin_configuration_added(
         ("UInt44", DataType.UInt64, False),
     ],
 )
-def test___measurement_service___add_non_pin_configuration__pin_type_annotations_not_added(
+def test___measurement_service___add_non_ioresource_configuration__ioresource_type_annotations_not_added(
     measurement_service: MeasurementService,
     display_name: str,
     type: DataType,
@@ -139,7 +141,7 @@ def test___measurement_service___add_non_pin_configuration__pin_type_annotations
     measurement_service.configuration(display_name, type, default_value)(_fake_measurement_function)
 
     assert not all(
-        param.annotations.get(TYPE_SPECIALIZATION_KEY) == TypeSpecialization.Pin.value
+        param.annotations.get(TYPE_SPECIALIZATION_KEY) == TypeSpecialization.IOResource.value
         for param in measurement_service._configuration_parameter_list
     )
 

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -88,7 +88,12 @@ def test___measurement_service___add_configuration__configuration_added(
         ("PinConfiguration", DataType.Pin, "Pin1", "test instrument"),
         ("PinArrayConfiguration", DataType.PinArray1D, ["Pin1", "Pin2"], "test instrument 2"),
         ("IOResourceConfiguration", DataType.IOResource, "Pin1", "test instrument"),
-        ("IOResourceArrayConfiguration", DataType.IOResourceArray1D, ["Pin1", "Pin2"], "test instrument 2"),
+        (
+            "IOResourceArrayConfiguration",
+            DataType.IOResourceArray1D,
+            ["Pin1", "Pin2"],
+            "test instrument 2",
+        ),
     ],
 )
 @pytest.mark.filterwarnings("ignore:.*Pin.*:DeprecationWarning")

--- a/tests/utilities/measurements/nidaqmx_measurement/__init__.py
+++ b/tests/utilities/measurements/nidaqmx_measurement/__init__.py
@@ -19,7 +19,7 @@ measurement_service = nims.MeasurementService(
 
 
 @measurement_service.register_measurement
-@measurement_service.configuration("pin_names", nims.DataType.PinArray1D, ["Pin1"])
+@measurement_service.configuration("pin_names", nims.DataType.IOResourceArray1D, ["Pin1"])
 @measurement_service.configuration("multi_session", nims.DataType.Boolean, False)
 @measurement_service.output("session_names", nims.DataType.StringArray1D)
 @measurement_service.output("resource_names", nims.DataType.StringArray1D)

--- a/tests/utilities/measurements/nidcpower_measurement/__init__.py
+++ b/tests/utilities/measurements/nidcpower_measurement/__init__.py
@@ -20,7 +20,7 @@ measurement_service = nims.MeasurementService(
 
 
 @measurement_service.register_measurement
-@measurement_service.configuration("pin_names", nims.DataType.PinArray1D, ["Pin1"])
+@measurement_service.configuration("pin_names", nims.DataType.IOResourceArray1D, ["Pin1"])
 @measurement_service.configuration("multi_session", nims.DataType.Boolean, False)
 @measurement_service.output("session_names", nims.DataType.StringArray1D)
 @measurement_service.output("resource_names", nims.DataType.StringArray1D)

--- a/tests/utilities/measurements/nidmm_measurement/__init__.py
+++ b/tests/utilities/measurements/nidmm_measurement/__init__.py
@@ -20,7 +20,7 @@ measurement_service = nims.MeasurementService(
 
 
 @measurement_service.register_measurement
-@measurement_service.configuration("pin_names", nims.DataType.PinArray1D, ["Pin1"])
+@measurement_service.configuration("pin_names", nims.DataType.IOResourceArray1D, ["Pin1"])
 @measurement_service.configuration("multi_session", nims.DataType.Boolean, False)
 @measurement_service.output("session_names", nims.DataType.StringArray1D)
 @measurement_service.output("resource_names", nims.DataType.StringArray1D)

--- a/tests/utilities/measurements/nifgen_measurement/__init__.py
+++ b/tests/utilities/measurements/nifgen_measurement/__init__.py
@@ -20,7 +20,7 @@ measurement_service = nims.MeasurementService(
 
 
 @measurement_service.register_measurement
-@measurement_service.configuration("pin_names", nims.DataType.PinArray1D, ["Pin1"])
+@measurement_service.configuration("pin_names", nims.DataType.IOResourceArray1D, ["Pin1"])
 @measurement_service.configuration("multi_session", nims.DataType.Boolean, False)
 @measurement_service.output("session_names", nims.DataType.StringArray1D)
 @measurement_service.output("resource_names", nims.DataType.StringArray1D)

--- a/tests/utilities/measurements/niscope_measurement/__init__.py
+++ b/tests/utilities/measurements/niscope_measurement/__init__.py
@@ -20,7 +20,7 @@ measurement_service = nims.MeasurementService(
 
 
 @measurement_service.register_measurement
-@measurement_service.configuration("pin_names", nims.DataType.PinArray1D, ["Pin1"])
+@measurement_service.configuration("pin_names", nims.DataType.IOResourceArray1D, ["Pin1"])
 @measurement_service.configuration("multi_session", nims.DataType.Boolean, False)
 @measurement_service.output("session_names", nims.DataType.StringArray1D)
 @measurement_service.output("resource_names", nims.DataType.StringArray1D)

--- a/tests/utilities/measurements/niswitch_multiplexer_measurement/__init__.py
+++ b/tests/utilities/measurements/niswitch_multiplexer_measurement/__init__.py
@@ -19,7 +19,7 @@ measurement_service = nims.MeasurementService(
 
 
 @measurement_service.register_measurement
-@measurement_service.configuration("pin_names", nims.DataType.PinArray1D, ["Pin1"])
+@measurement_service.configuration("pin_names", nims.DataType.IOResourceArray1D, ["Pin1"])
 @measurement_service.configuration("multi_session", nims.DataType.Boolean, False)
 @measurement_service.output("multiplexer_session_names", nims.DataType.StringArray1D)
 @measurement_service.output("multiplexer_resource_names", nims.DataType.StringArray1D)

--- a/tests/utilities/measurements/pin_aware_measurement/__init__.py
+++ b/tests/utilities/measurements/pin_aware_measurement/__init__.py
@@ -16,7 +16,7 @@ measurement_service = nims.MeasurementService(
 
 
 @measurement_service.register_measurement
-@measurement_service.configuration("pin_names", nims.DataType.PinArray1D, ["Pin1"])
+@measurement_service.configuration("pin_names", nims.DataType.IOResourceArray1D, ["Pin1"])
 @measurement_service.configuration("multi_session", nims.DataType.Boolean, False)
 @measurement_service.output("pin_map_id", nims.DataType.String)
 @measurement_service.output("sites", nims.DataType.Int32Array1D)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Adds new DataType.IOResource and DataType.IOResourceArray1D enum values for use annotating Configuration or Output parameters. These data types represent a pin or I/O resource like a channel, better supporting the ability to treat pin maps as optional.
- Maps the new IOResource and IOResourceArray1D data types and the existing Pin and PinArray1D data types to the "ioresource" type specialization.
- Adds a deprecation warning if a Pin or PinArray1D Datatype is used with a Configuration or Output parameter.

### Why should this Pull Request be merged?

[AB#2666681](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2666681)
This updates the python measurement service libraries to better indicate support for both pins and channels.

### What testing has been done?

Updated existing tests to test the new data types.