### PR TITLE
example: reset source channel in nidcpower with multiplexer measurement

### DIFF
--- a/examples/nidcpower_source_dc_voltage_with_multiplexer/measurement.py
+++ b/examples/nidcpower_source_dc_voltage_with_multiplexer/measurement.py
@@ -105,6 +105,9 @@ def measure(
 
                 measurement: _Measurement = source_channel.measure_multiple()[0]
 
+            # Reset the channel to a known state
+            source_channel.reset()
+
             # Disconnect the connected route.
             connection.multiplexer_session.disconnect_multiple(connection.multiplexer_route)
             connection.multiplexer_session.wait_for_debounce()


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Following #690, this adds a device reset on the channel in the nidcpower session similar to the `nidcpower_source_dc_voltage` and `output_voltage_measurement` examples.

### Why should this Pull Request be merged?
#695 

### What testing has been done?
Tested using IO Trace using a simulated NI-DCPower and NI-SWITCH.

_Before:_
![image](https://github.com/ni/measurementlink-python/assets/104884050/dcae1457-12cd-4354-8d11-74706e1d689c)

_Now:_
![image](https://github.com/ni/measurementlink-python/assets/104884050/f4e44aea-78db-4cda-afeb-290a95db51b0)
