### PR TITLE
[releases/2.3] Update to typeshed version of gRPC stubs

### DIFF
--- a/examples/game_of_life/pyproject.toml
+++ b/examples/game_of_life/pyproject.toml
@@ -13,7 +13,7 @@ click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pal
 [tool.poetry.group.dev.dependencies]
 ni-python-styleguide = ">=0.4.1"
 mypy = ">=1.0"
-grpc-stubs = "^1.53"
+types-grpcio = ">=1.0"
 types-protobuf = ">=4.21"
 # Uncomment to use prerelease dependencies.
 # ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}

--- a/examples/nidaqmx_analog_input/pyproject.toml
+++ b/examples/nidaqmx_analog_input/pyproject.toml
@@ -14,7 +14,7 @@ click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pal
 [tool.poetry.group.dev.dependencies]
 ni-python-styleguide = ">=0.4.1"
 mypy = ">=1.0"
-grpc-stubs = "^1.53"
+types-grpcio = ">=1.0"
 # Uncomment to use prerelease dependencies.
 # nidaqmx = { git = "https://github.com/ni/nidaqmx-python.git", branch = "master", extras = ["grpc"] }
 # ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}

--- a/examples/nidcpower_source_dc_voltage/pyproject.toml
+++ b/examples/nidcpower_source_dc_voltage/pyproject.toml
@@ -15,7 +15,7 @@ grpcio = "*"
 [tool.poetry.group.dev.dependencies]
 ni-python-styleguide = ">=0.4.1"
 mypy = ">=1.0"
-grpc-stubs = "^1.53"
+types-grpcio = ">=1.0"
 # Uncomment to use prerelease dependencies.
 # nidcpower = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/nidcpower", extras = ["grpc"] }
 # ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}

--- a/examples/nidcpower_source_dc_voltage_with_multiplexer/pyproject.toml
+++ b/examples/nidcpower_source_dc_voltage_with_multiplexer/pyproject.toml
@@ -16,7 +16,7 @@ grpcio = "*"
 [tool.poetry.group.dev.dependencies]
 ni-python-styleguide = ">=0.4.1"
 mypy = ">=1.0"
-grpc-stubs = "^1.53"
+types-grpcio = ">=1.0"
 # Uncomment to use prerelease dependencies.
 # nidcpower = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/nidcpower", extras = ["grpc"] }
 # niswitch = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/niswitch", extras = ["grpc"] }

--- a/examples/nidigital_spi/pyproject.toml
+++ b/examples/nidigital_spi/pyproject.toml
@@ -15,7 +15,7 @@ grpcio = "*"
 [tool.poetry.group.dev.dependencies]
 ni-python-styleguide = ">=0.4.1"
 mypy = ">=1.0"
-grpc-stubs = "^1.53"
+types-grpcio = ">=1.0"
 # Uncomment to use prerelease dependencies.
 # nidigital = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/nidigital", extras = ["grpc"] }
 # ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}

--- a/examples/nidmm_measurement/pyproject.toml
+++ b/examples/nidmm_measurement/pyproject.toml
@@ -15,7 +15,7 @@ grpcio = "*"
 [tool.poetry.group.dev.dependencies]
 ni-python-styleguide = ">=0.4.1"
 mypy = ">=1.0"
-grpc-stubs = "^1.53"
+types-grpcio = ">=1.0"
 # Uncomment to use prerelease dependencies.
 # nidmm = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/nidmm", extras = ["grpc"] }
 # ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}

--- a/examples/nifgen_standard_function/pyproject.toml
+++ b/examples/nifgen_standard_function/pyproject.toml
@@ -15,7 +15,7 @@ grpcio = "*"
 [tool.poetry.group.dev.dependencies]
 ni-python-styleguide = ">=0.4.1"
 mypy = ">=1.0"
-grpc-stubs = "^1.53"
+types-grpcio = ">=1.0"
 # Uncomment to use prerelease dependencies.
 # nifgen = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/nifgen", extras = ["grpc"] }
 # ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}

--- a/examples/niscope_acquire_waveform/pyproject.toml
+++ b/examples/niscope_acquire_waveform/pyproject.toml
@@ -15,7 +15,7 @@ grpcio = "*"
 [tool.poetry.group.dev.dependencies]
 ni-python-styleguide = ">=0.4.1"
 mypy = ">=1.0"
-grpc-stubs = "^1.53"
+types-grpcio = ">=1.0"
 # Uncomment to use prerelease dependencies.
 # niscope = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/niscope", extras = ["grpc"] }
 # ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}

--- a/examples/niswitch_control_relays/pyproject.toml
+++ b/examples/niswitch_control_relays/pyproject.toml
@@ -15,7 +15,7 @@ grpcio = "*"
 [tool.poetry.group.dev.dependencies]
 ni-python-styleguide = ">=0.4.1"
 mypy = ">=1.0"
-grpc-stubs = "^1.53"
+types-grpcio = ">=1.0"
 # Uncomment to use prerelease dependencies.
 # niswitch = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/niswitch", extras = ["grpc"] }
 # ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}

--- a/examples/nivisa_dmm_measurement/pyproject.toml
+++ b/examples/nivisa_dmm_measurement/pyproject.toml
@@ -17,7 +17,7 @@ python-decouple = ">=3.8"
 [tool.poetry.group.dev.dependencies]
 ni-python-styleguide = ">=0.4.1"
 mypy = ">=1.0"
-grpc-stubs = "^1.53"
+types-grpcio = ">=1.0"
 # Uncomment to use prerelease dependencies.
 # ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}
 

--- a/examples/output_voltage_measurement/pyproject.toml
+++ b/examples/output_voltage_measurement/pyproject.toml
@@ -18,7 +18,7 @@ python-decouple = ">=3.8"
 [tool.poetry.group.dev.dependencies]
 ni-python-styleguide = ">=0.4.1"
 mypy = ">=1.0"
-grpc-stubs = "^1.53"
+types-grpcio = ">=1.0"
 # Uncomment to use prerelease dependencies.
 # nidcpower = { git = "https://github.com/ni/nimi-python.git", subdirectory = "generated/nidcpower", extras=["grpc"] }
 # ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}

--- a/examples/sample_measurement/pyproject.toml
+++ b/examples/sample_measurement/pyproject.toml
@@ -13,7 +13,7 @@ click = ">=7.1.2, !=8.1.4" # mypy fails with click 8.1.4: https://github.com/pal
 [tool.poetry.group.dev.dependencies]
 ni-python-styleguide = ">=0.4.1"
 mypy = ">=1.0"
-grpc-stubs = "^1.53"
+types-grpcio = ">=1.0"
 grpcio-tools = "1.49.1"
 mypy-protobuf = "^3.6.0"
 types-protobuf = ">=4.21"

--- a/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
+++ b/packages/generator/ni_measurement_plugin_sdk_generator/client/templates/measurement_plugin_client.py.mako
@@ -112,7 +112,7 @@ class ${class_name}:
         self._pin_map_client = pin_map_client
         self._stub: v2_measurement_service_pb2_grpc.MeasurementServiceStub | None = None
         self._measure_response: None | (
-            grpc.CallIterator[v2_measurement_service_pb2.MeasureResponse]
+            grpc._CallIterator[v2_measurement_service_pb2.MeasureResponse]
         ) = None
         self._configuration_metadata = {
             % for key, value in configuration_metadata.items():

--- a/packages/generator/poetry.lock
+++ b/packages/generator/poetry.lock
@@ -353,20 +353,6 @@ pycodestyle = "*"
 setuptools = "*"
 
 [[package]]
-name = "grpc-stubs"
-version = "1.53.0.5"
-description = "Mypy stubs for gRPC"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "grpc-stubs-1.53.0.5.tar.gz", hash = "sha256:3e1b642775cbc3e0c6332cfcedfccb022176db87e518757bef3a1241397be406"},
-    {file = "grpc_stubs-1.53.0.5-py3-none-any.whl", hash = "sha256:04183fb65a1b166a1febb9627e3d9647d3926ccc2dfe049fe7b6af243428dbe1"},
-]
-
-[package.dependencies]
-grpcio = "*"
-
-[[package]]
 name = "grpcio"
 version = "1.71.0"
 description = "HTTP/2-based RPC framework"
@@ -1433,6 +1419,17 @@ files = [
 ]
 
 [[package]]
+name = "types-grpcio"
+version = "1.0.0.20250603"
+description = "Typing stubs for grpcio"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "types_grpcio-1.0.0.20250603-py3-none-any.whl", hash = "sha256:4ef6a79d5f50d942d48eeb1cdfc2147fff722e74fd4b29598fbefb6dcf39c159"},
+    {file = "types_grpcio-1.0.0.20250603.tar.gz", hash = "sha256:27e83fba0471d705ec54a60dbc50d3d8cc988aa38477644da8bc6173531d0c1a"},
+]
+
+[[package]]
 name = "types-protobuf"
 version = "5.29.1.20250315"
 description = "Typing stubs for protobuf"
@@ -1477,4 +1474,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "51fb9f1e2f9fd961f0db201f5767032c5472cdc15d0bf10ad4d99b954392c1dd"
+content-hash = "4139773f7dd91bcfa375f2caf85584f4c722e0d9b735d50ff08d3ada68ad7263"

--- a/packages/generator/pyproject.toml
+++ b/packages/generator/pyproject.toml
@@ -35,7 +35,7 @@ ni-python-styleguide = ">=0.4.1"
 mypy = ">=1.0"
 mypy-protobuf = ">=3.4"
 types-protobuf = ">=4.21"
-grpc-stubs = "^1.53"
+types-grpcio = ">=1.0"
 # During development, use file paths to reference the latest source for packages
 # in the same Git repository.
 ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}

--- a/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/localized_measurement_client.py
+++ b/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/localized_measurement_client.py
@@ -101,7 +101,7 @@ class LocalizedMeasurementClient:
         self._pin_map_client = pin_map_client
         self._stub: v2_measurement_service_pb2_grpc.MeasurementServiceStub | None = None
         self._measure_response: None | (
-            grpc.CallIterator[v2_measurement_service_pb2.MeasureResponse]
+            grpc._CallIterator[v2_measurement_service_pb2.MeasureResponse]
         ) = None
         self._configuration_metadata = {
             1: ParameterMetadata(

--- a/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
+++ b/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/non_streaming_data_measurement_client.py
@@ -111,7 +111,7 @@ class NonStreamingDataMeasurementClient:
         self._pin_map_client = pin_map_client
         self._stub: v2_measurement_service_pb2_grpc.MeasurementServiceStub | None = None
         self._measure_response: None | (
-            grpc.CallIterator[v2_measurement_service_pb2.MeasureResponse]
+            grpc._CallIterator[v2_measurement_service_pb2.MeasureResponse]
         ) = None
         self._configuration_metadata = {
             1: ParameterMetadata(

--- a/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/void_measurement_client.py
+++ b/packages/generator/tests/test_assets/example_renders/measurement_plugin_client/void_measurement_client.py
@@ -59,7 +59,7 @@ class VoidMeasurementClient:
         self._pin_map_client = pin_map_client
         self._stub: v2_measurement_service_pb2_grpc.MeasurementServiceStub | None = None
         self._measure_response: None | (
-            grpc.CallIterator[v2_measurement_service_pb2.MeasureResponse]
+            grpc._CallIterator[v2_measurement_service_pb2.MeasureResponse]
         ) = None
         self._configuration_metadata = {
             1: ParameterMetadata(

--- a/packages/service/poetry.lock
+++ b/packages/service/poetry.lock
@@ -506,20 +506,6 @@ pycodestyle = "*"
 setuptools = "*"
 
 [[package]]
-name = "grpc-stubs"
-version = "1.53.0.5"
-description = "Mypy stubs for gRPC"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "grpc-stubs-1.53.0.5.tar.gz", hash = "sha256:3e1b642775cbc3e0c6332cfcedfccb022176db87e518757bef3a1241397be406"},
-    {file = "grpc_stubs-1.53.0.5-py3-none-any.whl", hash = "sha256:04183fb65a1b166a1febb9627e3d9647d3926ccc2dfe049fe7b6af243428dbe1"},
-]
-
-[package.dependencies]
-grpcio = "*"
-
-[[package]]
 name = "grpcio"
 version = "1.71.0"
 description = "HTTP/2-based RPC framework"
@@ -2207,6 +2193,20 @@ files = [
 ]
 
 [[package]]
+name = "types-grpcio"
+version = "1.0.0.20250426"
+description = "Typing stubs for grpcio"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "types_grpcio-1.0.0.20250426-py3-none-any.whl", hash = "sha256:7931b4ec0bedb8af7c53910ed54edeb8be964251ecf0c4f0234f95e472a90ce3"},
+    {file = "types_grpcio-1.0.0.20250426.tar.gz", hash = "sha256:a079034b1c32520b1218bd50187539352b8ff495cf9b91a7c98772a3baf5f1d1"},
+]
+
+[package.dependencies]
+types-protobuf = "*"
+
+[[package]]
 name = "types-protobuf"
 version = "5.29.1.20250315"
 description = "Typing stubs for protobuf"
@@ -2361,4 +2361,4 @@ niswitch = ["niswitch"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "51196bf52d5ba934fb77553b6373174c1e85d5d618eb4fa87367ae0ef707cb1d"
+content-hash = "1d06f08d41235fbcfe4790c57fde4b1a2b1cbe7dd5ee4faf40c046a373eaea4d"

--- a/packages/service/pyproject.toml
+++ b/packages/service/pyproject.toml
@@ -72,7 +72,7 @@ mypy-protobuf = ">=3.4"
 types-protobuf = ">=4.21"
 types-setuptools = "*"
 types-pywin32 = ">=304"
-grpc-stubs = "^1.53"
+types-grpcio = ">=1.0"
 psutil = ">=6.0"
 types-psutil = ">=6.0"
 # NumPy dropped support for Python 3.8 before adding support for Python 3.12, so


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-plugin-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Cherry-pick https://github.com/ni/measurement-plugin-python/pull/1115

Original PR description follows:

### What does this Pull Request accomplish?

Replace `grpc-stubs` with `types-grpcio`.

Retrofit for differences between `grpc-stubs` and `types-grpcio`:
- Typing-only types like `CallFuture` and `CallIterator` now have an underscore prefix.
- The type stubs for abstract base classes like `Call`, `Future`, etc. now use `ABCMeta`, so mypy now knows they're abstract. 

### Why should this Pull Request be merged?

The `grpc-stubs` package is archived and will not be updated.

The abstract base class change was a fix for a bug that I reported.

### What testing has been done?

Ran nps, mypy, pytest locally on a machine w/o InStudio or drivers.