### PR TITLE
Fix get_connections when there is no pin map

### DIFF
--- a/ni_measurementlink_service/session_management/_client.py
+++ b/ni_measurementlink_service/session_management/_client.py
@@ -145,7 +145,7 @@ class SessionManagementClient(object):
                 multiplexer_session_info=response.multiplexer_sessions,
                 pin_or_relay_group_mappings=_to_group_mappings_dict(response.group_mappings),
                 reserved_pin_or_relay_names=pin_or_relay_names,
-                reserved_sites=context.sites,
+                reserved_sites=[0] if len(context.sites) == 0 else context.sites,
             )
 
     def reserve_sessions(

--- a/tests/integration/session_management/test_niscope_reservation.py
+++ b/tests/integration/session_management/test_niscope_reservation.py
@@ -83,6 +83,24 @@ def test___sessions_created___get_niscope_connections___returns_connections(
         ]
 
 
+def test___no_pin_map___session_created___get_niscope_connection___returns_connection(
+    session_management_client: SessionManagementClient,
+) -> None:
+    channel_names = ["SCOPE1/0"]
+    empty_pin_map_context = PinMapContext(pin_map_id='', sites=[])
+    with ExitStack() as stack:
+        reservation = stack.enter_context(
+            session_management_client.reserve_session(empty_pin_map_context, channel_names)
+        )
+        stack.enter_context(reservation.initialize_niscope_session())
+
+        connection = reservation.get_niscope_connection(channel_names[0])
+
+        assert get_connection_subset(connection) == ConnectionSubset(
+            channel_names[0], _SITE, "SCOPE1", "0"
+        )
+
+
 @pytest.fixture
 def pin_map_context(pin_map_client: PinMapClient, pin_map_directory: pathlib.Path) -> PinMapContext:
     pin_map_name = "2Scope2Pin2Group1Site.pinmap"


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

NOTE: The new automated test won't pass until the test machines are upgraded with the latest version of the IODiscoveryService.

Fixes a bug with looking up connections when there is no pin map. The list of sites was empty and this was one of the keys used in caching a connection.

Errors looked like this:
![image](https://github.com/ni/measurementlink-python/assets/38357562/94cfb469-e736-4074-b4e1-92c951d8fe0c)


I fixed this by replacing the empty list of sites with a single [0] site when there are no pin map context sites.

### Why should this Pull Request be merged?

Without this, several of the MI instruments will not work correctly without a pin map.

### What testing has been done?

Adding an automated test fetching the scope connections with no pin map. It fails without the fix and passes with it.