### PR TITLE
Redirect old imports of ni.protobuf.types to their new location

### DIFF
--- a/packages/service/ni_measurement_plugin_sdk_service/_internal/__init__.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/_internal/__init__.py
@@ -4,4 +4,6 @@ import sys
 
 import ni.protobuf
 
+
+# Redirect old imports of the stubs that used to be defined here to their new location.
 sys.modules["ni_measurement_plugin_sdk_service._internal.stubs.ni.protobuf"] = ni.protobuf


### PR DESCRIPTION
<!-- TODO: Check the below box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/measurement-plugin-python/blob/main/CONTRIBUTING.md) -->
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-plugin-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Uses `sys.modules` to redirect old imports from
```
ni_measurement_plugin_sdk_service._internal.stubs.ni.protobuf
```
to their new location in the `ni.protobuf.types` package.

### Why should this Pull Request be merged?

Because these stubs were moved out of this package and into `ni.protobuf.types`, old code generated by the measurement SDK will still have the old import statements. This will allow the old code to work by importing the new code.

Example: This code runs successfully...
```
from ni_measurement_plugin_sdk_service._internal.stubs.ni.protobuf.types.array_pb2 import Double2DArray


my_array = Double2DArray(rows=2, columns=2, data=[1, 2, 3, 4])
print(f"my_array: {my_array}")
```

### What testing has been done?

- I tried this out by running the python script shown above successfully.
- Unit tests, mypy, pyright, styleguide.