### PR TITLE
github: Disable "check" workflows on macOS

### DIFF
--- a/.github/workflows/check_nimg.yml
+++ b/.github/workflows/check_nimg.yml
@@ -11,7 +11,7 @@ jobs:
       oldest-python-version: '3.10'
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest]
         python-version: ['3.10', 3.14]
     runs-on: ${{ matrix.os }}
     defaults:

--- a/.github/workflows/check_nims.yml
+++ b/.github/workflows/check_nims.yml
@@ -11,7 +11,7 @@ jobs:
       oldest-python-version: '3.10'
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest]
         python-version: ['3.10', 3.14]
     runs-on: ${{ matrix.os }}
     defaults:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-plugin-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Disable `check_nimg.yml` and `check_nims.yml` on macOS

### Why should this Pull Request be merged?

They are failing because:
- There are no binary wheels for grpcio 1.49.1
- Building from source requires pkg_resources, which was removed from setuptools in version 82

### What testing has been done?

None