### PR TITLE
Allowing _helpers.py in our examples to return an empty string for th…

### DIFF
--- a/examples/game_of_life/_helpers.py
+++ b/examples/game_of_life/_helpers.py
@@ -26,13 +26,12 @@ class TestStandSupport(object):
         """Get the active pin map id from the NI.MeasurementLink.PinMapId runtime variable.
 
         Returns:
-            The resource id of the pin map that is registered to the pin map service.
+            The resource id of the pin map if one is registered to the pin map service,
+            otherwise an empty string.
         """
         run_time_variables = self._sequence_context.Execution.RunTimeVariables
         if not run_time_variables.Exists(self._PIN_MAP_ID_VAR, 0x0):
-            raise RuntimeError(
-                "Failed to retrieve the registered pin map ID. Possible reason: The sequence might not include an 'Update Pin Map' step."
-            )
+            return ""
         return run_time_variables.GetValString(self._PIN_MAP_ID_VAR, 0x0)
 
     def resolve_file_path(self, file_path: str) -> str:

--- a/examples/nidcpower_source_dc_voltage/_helpers.py
+++ b/examples/nidcpower_source_dc_voltage/_helpers.py
@@ -26,13 +26,12 @@ class TestStandSupport(object):
         """Get the active pin map id from the NI.MeasurementLink.PinMapId runtime variable.
 
         Returns:
-            The resource id of the pin map that is registered to the pin map service.
+            The resource id of the pin map if one is registered to the pin map service,
+            otherwise an empty string.
         """
         run_time_variables = self._sequence_context.Execution.RunTimeVariables
         if not run_time_variables.Exists(self._PIN_MAP_ID_VAR, 0x0):
-            raise RuntimeError(
-                "Failed to retrieve the registered pin map ID. Possible reason: The sequence might not include an 'Update Pin Map' step."
-            )
+            return ""
         return run_time_variables.GetValString(self._PIN_MAP_ID_VAR, 0x0)
 
     def resolve_file_path(self, file_path: str) -> str:

--- a/examples/nidcpower_source_dc_voltage_with_multiplexer/_helpers.py
+++ b/examples/nidcpower_source_dc_voltage_with_multiplexer/_helpers.py
@@ -26,13 +26,12 @@ class TestStandSupport(object):
         """Get the active pin map id from the NI.MeasurementLink.PinMapId runtime variable.
 
         Returns:
-            The resource id of the pin map that is registered to the pin map service.
+            The resource id of the pin map if one is registered to the pin map service,
+            otherwise an empty string.
         """
         run_time_variables = self._sequence_context.Execution.RunTimeVariables
         if not run_time_variables.Exists(self._PIN_MAP_ID_VAR, 0x0):
-            raise RuntimeError(
-                "Failed to retrieve the registered pin map ID. Possible reason: The sequence might not include an 'Update Pin Map' step."
-            )
+            return ""
         return run_time_variables.GetValString(self._PIN_MAP_ID_VAR, 0x0)
 
     def resolve_file_path(self, file_path: str) -> str:

--- a/examples/nidigital_spi/_helpers.py
+++ b/examples/nidigital_spi/_helpers.py
@@ -26,13 +26,12 @@ class TestStandSupport(object):
         """Get the active pin map id from the NI.MeasurementLink.PinMapId runtime variable.
 
         Returns:
-            The resource id of the pin map that is registered to the pin map service.
+            The resource id of the pin map if one is registered to the pin map service,
+            otherwise an empty string.
         """
         run_time_variables = self._sequence_context.Execution.RunTimeVariables
         if not run_time_variables.Exists(self._PIN_MAP_ID_VAR, 0x0):
-            raise RuntimeError(
-                "Failed to retrieve the registered pin map ID. Possible reason: The sequence might not include an 'Update Pin Map' step."
-            )
+            return ""
         return run_time_variables.GetValString(self._PIN_MAP_ID_VAR, 0x0)
 
     def resolve_file_path(self, file_path: str) -> str:

--- a/examples/nidmm_measurement/_helpers.py
+++ b/examples/nidmm_measurement/_helpers.py
@@ -26,13 +26,12 @@ class TestStandSupport(object):
         """Get the active pin map id from the NI.MeasurementLink.PinMapId runtime variable.
 
         Returns:
-            The resource id of the pin map that is registered to the pin map service.
+            The resource id of the pin map if one is registered to the pin map service,
+            otherwise an empty string.
         """
         run_time_variables = self._sequence_context.Execution.RunTimeVariables
         if not run_time_variables.Exists(self._PIN_MAP_ID_VAR, 0x0):
-            raise RuntimeError(
-                "Failed to retrieve the registered pin map ID. Possible reason: The sequence might not include an 'Update Pin Map' step."
-            )
+            return ""
         return run_time_variables.GetValString(self._PIN_MAP_ID_VAR, 0x0)
 
     def resolve_file_path(self, file_path: str) -> str:

--- a/examples/nifgen_standard_function/_helpers.py
+++ b/examples/nifgen_standard_function/_helpers.py
@@ -26,13 +26,12 @@ class TestStandSupport(object):
         """Get the active pin map id from the NI.MeasurementLink.PinMapId runtime variable.
 
         Returns:
-            The resource id of the pin map that is registered to the pin map service.
+            The resource id of the pin map if one is registered to the pin map service,
+            otherwise an empty string.
         """
         run_time_variables = self._sequence_context.Execution.RunTimeVariables
         if not run_time_variables.Exists(self._PIN_MAP_ID_VAR, 0x0):
-            raise RuntimeError(
-                "Failed to retrieve the registered pin map ID. Possible reason: The sequence might not include an 'Update Pin Map' step."
-            )
+            return ""
         return run_time_variables.GetValString(self._PIN_MAP_ID_VAR, 0x0)
 
     def resolve_file_path(self, file_path: str) -> str:

--- a/examples/niscope_acquire_waveform/_helpers.py
+++ b/examples/niscope_acquire_waveform/_helpers.py
@@ -26,13 +26,12 @@ class TestStandSupport(object):
         """Get the active pin map id from the NI.MeasurementLink.PinMapId runtime variable.
 
         Returns:
-            The resource id of the pin map that is registered to the pin map service.
+            The resource id of the pin map if one is registered to the pin map service,
+            otherwise an empty string.
         """
         run_time_variables = self._sequence_context.Execution.RunTimeVariables
         if not run_time_variables.Exists(self._PIN_MAP_ID_VAR, 0x0):
-            raise RuntimeError(
-                "Failed to retrieve the registered pin map ID. Possible reason: The sequence might not include an 'Update Pin Map' step."
-            )
+            return ""
         return run_time_variables.GetValString(self._PIN_MAP_ID_VAR, 0x0)
 
     def resolve_file_path(self, file_path: str) -> str:

--- a/examples/niswitch_control_relays/_helpers.py
+++ b/examples/niswitch_control_relays/_helpers.py
@@ -26,13 +26,12 @@ class TestStandSupport(object):
         """Get the active pin map id from the NI.MeasurementLink.PinMapId runtime variable.
 
         Returns:
-            The resource id of the pin map that is registered to the pin map service.
+            The resource id of the pin map if one is registered to the pin map service,
+            otherwise an empty string.
         """
         run_time_variables = self._sequence_context.Execution.RunTimeVariables
         if not run_time_variables.Exists(self._PIN_MAP_ID_VAR, 0x0):
-            raise RuntimeError(
-                "Failed to retrieve the registered pin map ID. Possible reason: The sequence might not include an 'Update Pin Map' step."
-            )
+            return ""
         return run_time_variables.GetValString(self._PIN_MAP_ID_VAR, 0x0)
 
     def resolve_file_path(self, file_path: str) -> str:

--- a/examples/nivisa_dmm_measurement/_helpers.py
+++ b/examples/nivisa_dmm_measurement/_helpers.py
@@ -26,13 +26,12 @@ class TestStandSupport(object):
         """Get the active pin map id from the NI.MeasurementLink.PinMapId runtime variable.
 
         Returns:
-            The resource id of the pin map that is registered to the pin map service.
+            The resource id of the pin map if one is registered to the pin map service,
+            otherwise an empty string.
         """
         run_time_variables = self._sequence_context.Execution.RunTimeVariables
         if not run_time_variables.Exists(self._PIN_MAP_ID_VAR, 0x0):
-            raise RuntimeError(
-                "Failed to retrieve the registered pin map ID. Possible reason: The sequence might not include an 'Update Pin Map' step."
-            )
+            return ""
         return run_time_variables.GetValString(self._PIN_MAP_ID_VAR, 0x0)
 
     def resolve_file_path(self, file_path: str) -> str:

--- a/examples/output_voltage_measurement/_helpers.py
+++ b/examples/output_voltage_measurement/_helpers.py
@@ -26,13 +26,12 @@ class TestStandSupport(object):
         """Get the active pin map id from the NI.MeasurementLink.PinMapId runtime variable.
 
         Returns:
-            The resource id of the pin map that is registered to the pin map service.
+            The resource id of the pin map if one is registered to the pin map service,
+            otherwise an empty string.
         """
         run_time_variables = self._sequence_context.Execution.RunTimeVariables
         if not run_time_variables.Exists(self._PIN_MAP_ID_VAR, 0x0):
-            raise RuntimeError(
-                "Failed to retrieve the registered pin map ID. Possible reason: The sequence might not include an 'Update Pin Map' step."
-            )
+            return ""
         return run_time_variables.GetValString(self._PIN_MAP_ID_VAR, 0x0)
 
     def resolve_file_path(self, file_path: str) -> str:

--- a/examples/sample_measurement/_helpers.py
+++ b/examples/sample_measurement/_helpers.py
@@ -26,13 +26,12 @@ class TestStandSupport(object):
         """Get the active pin map id from the NI.MeasurementLink.PinMapId runtime variable.
 
         Returns:
-            The resource id of the pin map that is registered to the pin map service.
+            The resource id of the pin map if one is registered to the pin map service,
+            otherwise an empty string.
         """
         run_time_variables = self._sequence_context.Execution.RunTimeVariables
         if not run_time_variables.Exists(self._PIN_MAP_ID_VAR, 0x0):
-            raise RuntimeError(
-                "Failed to retrieve the registered pin map ID. Possible reason: The sequence might not include an 'Update Pin Map' step."
-            )
+            return ""
         return run_time_variables.GetValString(self._PIN_MAP_ID_VAR, 0x0)
 
     def resolve_file_path(self, file_path: str) -> str:


### PR DESCRIPTION
…e pin map ID when there is no active pin map.

- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Rather than erroring, _helpers.py will return an empty string if the sequence context does not contain a runtime variable called NI.MeasurementLink.PinMapId.

### Why should this Pull Request be merged?

In non-pin centric workflows, we expect to pass an empty string as the PinMapId to the session manager to indicate we want to use I/O resources rather than pins.

### What testing has been done?

Ran DCPower sequence successfully without a pin map after making this change.