### PR TITLE
github: Fix version number for example zip

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -102,6 +102,10 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Set up Python
+        uses: ni/python-actions/setup-python@8554e7ef74e95c9762962205f45a1e10c48de671 # v0.5.1
+      - name: Set up Poetry
+        uses: ni/python-actions/setup-poetry@8554e7ef74e95c9762962205f45a1e10c48de671 # v0.5.1
       - name: Get version
         id: get-version
         run: echo "version=$(poetry version --short)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-plugin-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Set up Python and Poetry in the publish examples job, in order to get the service package version number.

### Why should this Pull Request be merged?

The version number was evaluating to empty string because Poetry wasn't installed. I didn't notice this in testing because
the example zip file isn't uploaded for non-release builds.

### What testing has been done?

Verified that the logs include the version number in EXAMPLE_ARCHIVE: https://github.com/ni/measurement-plugin-python/actions/runs/17872320926/job/50828086201

```
EXAMPLE_ARCHIVE: measurement-plugin-python-examples-2.4.0-dev2
```

