### PR TITLE
Add ni-apis submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/ni-apis"]
+	path = third_party/ni-apis
+	url = https://github.com/ni/ni-apis.git


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Since #702 is not working, this is an attempt to simply add the submodule for ni-apis in a separate PR. If this succeeds, I'll update #702 and see if it then passes.

### Why should this Pull Request be merged?

We'd like to add this submodule so this is a first step. Adding it into third_party should be innocuous.

### What testing has been done?

PR