### PR TITLE
docs: Use intersphinx to link to ni-apis-python documentation

### DIFF
--- a/packages/service/_docs_source/conf.py
+++ b/packages/service/_docs_source/conf.py
@@ -87,6 +87,41 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 intersphinx_mapping = {
     "grpc": ("https://grpc.github.io/grpc/python/", None),
+    # Work around https://github.com/ni/ni-apis-python/issues/337 by using latest instead of stable
+    "ni_grpc_extensions": ("https://ni-grpc-extensions.readthedocs.io/en/latest/", None),
+    "ni.measurementlink.discovery.v1.client": (
+        "https://nimeasurementlinkdiscoveryv1client.readthedocs.io/en/latest/",
+        None,
+    ),
+    "ni.measurementlink.discovery.v1.proto": (
+        "https://nimeasurementlinkdiscoveryv1proto.readthedocs.io/en/latest/",
+        None,
+    ),
+    "ni.measurementlink.measurement.v1.proto": (
+        "https://nimeasurementlinkmeasurementv1proto.readthedocs.io/en/latest/",
+        None,
+    ),
+    "ni.measurementlink.measurement.v2.proto": (
+        "https://nimeasurementlinkmeasurementv2proto.readthedocs.io/en/latest/",
+        None,
+    ),
+    "ni.measurementlink.pinmap.v1.client": (
+        "https://nimeasurementlinkpinmapv1client.readthedocs.io/en/latest/",
+        None,
+    ),
+    "ni.measurementlink.pinmap.v1.proto": (
+        "https://nimeasurementlinkpinmapv1proto.readthedocs.io/en/latest/",
+        None,
+    ),
+    "ni.measurementlink.sessionmanagement.v1.client": (
+        "https://nimeasurementlinksessionmanagementclient.readthedocs.io/en/latest/",
+        None,
+    ),
+    "ni.measurementlink.sessionmanagement.v1.proto": (
+        "https://nimeasurementlinksessionmanagementv1proto.readthedocs.io/en/latest/",
+        None,
+    ),
+    "ni.protobuf.types": ("https://niprotobuftypes.readthedocs.io/en/latest/", None),
     "nidaqmx": ("https://nidaqmx-python.readthedocs.io/en/stable/", None),
     "nidcpower": ("https://nidcpower.readthedocs.io/en/stable/", None),
     "nidigital": ("https://nidigital.readthedocs.io/en/stable/", None),

--- a/packages/service/ni_measurement_plugin_sdk_service/grpc/__init__.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/grpc/__init__.py
@@ -1,7 +1,6 @@
 """Compatibility API for gRPC extensions.
 
-The public gRPC extensions API has moved to the :mod:`ni_grpc_extensions`
-package.
+The public gRPC extensions API has moved to the :external+ni_grpc_extensions:doc:`index` package.
 
 The :mod:`ni_measurement_plugin_sdk_service.grpc` subpackage provides
 compatibility with existing applications and will be deprecated in a future

--- a/packages/service/ni_measurement_plugin_sdk_service/grpc/channelpool.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/grpc/channelpool.py
@@ -1,7 +1,7 @@
 """Compatibility API for gRPC channel pool.
 
-The :obj:`GrpcChannelPool` class has moved to the :mod:`ni_grpc_extensions`
-package.
+The :obj:`GrpcChannelPool` class has moved to the :mod:`ni_grpc_extensions.channelpool`
+submodule.
 
 The :mod:`ni_measurement_plugin_sdk_service.grpc.channelpool` submodule provides
 compatibility with existing applications and will be deprecated in a future

--- a/packages/service/ni_measurement_plugin_sdk_service/grpc/loggers.py
+++ b/packages/service/ni_measurement_plugin_sdk_service/grpc/loggers.py
@@ -1,7 +1,7 @@
 """Compatibility API for gRPC logging interceptors.
 
-The gRPC logging interceptor classes have moved to the :mod:`ni_grpc_extensions`
-package.
+The gRPC logging interceptor classes have moved to the :mod:`ni_grpc_extensions.loggers`
+submodule.
 
 The :mod:`ni_measurement_plugin_sdk_service.grpc.loggers` submodule provides
 compatibility with existing applications and will be deprecated in a future


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-plugin-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update documentation to use Intersphinx to link to the ni-apis-python documentation.

### Why should this Pull Request be merged?

Pages like https://measurement-plugin-python.readthedocs.io/en/stable/autoapi/ni_measurement_plugin_sdk_service/session_management/index.html would be more helpful if they linked to the other package's documentation.

### What testing has been done?

Built docs and manually tested links to grpc extensions, discovery, pinmap, session management.