### PR TITLE
Replace MeasurementLink Support for Python with Measurement Plugin Support for Python

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ poetry install
 
 # Adding dependencies
 
-Add dependency package for `ni_measurementlink_service`  using the [`poetry add`](https://python-poetry.org/docs/cli/#add) command.
+Add dependency package for `ni_measurement_plugin_sdk`  using the [`poetry add`](https://python-poetry.org/docs/cli/#add) command.
 
 ```cmd
 poetry add <name_of_dependency>:<version>
@@ -66,7 +66,7 @@ poetry add -D <name_of_dev_dependency>:<version>
 
 # Updating gRPC stubs when a .proto file is modified
 
-The `ni_measurementlink_service\_internal\stubs` directory contains the auto-generated Python files based on MeasurementLink protobuf (`.proto`) files. The file needs to be replaced whenever there is a change to these `.proto` files:
+The `ni_measurement_plugin_sdk\_internal\stubs` directory contains the auto-generated Python files based on MeasurementLink protobuf (`.proto`) files. The file needs to be replaced whenever there is a change to these `.proto` files:
 
 - ni/measurementlink/pin_map_context.proto
 - ni/measurementlink/discovery/v1/discovery_service.proto
@@ -76,7 +76,7 @@ The `ni_measurementlink_service\_internal\stubs` directory contains the auto-gen
 - nidevice_grpc/README.md
 - nidevice_grpc/session.proto
 
-The latest .proto files are available in [Azure Repo](https://dev.azure.com/ni/DevCentral/_git/ASW?path=/Source/Protos). From the Azure Repo manually download and overwrite the `.proto` files under the `ni_measurementlink_service\_internal\stubs\proto` folder.
+The latest .proto files are available in [Azure Repo](https://dev.azure.com/ni/DevCentral/_git/ASW?path=/Source/Protos). From the Azure Repo manually download and overwrite the `.proto` files under the `ni_measurement_plugin_sdk\_internal\stubs\proto` folder.
 
 Run `poetry run python scripts/generate_grpc_stubs.py`. This generates the required `.py` files for the listed `.proto` files. The required `grpcio-tools` package is already added as a development dependency in pyproject.toml.
 
@@ -96,13 +96,13 @@ poetry run ni-python-styleguide fix
 poetry build
 ```
 
-Running this command from the repo's root directory will generate the tar.gz file and .whl file of ni_measurementlink_service package to the `dist` directory.
+Running this command from the repo's root directory will generate the tar.gz file and .whl file of ni_measurement_plugin_sdk package to the `dist` directory.
 
 # Testing
 
-`ni-measurementlink-service` includes regression tests under the `tests/` directory. The GitHub CI runs these tests for PRs targeting the main branch. It is recommended that during development you run the tests locally before creating a PR.
+`ni-measurement-plugin-sdk` includes regression tests under the `tests/` directory. The GitHub CI runs these tests for PRs targeting the main branch. It is recommended that during development you run the tests locally before creating a PR.
 
-In order to run the `ni-measurementlink-service` tests locally:
+In order to run the `ni-measurement-plugin-sdk` tests locally:
 
 ## Using Command Line
 
@@ -143,8 +143,8 @@ extension, refer
 
 - Install the required dependency by running `poetry install`
 - Activate the virtual environment if not already activated : `.venv\Scripts\activate`
-- Run the command `pytest --cov=ni_measurementlink_service`, from the repo's root directory **to get the summary of test coverage** in the console.
-- Run the command `pytest --cov-report html:cov_html --cov=ni_measurementlink_service`, from the repo's root directory **to generate detailed HTML based coverage report**. Upon running, the coverage reports will be created under `<repo_root>\cov_html` directory.
+- Run the command `pytest --cov=ni_measurement_plugin_sdk`, from the repo's root directory **to get the summary of test coverage** in the console.
+- Run the command `pytest --cov-report html:cov_html --cov=ni_measurement_plugin_sdk`, from the repo's root directory **to generate detailed HTML based coverage report**. Upon running, the coverage reports will be created under `<repo_root>\cov_html` directory.
 
 # Developer Certificate of Origin (DCO)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,11 @@
-# Contributing to MeasurementLink™ Support for Python
+# Contributing to Measurement Plugin Support for Python
 
-Contributions to MeasurementLink Support for Python are welcome from all!
+Contributions to Measurement Plugin Support for Python are welcome from all!
 
-MeasurementLink Support for Python is managed via [git](https://git-scm.com), with the canonical upstream
+Measurement Plugin Support for Python is managed via [git](https://git-scm.com), with the canonical upstream
 repository hosted on [GitHub](https://github.com/ni/measurementlink-python/). The repo contains templates and examples for developing MeasurementLink services in Python.
 
-MeasurementLink Support for Python follows a pull-request model for development.  If you wish to
+Measurement Plugin Support for Python follows a pull-request model for development.  If you wish to
 contribute, you will need to create a GitHub account, fork this project, push a
 branch with your changes to your project, and then submit a pull request.
 
@@ -30,7 +30,7 @@ See [GitHub's official documentation](https://help.github.com/articles/using-pul
 
 ## Clone Repo
 
-Clone the repo, this will pull the MeasurementLink Support for Python components and related components.
+Clone the repo, this will pull the Measurement Plugin Support for Python components and related components.
 
 ```cmd
 git clone https://github.com/ni/measurementlink-python.git
@@ -177,4 +177,4 @@ extension, refer
 (taken from [developercertificate.org](https://developercertificate.org/))
 
 See [LICENSE](https://github.com/ni/measurementlink-python/blob/master/LICENSE)
-for details about how MeasurementLink Support for Python is licensed.
+for details about how Measurement Plugin Support for Python is licensed.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# MeasurementLink™ Support for Python
+# Measurement Plugin Support for Python
 
-- [MeasurementLink™ Support for Python](#measurementlink--support-for-python)
+- [Measurement Plugin Support for Python](#measurement-plugin-support-for-python)
   - [Introduction](#introduction)
   - [Dependencies](#dependencies)
   - [Documentation](#documentation)
@@ -21,7 +21,7 @@
 
 ## Introduction
 
-MeasurementLink Support for Python (`ni-measurementlink-service`) is a Python
+Measurement Plugin Support for Python (`ni-measurementlink-service`) is a Python
 framework that helps you create reusable measurement plug-ins using gRPC
 services. Deploy your measurement plug-ins to perform interactive validation in
 InstrumentStudio and automated testing in TestStand.
@@ -83,18 +83,18 @@ versions of MeasurementLink.
 
 ## Developing Measurements: Quick Start
 
-This section provides instructions to develop custom measurement services in Python using MeasurementLink Support for Python.
+This section provides instructions to develop custom measurement services in Python using Measurement Plugin Support for Python.
 
 ### Installation
 
-Make sure the system has the recommended Python version is installed. Install MeasurementLink Support for Python using [pip](https://pip.pypa.io/).
+Make sure the system has the recommended Python version is installed. Install Measurement Plugin Support for Python using [pip](https://pip.pypa.io/).
 
 ``` cmd
 REM Activate the required virtual environment if any.
 pip install ni-measurementlink-service
 ```
 
-Check if you have installed the expected version of MeasurementLink Support for Python installed by running the below command:
+Check if you have installed the expected version of Measurement Plugin Support for Python installed by running the below command:
 
 ```cmd
 pip show ni-measurementlink-service

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@
   - [Appendix: Managing Measurement with Python](#appendix-managing-measurement-with-python)
     - [Create and Manage Python Measurement using Poetry](#create-and-manage-python-measurement-using-poetry)
     - [Create and Manage Python Measurement using `venv`](#create-and-manage-python-measurement-using-venv)
-    - [Create and Manage Python Measurement by directly installing `ni-measurementlink-service` as a system-level package](#create-and-manage-python-measurement-by-directly-installing-ni-measurementlink-service-as-a-system-level-package)
+    - [Create and Manage Python Measurement by directly installing `ni-measurement-plugin-sdk` as a system-level package](#create-and-manage-python-measurement-by-directly-installing-ni-measurement-plugin-sdk-as-a-system-level-package)
 
 ---
 
 ## Introduction
 
-Measurement Plugin Support for Python (`ni-measurementlink-service`) is a Python
+Measurement Plugin Support for Python (`ni-measurement-plugin-sdk`) is a Python
 framework that helps you create reusable measurement plug-ins using gRPC
 services. Deploy your measurement plug-ins to perform interactive validation in
 InstrumentStudio and automated testing in TestStand.
@@ -91,13 +91,13 @@ Make sure the system has the recommended Python version is installed. Install Me
 
 ``` cmd
 REM Activate the required virtual environment if any.
-pip install ni-measurementlink-service
+pip install ni-measurement-plugin-sdk
 ```
 
 Check if you have installed the expected version of Measurement Plugin Support for Python installed by running the below command:
 
 ```cmd
-pip show ni-measurementlink-service
+pip show ni-measurement-plugin-sdk
 ```
 
 ### Developing a minimal Python measurement
@@ -273,7 +273,7 @@ Python communities have different ways of managing Python projects and their dep
 
     2. Install `poetry` using the installation steps given in <https://python-poetry.org/docs/#installation>.
 
-2. Create a new Python project and add `ni-measurementlink-service` as a dependency to the project.
+2. Create a new Python project and add `ni-measurement-plugin-sdk` as a dependency to the project.
 
     1. Open a command prompt, and change the working directory to the directory of your choice where you want to create the project.
 
@@ -287,11 +287,11 @@ Python communities have different ways of managing Python projects and their dep
         poetry new <name_of_the_project>
         ```
 
-    3. Add the `ni-measurementlink-service` package as a dependency using the [`poetry add`](https://python-poetry.org/docs/cli/#add) command.
+    3. Add the `ni-measurement-plugin-sdk` package as a dependency using the [`poetry add`](https://python-poetry.org/docs/cli/#add) command.
 
         ``` cmd
         cd <name_of_the_project>
-        poetry add ni-measurementlink-service
+        poetry add ni-measurement-plugin-sdk
         ```
 
     4. The virtual environment will be auto-created by poetry.
@@ -330,10 +330,10 @@ For detailed info on managing projects using poetry [refer to the official docum
     python -m pip install -U pip
     ```
 
-5. Install the `ni-measurementlink-service` package into the virtual environment.
+5. Install the `ni-measurement-plugin-sdk` package into the virtual environment.
 
     ``` cmd
-    pip install ni-measurementlink-service
+    pip install ni-measurement-plugin-sdk
     ```
 
 6. Create measurement modules as described in ["Developing a minimal Python measurement"](#developing-a-minimal-python-measurement)
@@ -345,14 +345,14 @@ For detailed info on managing projects using poetry [refer to the official docum
 
 For detailed info on managing projects with a virtual environment, refer to the [official documentation](https://docs.python.org/3/tutorial/venv.html).
 
-### Create and Manage Python Measurement by directly installing `ni-measurementlink-service` as a system-level package
+### Create and Manage Python Measurement by directly installing `ni-measurement-plugin-sdk` as a system-level package
 
-Measurement developers can also install `ni-measurementlink-service` as a system package if necessary.
+Measurement developers can also install `ni-measurement-plugin-sdk` as a system package if necessary.
 
-1. Install the `ni-measurementlink-service` package from the command prompt
+1. Install the `ni-measurement-plugin-sdk` package from the command prompt
 
     ``` cmd
-    pip install ni-measurementlink-service
+    pip install ni-measurement-plugin-sdk
     ```
 
 2. Create measurement modules as described in ["Developing a minimal Python measurement"](#developing-a-minimal-python-measurement)

--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -1,7 +1,7 @@
 THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
 Do Not Translate or Localize
 
-MeasurementLink™ Support for Python uses third party material from the projects listed below.
+Measurement Plugin Support for Python uses third party material from the projects listed below.
 
 ****** gRPC (https://github.com/grpc/grpc) ******
 

--- a/ni_measurement_plugin_generator/README.md
+++ b/ni_measurement_plugin_generator/README.md
@@ -7,7 +7,7 @@
 MeasurementLink Code Generator for Python (`ni-measurement-plugin-generator`) is a
 tool for generating reusable measurement plug-ins using gRPC services.
 
-For installation and usage, see [MeasurementLink Support for Python (`ni-measurementlink-service`)](https://pypi.org/project/ni-measurementlink-service/).
+For installation and usage, see [Measurement Plugin Support for Python (`ni-measurementlink-service`)](https://pypi.org/project/ni-measurementlink-service/).
 
 ---
 

--- a/ni_measurement_plugin_generator/README.md
+++ b/ni_measurement_plugin_generator/README.md
@@ -7,7 +7,7 @@
 MeasurementLink Code Generator for Python (`ni-measurement-plugin-generator`) is a
 tool for generating reusable measurement plug-ins using gRPC services.
 
-For installation and usage, see [Measurement Plugin Support for Python (`ni-measurementlink-service`)](https://pypi.org/project/ni-measurementlink-service/).
+For installation and usage, see [Measurement Plugin Support for Python (`ni-measurement-plugin-sdk`)](https://pypi.org/project/ni-measurement-plugin-sdk/).
 
 ---
 

--- a/ni_measurement_plugin_sdk/__init__.py
+++ b/ni_measurement_plugin_sdk/__init__.py
@@ -1,4 +1,4 @@
-"""MeasurementLink Support for Python."""
+"""Measurement Plugin Support for Python."""
 
 import logging
 

--- a/ni_measurement_plugin_sdk/_internal/parameter/serialization_strategy.py
+++ b/ni_measurement_plugin_sdk/_internal/parameter/serialization_strategy.py
@@ -67,7 +67,7 @@ def _scalar_decoder(decoder: DecoderConstructor) -> PartialDecoderConstructor:
 
     def _unsupported_new_default(message: Optional[Message]) -> Any:
         raise NotImplementedError(
-            "This function should not be called. Verify that you are using up-to-date and compatible versions of the ni-measurementlink-service and protobuf packages."
+            "This function should not be called. Verify that you are using up-to-date and compatible versions of the ni-measurement-plugin-sdk and protobuf packages."
         )
 
     def scalar_decoder(field_index: int, key: Key) -> Decoder:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Replace documentation and other usages of `MeasurementLink Support for Python` with `Measurement Plugin Support for Python`.

Also replace some more usages of the `ni-measurementlink-service` package name with `ni-measurement-plugin-sdk`.

### Why should this Pull Request be merged?

Newest name for the repo.

### What testing has been done?

None - docs only.