### PR TITLE
fix: Specify setuptools<82 build constraint for grpcio-tools

### DIFF
--- a/.github/workflows/check_examples.yml
+++ b/.github/workflows/check_examples.yml
@@ -16,6 +16,8 @@ jobs:
         id: setup-python
       - name: Set up Poetry
         uses: ni/python-actions/setup-poetry@aa64e60612cb078b0c2ada666becbd70d4817d55 # v0.7.1
+        with:
+          poetry-version: 2.3.2
       # Updating poetry.lock for all of the examples takes over 6 minutes, so it's worth caching.
       - name: Cache poetry.lock
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3

--- a/.github/workflows/check_nimg.yml
+++ b/.github/workflows/check_nimg.yml
@@ -28,6 +28,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Set up Poetry
         uses: ni/python-actions/setup-poetry@aa64e60612cb078b0c2ada666becbd70d4817d55 # v0.7.1
+        with:
+          poetry-version: 2.3.2
       - name: Analyze generator
         uses: ni/python-actions/analyze-project@aa64e60612cb078b0c2ada666becbd70d4817d55 # v0.7.1
         with:

--- a/.github/workflows/check_nims.yml
+++ b/.github/workflows/check_nims.yml
@@ -30,6 +30,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Set up Poetry
         uses: ni/python-actions/setup-poetry@aa64e60612cb078b0c2ada666becbd70d4817d55 # v0.7.1
+        with:
+          poetry-version: 2.3.2
       - name: Analyze generator
         uses: ni/python-actions/analyze-project@aa64e60612cb078b0c2ada666becbd70d4817d55 # v0.7.1
         with:

--- a/.github/workflows/check_nims_docs.yml
+++ b/.github/workflows/check_nims_docs.yml
@@ -22,6 +22,8 @@ jobs:
         id: setup-python
       - name: Set up Poetry
         uses: ni/python-actions/setup-poetry@aa64e60612cb078b0c2ada666becbd70d4817d55 # v0.7.1
+        with:
+          poetry-version: 2.3.2
       - name: Install ni-measurement-plugin-sdk-service (all extras, docs)
         run: poetry install -v --all-extras --with docs
       - name: Build docs and check for errors/warnings

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,7 @@ env:
       "sdk": "ni_measurement_plugin_sdk",
       "service": "ni_measurement_plugin_sdk_service"
     }
+  poetry-version: 2.3.2
 
 jobs:
   # Do not call check_examples.yml because the examples may depend on the version we are releasing.
@@ -60,6 +61,8 @@ jobs:
         uses: ni/python-actions/setup-python@aa64e60612cb078b0c2ada666becbd70d4817d55 # v0.7.1
       - name: Set up Poetry
         uses: ni/python-actions/setup-poetry@aa64e60612cb078b0c2ada666becbd70d4817d55 # v0.7.1
+        with:
+          poetry-version: ${{ env.poetry-version }}
       - name: Check project version
         if: github.event_name == 'release'
         uses: ni/python-actions/check-project-version@aa64e60612cb078b0c2ada666becbd70d4817d55 # v0.7.1
@@ -109,6 +112,8 @@ jobs:
         uses: ni/python-actions/setup-python@aa64e60612cb078b0c2ada666becbd70d4817d55 # v0.7.1
       - name: Set up Poetry
         uses: ni/python-actions/setup-poetry@aa64e60612cb078b0c2ada666becbd70d4817d55 # v0.7.1
+        with:
+          poetry-version: ${{ env.poetry-version }}
       - name: Get version
         id: get-version
         run: echo "version=$(poetry version --short)" >> "$GITHUB_OUTPUT"
@@ -147,6 +152,8 @@ jobs:
         uses: ni/python-actions/setup-python@aa64e60612cb078b0c2ada666becbd70d4817d55 # v0.7.1
       - name: Set up Poetry
         uses: ni/python-actions/setup-poetry@aa64e60612cb078b0c2ada666becbd70d4817d55 # v0.7.1
+        with:
+          poetry-version: ${{ env.poetry-version }}
       # Create one pull request that updates all three packages.
       - name: Update generator project version
         uses: ni/python-actions/update-project-version@aa64e60612cb078b0c2ada666becbd70d4817d55 # v0.7.1

--- a/.github/workflows/run_system_tests.yml
+++ b/.github/workflows/run_system_tests.yml
@@ -22,6 +22,13 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Python
+        uses: ni/python-actions/setup-python@aa64e60612cb078b0c2ada666becbd70d4817d55 # v0.7.1
+        id: setup-python
+      - name: Set up Poetry
+        uses: ni/python-actions/setup-poetry@aa64e60612cb078b0c2ada666becbd70d4817d55 # v0.7.1
+        with:
+          poetry-version: 2.3.2
       - name: Copy and rename .env.simulation to .env
         run: cp examples/.env.simulation .env
 

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -26,6 +26,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Set up Poetry
         uses: ni/python-actions/setup-poetry@aa64e60612cb078b0c2ada666becbd70d4817d55 # v0.7.1
+        with:
+          poetry-version: 2.3.2
 
       # ni-measurement-plugin-sdk-service, no extras
       - name: Restore cached virtualenv (ni-measurement-plugin-sdk-service, no extras)

--- a/examples/sample_measurement/pyproject.toml
+++ b/examples/sample_measurement/pyproject.toml
@@ -21,6 +21,9 @@ types-protobuf = ">=4.21"
 # Uncomment to use prerelease dependencies.
 # ni-measurement-plugin-sdk-service = {path = "../../packages/service", develop = true}
 
+[tool.poetry.build-constraints]
+grpcio-tools = { setuptools = "<82" }
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/packages/generator/pyproject.toml
+++ b/packages/generator/pyproject.toml
@@ -74,6 +74,9 @@ ni-measurementlink-proto = { version = "^1.0.0" }
 ni-measurement-plugin-generator = "ni_measurement_plugin_sdk_generator.plugin:create_measurement"
 ni-measurement-plugin-client-generator = "ni_measurement_plugin_sdk_generator.client:create_client"
 
+[tool.poetry.build-constraints]
+grpcio-tools = { setuptools = "<82" }
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/packages/service/pyproject.toml
+++ b/packages/service/pyproject.toml
@@ -126,6 +126,9 @@ sphinx-click = ">=4.1.0"
 # Workaround to docutils error with 0.21.post1 release
 docutils = ">=0.16, !=0.21.post1"
 
+[tool.poetry.build-constraints]
+grpcio-tools = { setuptools = "<82" }
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-plugin-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Use `tool.poetry.build-constraints` to pin setuptools<82 in the event that we build grpcio-tools from source, which we do on macOS.

Upgrade to Poetry 2.3.x so that build constraints are supported.

### Why should this Pull Request be merged?

Fix build.

### What testing has been done?

PR build