### PR TITLE
github: Remove unit_tests_succeeded step

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,12 +31,6 @@ jobs:
     name: Run unit tests
     uses: ./.github/workflows/run_unit_tests.yml
     needs: [check_nims]
-  unit_tests_succeeded:
-    name: Unit tests succeeded
-    needs: [run_unit_tests]
-    runs-on: ubuntu-latest
-    steps:
-      - run: exit 0
   run_system_tests:
     name: Run system tests
     uses: ./.github/workflows/run_system_tests.yml


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-plugin-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Remove `unit_tests_succeeded` step.

### Why should this Pull Request be merged?

https://github.com/EnricoMi/publish-unit-test-result-action already summarizes test results in the "Test Results" check.

### What testing has been done?

PR build